### PR TITLE
Fix IMA in dynamicemb's forward(initializer)

### DIFF
--- a/corelib/dynamicemb/src/hkv_variable.cuh
+++ b/corelib/dynamicemb/src/hkv_variable.cuh
@@ -141,16 +141,17 @@ struct BaseEmbeddingGenerator {
   DEVICE_INLINE
   void set_state(uint64_t emb_id) {
     hkv_ptr_ = hkv_ptrs_[emb_id];
-    if (founds_[emb_id]) {
+    bool found_ = founds_[emb_id];
+    if (hkv_ptr_ == nullptr) {
+      action_ = Action::ZERO_TO_TENSOR;
+    } else if (found_) {
       action_ = Action::FROM_HKV_TO_TENSOR;
-    } else if (hkv_ptr_ != nullptr) {
+    } else {
       action_ = Action::TO_HKV_TO_TENSOR;
       if (!load_) {
         localState_ = state_[GlobalThreadId()];
         load_ = true;
       }
-    } else {
-      action_ = Action::ZERO_TO_TENSOR;
     }
   }
 

--- a/corelib/dynamicemb/src/torch_utils.cu
+++ b/corelib/dynamicemb/src/torch_utils.cu
@@ -38,6 +38,7 @@ public:
 
   uint64_t get(const cudaStream_t& stream) {
     device_nano_kernel<uint64_t><<<1, 1, 0, stream>>>(d_timestamp);
+    DEMB_CUDA_KERNEL_LAUNCH_CHECK();
     CUDACHECK(cudaMemcpyAsync(&h_timestamp, d_timestamp, sizeof(uint64_t), 
       cudaMemcpyDeviceToHost, stream));
     CUDACHECK(cudaStreamSynchronize(stream));


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. --> In dynamicemb' forward,  illegal memory access occurs in the initializer. 
For find_or_insert(V**) API,  should check the `V*` is not nullptr first. This can be also fixed in HKV.
<!-- Reference any issues closed by this PR with "closes #1234". --> Tracking internally.
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
