### PR TITLE
Test:fix empty batch defualt fp32 dtype

### DIFF
--- a/examples/hstu/test/test_dataset.py
+++ b/examples/hstu/test/test_dataset.py
@@ -44,12 +44,15 @@ def batch_slice(
         sliced_lengths = torch.split(feature.lengths(), split_size)[rank]
         segment_start = feature.offsets()[rank * batch_size]
         segment_end = feature.offsets()[(rank + 1) * batch_size]
-        sliced_values = feature.values()[segment_start:segment_end]
+        # in case of zero-sized segment
+        sliced_values = feature.values()[segment_start:segment_end].to(
+            feature.values().dtype
+        )
         values.extend(sliced_values)
         lengths.extend(sliced_lengths)
     sliced_feature = KeyedJaggedTensor.from_lengths_sync(
         keys=keys,
-        values=torch.tensor(values, device=batch.features.device()),
+        values=torch.tensor(values, device=batch.features.device()).long(),
         lengths=torch.tensor(lengths, device=batch.features.device()),
     )
 


### PR DESCRIPTION
## Description
The multi-gpu test may run into a zero-sized batch of which dtype is mistakenly set as fp32. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
