### PR TITLE
[FEA]Make dynamicemb default initialize behavior consisitent with torchrec

### DIFF
--- a/corelib/dynamicemb/DynamicEmb_APIs.md
+++ b/corelib/dynamicemb/DynamicEmb_APIs.md
@@ -255,8 +255,8 @@ Parameters for each random initialization method in DynamicEmbInitializerMode.
         mode: DynamicEmbInitializerMode
         mean: float = 0.0
         std_dev: float = 1.0
-        lower: float = 0.0
-        upper: float = 1.0
+        lower: float = None
+        upper: float = None
         value: float = 0.0
     ```
 
@@ -327,7 +327,8 @@ Dynamic embedding table parameter class, used to configure the parameters for ea
         num_of_buckets_per_alloc : int
             Number of buckets allocated per memory allocation request. Default is 1.
         initializer_args : DynamicEmbInitializerArgs
-            Arguments for initializing dynamic embedding vector values. Default is uniform distribution.
+            Arguments for initializing dynamic embedding vector values.
+            Default is uniform distribution, and absolute values of upper and lower bound are sqrt(1 / eb_config.num_embeddings).
         safe_check_mode : DynamicEmbCheckMode
             Should dynamic embedding table insert safe check be enabled? By default, it is disabled.
             Please refer to the API documentation for DynamicEmbCheckMode for more information.
@@ -338,8 +339,12 @@ Dynamic embedding table parameter class, used to configure the parameters for ea
         https://github.com/NVIDIA-Merlin/HierarchicalKV.
         """
 
-        initializer_args: DynamicEmbInitializerArgs = DynamicEmbInitializerArgs(mode=DynamicEmbInitializerMode.UNIFORM)
+        initializer_args: DynamicEmbInitializerArgs = field(
+            default_factory=DynamicEmbInitializerArgs
+        )
     ```
+If using `DynamicEmbInitializerMode.UNIFORM`, `DynamicEmbeddingShardingPlanner` will set the `initializer_args.upper` and `initializer_args.lower` to +/- sqrt(1 / eb_config.num_embeddings)
+by default(except users provide them explicitly).
 
 ## DynamicEmbDump
 

--- a/corelib/dynamicemb/dynamicemb/construct_twin_module.py
+++ b/corelib/dynamicemb/dynamicemb/construct_twin_module.py
@@ -23,11 +23,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import torch
 import torch.distributed as dist
 import torchrec
-from dynamicemb import (
-    DynamicEmbInitializerArgs,
-    DynamicEmbInitializerMode,
-    DynamicEmbTableOptions,
-)
+from dynamicemb import DynamicEmbTableOptions
 from dynamicemb.dump_load import find_sharded_modules, get_dynamic_emb_module
 from dynamicemb.planner import (
     DynamicEmbeddingEnumerator,
@@ -156,9 +152,6 @@ def get_planner(
                 use_dynamicemb=True,
                 dynamicemb_options=DynamicEmbTableOptions(
                     global_hbm_for_values=1024**3,
-                    initializer_args=DynamicEmbInitializerArgs(
-                        mode=DynamicEmbInitializerMode.UNIFORM,
-                    ),
                 ),
             )
         else:

--- a/corelib/dynamicemb/dynamicemb/planner/planner.py
+++ b/corelib/dynamicemb/dynamicemb/planner/planner.py
@@ -49,7 +49,11 @@ from ..batched_dynamicemb_compute_kernel import (
     BatchedDynamicEmbedding,
     BatchedDynamicEmbeddingBag,
 )
-from ..dynamicemb_config import DynamicEmbKernel, DynamicEmbTableOptions
+from ..dynamicemb_config import (
+    DynamicEmbKernel,
+    DynamicEmbTableOptions,
+    validate_initializer_args,
+)
 
 HBM_CAP: int = 32 * 1024 * 1024 * 1024
 DDR_CAP: int = 128 * 1024 * 1024 * 1024
@@ -175,6 +179,9 @@ def _validate_configs(
         if not tmp_constraint.use_dynamicemb:
             continue
         tmp_config = eb_configs[i]
+        validate_initializer_args(
+            tmp_constraint.dynamicemb_options.initializer_args, tmp_config
+        )
         # modify num_embeddings per rank to power of 2
         num_embeddings_per_rank = int(
             _next_power_of_2(math.ceil(tmp_config.num_embeddings / world_size))

--- a/corelib/dynamicemb/test/test_batched_dynamic_embedding_tables.py
+++ b/corelib/dynamicemb/test/test_batched_dynamic_embedding_tables.py
@@ -16,8 +16,6 @@
 import torch
 from dynamicemb import (
     DynamicEmbEvictStrategy,
-    DynamicEmbInitializerArgs,
-    DynamicEmbInitializerMode,
     DynamicEmbPoolingMode,
     DynamicEmbStorageConfig,
     EmbOptimType,
@@ -55,9 +53,6 @@ def test_embedding_optimizer(opt_type, opt_params):
         evict_strategy=DynamicEmbEvictStrategy.LRU,
         feature_table_map=[0, 0, 1, 2],
         pooling_mode=DynamicEmbPoolingMode.MEAN,
-        initializer_args=DynamicEmbInitializerArgs(
-            mode=DynamicEmbInitializerMode.UNIFORM,
-        ),
         optimizer=opt_type,
         **opt_params,
     )

--- a/corelib/dynamicemb/test/test_optimizer.py
+++ b/corelib/dynamicemb/test/test_optimizer.py
@@ -428,9 +428,6 @@ def test_optimizer(
             local_hbm_for_values=4 * 1024**3,
             bucket_capacity=1024,
             device_id=-1,
-            initializer_args=DynamicEmbInitializerArgs(
-                mode=DynamicEmbInitializerMode.UNIFORM,
-            ),
         )
         for i in range(num_tables)
     ]

--- a/corelib/dynamicemb/test/unit_tests/incremental_dump/test_distributed_dynamicemb.py
+++ b/corelib/dynamicemb/test/unit_tests/incremental_dump/test_distributed_dynamicemb.py
@@ -23,8 +23,6 @@ import torch.distributed as dist
 import torchrec
 from dynamicemb import (
     BATCH_SIZE_PER_DUMP,
-    DynamicEmbInitializerArgs,
-    DynamicEmbInitializerMode,
     DynamicEmbScoreStrategy,
     DynamicEmbTableOptions,
 )
@@ -119,9 +117,6 @@ def get_planner(
             use_dynamicemb=use_dynamicembs[i],
             dynamicemb_options=DynamicEmbTableOptions(
                 global_hbm_for_values=1024**3,
-                initializer_args=DynamicEmbInitializerArgs(
-                    mode=DynamicEmbInitializerMode.UNIFORM,
-                ),
                 score_strategy=score_strategies[i],
             ),
         )


### PR DESCRIPTION
… #24

## Description Make dynamicemb default initialize behavior consisitent with torchrec
<!-- Provide a standalone description of changes in this PR. -->

- Default initializer is None, and reset to Uniform with upper/lower bounds(+/- sqrt(1/max_capacity)) in post init function if `initializer_args` not provided.
- Remove initialization of `initializer_args` when using `DynamicEmbInitializerMode.UNIFORM`.
- Update API Docs.

<!-- Reference any issues closed by this PR with "closes #1234". -->

https://github.com/NVIDIA/recsys-examples/issues/24

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
