### PR TITLE
Insert embeddings and optimizer states to HKV in backward when use_index_dedup is true

### DIFF
--- a/corelib/dynamicemb/dynamicemb/optimizer.py
+++ b/corelib/dynamicemb/dynamicemb/optimizer.py
@@ -155,6 +155,7 @@ class BaseDynamicEmbeddingOptimizer(abc.ABC):
         hashtables: List[DynamicEmbTable],
         indices: List[torch.Tensor],
         grads: List[torch.Tensor],
+        embs: List[torch.Tensor] = None,
         scores: Optional[List[int]] = None,
     ) -> None:
         ...
@@ -182,6 +183,7 @@ class SGDDynamicEmbeddingOptimizer(BaseDynamicEmbeddingOptimizer):
         hashtables: List[DynamicEmbTable],
         indices: List[torch.Tensor],
         grads: List[torch.Tensor],
+        embs: List[torch.Tensor] = None,
         scores: Optional[List[int]] = None,
     ) -> None:
         for ht in hashtables:
@@ -200,9 +202,28 @@ class SGDDynamicEmbeddingOptimizer(BaseDynamicEmbeddingOptimizer):
             num_indice = indice.shape[0]
             weight_dtype = torch_to_dyn_emb(table_option.embedding_dtype)
             score = scores[i] if scores is not None else None
-            dynamic_emb_sgd_with_table(
-                ht, num_indice, indice, grad, lr, weight_dtype, score
-            )
+            if embs is not None and len(embs) != 0:
+                emb = embs[i]
+                dynamic_emb_sgd_with_table(
+                    ht,
+                    num_indice,
+                    indice,
+                    grad,
+                    lr,
+                    weight_dtype,
+                    score,
+                    emb,
+                )
+            else:
+                dynamic_emb_sgd_with_table(
+                    ht,
+                    num_indice,
+                    indice,
+                    grad,
+                    lr,
+                    weight_dtype,
+                    score,
+                )
 
     def get_opt_args(self):
         ret_args = {"lr": self._opt_args.learning_rate}
@@ -231,6 +252,7 @@ class AdamDynamicEmbeddingOptimizer(BaseDynamicEmbeddingOptimizer):
         hashtables: List[DynamicEmbTable],
         indices: List[torch.Tensor],
         grads: List[torch.Tensor],
+        embs: List[torch.Tensor] = None,
         scores: Optional[List[int]] = None,
     ) -> None:
         for ht in hashtables:
@@ -255,20 +277,38 @@ class AdamDynamicEmbeddingOptimizer(BaseDynamicEmbeddingOptimizer):
 
             weight_dtype = torch_to_dyn_emb(table_option.embedding_dtype)
             score = scores[i] if scores is not None else None
-            dynamic_emb_adam_with_table(
-                ht,
-                num_indice,
-                indice,
-                grad,
-                lr,
-                beta1,
-                beta2,
-                eps,
-                weight_decay,
-                self._iterations,
-                weight_dtype,
-                score,
-            )
+            if embs is not None and len(embs) != 0:
+                emb = embs[i]
+                dynamic_emb_adam_with_table(
+                    ht,
+                    num_indice,
+                    indice,
+                    grad,
+                    lr,
+                    beta1,
+                    beta2,
+                    eps,
+                    weight_decay,
+                    self._iterations,
+                    weight_dtype,
+                    score,
+                    emb,
+                )
+            else:
+                dynamic_emb_adam_with_table(
+                    ht,
+                    num_indice,
+                    indice,
+                    grad,
+                    lr,
+                    beta1,
+                    beta2,
+                    eps,
+                    weight_decay,
+                    self._iterations,
+                    weight_dtype,
+                    score,
+                )
 
     def get_opt_args(self):
         ret_args = {
@@ -310,6 +350,7 @@ class AdaGradDynamicEmbeddingOptimizer(BaseDynamicEmbeddingOptimizer):
         hashtables: List[DynamicEmbTable],
         indices: List[torch.Tensor],
         grads: List[torch.Tensor],
+        embs: List[torch.Tensor] = None,
         scores: Optional[List[int]] = None,
     ) -> None:
         for ht in hashtables:
@@ -331,9 +372,23 @@ class AdaGradDynamicEmbeddingOptimizer(BaseDynamicEmbeddingOptimizer):
             weight_dtype = torch_to_dyn_emb(table_option.embedding_dtype)
             score = scores[i] if scores is not None else None
 
-            dynamic_emb_adagrad_with_table(
-                ht, num_indice, indice, grad, lr, eps, weight_dtype, score
-            )
+            if embs is not None and len(embs) != 0:
+                emb = embs[i]
+                dynamic_emb_adagrad_with_table(
+                    ht,
+                    num_indice,
+                    indice,
+                    grad,
+                    lr,
+                    eps,
+                    weight_dtype,
+                    score,
+                    emb,
+                )
+            else:
+                dynamic_emb_adagrad_with_table(
+                    ht, num_indice, indice, grad, lr, eps, weight_dtype, score
+                )
 
     def get_opt_args(self):
         ret_args = {
@@ -372,6 +427,7 @@ class RowWiseAdaGradDynamicEmbeddingOptimizer(BaseDynamicEmbeddingOptimizer):
         hashtables: List[DynamicEmbTable],
         indices: List[torch.Tensor],
         grads: List[torch.Tensor],
+        embs: List[torch.Tensor] = None,
         scores: Optional[List[int]] = None,
     ) -> None:
         for ht in hashtables:
@@ -392,9 +448,23 @@ class RowWiseAdaGradDynamicEmbeddingOptimizer(BaseDynamicEmbeddingOptimizer):
             weight_dtype = torch_to_dyn_emb(table_option.embedding_dtype)
             score = scores[i] if scores is not None else None
 
-            dynamic_emb_rowwise_adagrad_with_table(
-                ht, num_indice, indice, grad, lr, eps, weight_dtype, score
-            )
+            if embs is not None and len(embs) != 0:
+                emb = embs[i]
+                dynamic_emb_rowwise_adagrad_with_table(
+                    ht,
+                    num_indice,
+                    indice,
+                    grad,
+                    lr,
+                    eps,
+                    weight_dtype,
+                    score,
+                    emb,
+                )
+            else:
+                dynamic_emb_rowwise_adagrad_with_table(
+                    ht, num_indice, indice, grad, lr, eps, weight_dtype, score
+                )
 
     def get_opt_args(self):
         ret_args = {

--- a/corelib/dynamicemb/src/dynamic_variable_base.h
+++ b/corelib/dynamicemb/src/dynamic_variable_base.h
@@ -131,6 +131,10 @@ public:
                                        bool unique_key = true,
                                        bool ignore_evict_strategy = false) = 0;
 
+  virtual void find_and_initialize(
+    const size_t n, const void *keys, void **value_ptrs, void *values,
+    bool *founds, const cudaStream_t& stream) = 0;
+
   virtual void assign(const size_t n,
                       const void *keys,             // (n)
                       const void *values,           // (n, DIM)

--- a/corelib/dynamicemb/src/hkv_variable.h
+++ b/corelib/dynamicemb/src/hkv_variable.h
@@ -84,6 +84,10 @@ public:
                          cudaStream_t stream = 0, bool unique_key = true,
                          bool ignore_evict_strategy = false) override;
 
+  void find_and_initialize(
+    const size_t n, const void *keys, void **value_ptrs, void *values,
+    bool *founds, const cudaStream_t& stream) override;
+
   void find_or_insert_pointers(const size_t n, const void *keys, // (n)
                                void **value_ptrs,                // (n * ptrs)
                                bool *d_found,                    // (n * 1)

--- a/corelib/dynamicemb/src/hkv_variable.h
+++ b/corelib/dynamicemb/src/hkv_variable.h
@@ -162,7 +162,7 @@ private:
   DataType value_type_;
   SafeCheckMode safe_check_mode_;
   OptimizerType optimizer_type_;
-  ValueType initial_optstate_ {0.};
+  float initial_optstate_ {0.};
 
 };
 

--- a/corelib/dynamicemb/src/optimizer.cu
+++ b/corelib/dynamicemb/src/optimizer.cu
@@ -28,6 +28,16 @@ void find_pointers(
   at::Tensor values,
   at::Tensor founds);
 
+void find_or_insert_pointers(
+  std::shared_ptr<dyn_emb::DynamicVariableBase> table,
+  const size_t n,
+  const at::Tensor keys,
+  at::Tensor values,
+  at::Tensor founds,
+  const std::optional<uint64_t> score = std::nullopt,
+  bool unique_key = true,
+  bool ignore_evict_strategy = false);
+
 namespace dyn_emb {
 
 constexpr int MULTIPLIER = 4;
@@ -38,7 +48,7 @@ constexpr int OPTIMIZER_BLOCKSIZE = 1024;
 void dynamic_emb_sgd_with_table(
     std::shared_ptr<dyn_emb::DynamicVariableBase> table, const uint64_t n, 
     const at::Tensor indices, const at::Tensor grads, const float lr, DataType weight_type, 
-    const std::optional<uint64_t> score) {
+    const std::optional<uint64_t> score, const c10::optional<at::Tensor>& embs) {
 
   if (n == 0) return;
   TORCH_CHECK(indices.is_cuda(), "indices must be a CUDA tensor");
@@ -50,7 +60,11 @@ void dynamic_emb_sgd_with_table(
                                      at::TensorOptions().dtype(at::kLong).device(indices.device()));
 
   auto stream = at::cuda::getCurrentCUDAStream().stream();
-  find_pointers(table, n, indices, weight_ptrs, founds);
+  if (embs.has_value()) {
+    find_or_insert_pointers(table, n, indices, weight_ptrs, founds, score);
+  } else {
+    find_pointers(table, n, indices, weight_ptrs, founds);
+  }
 
   auto &device_prop = DeviceProp::getDeviceProp(grads.device().index());
 
@@ -59,6 +73,47 @@ void dynamic_emb_sgd_with_table(
 
   auto grad_type =
       scalartype_to_datatype(convertTypeMetaToScalarType(grads.dtype()));
+
+  if (embs.has_value()) {
+    DISPATCH_FLOAT_DATATYPE_FUNCTION(grad_type, g_t, [&] {
+      DISPATCH_FLOAT_DATATYPE_FUNCTION(weight_type, w_t, [&] {
+        
+        SgdVecOptimizerV2<g_t, w_t> opt{lr};
+        if (dim % 4 == 0) {
+          const int max_grid_size =
+              device_prop.num_sms *
+              (device_prop.max_thread_per_sm / OPTIMIZER_BLOCKSIZE_VEC);
+          const int warp_per_block = OPTIMIZER_BLOCKSIZE_VEC / WARPSIZE;
+
+          int grid_size = 0;
+          if (ev_nums / warp_per_block < max_grid_size) {
+            grid_size = (ev_nums - 1) / warp_per_block + 1;
+          } else if (ev_nums / warp_per_block > max_grid_size * MULTIPLIER) {
+            grid_size = max_grid_size * MULTIPLIER;
+          } else {
+            grid_size = max_grid_size;
+          }
+
+          auto kernel = update4_kernel_v2<g_t, w_t, decltype(opt)>;
+          kernel<<<grid_size, OPTIMIZER_BLOCKSIZE_VEC, 0, stream>>>(
+            ev_nums, dim, reinterpret_cast<const g_t *>(grads.data_ptr()),
+            reinterpret_cast<w_t **>(weight_ptrs.data_ptr()), reinterpret_cast<w_t *>(embs.value().data_ptr()), founds.data_ptr<bool>(), opt);
+          DEMB_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          int block_size = dim > OPTIMIZER_BLOCKSIZE ? OPTIMIZER_BLOCKSIZE : dim;
+          int grid_size = ev_nums;
+
+          auto kernel = update_kernel_v2<g_t, w_t, decltype(opt)>;
+          kernel<<<grid_size, block_size, 0, stream>>>(
+            ev_nums, dim, reinterpret_cast<const g_t *>(grads.data_ptr()),
+            reinterpret_cast<w_t **>(weight_ptrs.data_ptr()), reinterpret_cast<w_t *>(embs.value().data_ptr()), founds.data_ptr<bool>(), opt);
+          DEMB_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+    });
+    DEMB_CUDA_KERNEL_LAUNCH_CHECK();
+    return;
+  }
 
   DISPATCH_FLOAT_DATATYPE_FUNCTION(grad_type, g_t, [&] {
     DISPATCH_FLOAT_DATATYPE_FUNCTION(weight_type, w_t, [&] {
@@ -105,7 +160,8 @@ void dynamic_emb_adam_with_table(
   const float lr, const float beta1, const float beta2, const float eps,
   const float weight_decay,
   const uint32_t iter_num, DataType weight_type, 
-  const std::optional<uint64_t> score) {
+  const std::optional<uint64_t> score,
+  const c10::optional<at::Tensor>& embs) {
 
   if (n == 0) return;
   TORCH_CHECK(indices.is_cuda(), "indices must be a CUDA tensor");
@@ -117,7 +173,12 @@ void dynamic_emb_adam_with_table(
                                      at::TensorOptions().dtype(at::kLong).device(indices.device()));
 
   auto stream = at::cuda::getCurrentCUDAStream().stream();
-  find_pointers(ht, n, indices, vector_ptrs, founds);
+  if (embs.has_value()) {
+    find_or_insert_pointers(ht, n, indices, vector_ptrs, founds, score);
+  } else {
+    find_pointers(ht, n, indices, vector_ptrs, founds);
+  }
+  
 
   auto &device_prop = DeviceProp::getDeviceProp(grads.device().index());
 
@@ -126,6 +187,51 @@ void dynamic_emb_adam_with_table(
 
   auto grad_type =
       scalartype_to_datatype(convertTypeMetaToScalarType(grads.dtype()));
+
+  if (embs.has_value()) {
+    DISPATCH_FLOAT_DATATYPE_FUNCTION(grad_type, g_t, [&] {
+      DISPATCH_FLOAT_DATATYPE_FUNCTION(weight_type, w_t, [&] {
+        AdamVecOptimizerV2<g_t, w_t> opt{lr,
+                                      beta1,
+                                      beta2,
+                                      eps,
+                                      weight_decay,
+                                      iter_num};
+        if (dim % 4 == 0) {
+          const int max_grid_size =
+              device_prop.num_sms *
+              (device_prop.max_thread_per_sm / OPTIMIZER_BLOCKSIZE_VEC);
+          const int warp_per_block = OPTIMIZER_BLOCKSIZE_VEC / WARPSIZE;
+
+          int grid_size = 0;
+          if (ev_nums / warp_per_block < max_grid_size) {
+            grid_size = (ev_nums - 1) / warp_per_block + 1;
+          } else if (ev_nums / warp_per_block > max_grid_size * MULTIPLIER) {
+            grid_size = max_grid_size * MULTIPLIER;
+          } else {
+            grid_size = max_grid_size;
+          }
+
+          auto kernel = update4_kernel_v2<g_t, w_t, decltype(opt)>;
+          kernel<<<grid_size, OPTIMIZER_BLOCKSIZE_VEC, 0, stream>>>(
+            ev_nums, dim, reinterpret_cast<const g_t *>(grads.data_ptr()),
+            reinterpret_cast<w_t **>(vector_ptrs.data_ptr()), reinterpret_cast<w_t *>(embs.value().data_ptr()), founds.data_ptr<bool>(), opt);
+          DEMB_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          int block_size = dim > OPTIMIZER_BLOCKSIZE ? OPTIMIZER_BLOCKSIZE : dim;
+          int grid_size = ev_nums;
+
+          auto kernel = update_kernel_v2<g_t, w_t, decltype(opt)>;
+          kernel<<<grid_size, block_size, 0, stream>>>(
+            ev_nums, dim, reinterpret_cast<const g_t *>(grads.data_ptr()),
+            reinterpret_cast<w_t **>(vector_ptrs.data_ptr()), reinterpret_cast<w_t *>(embs.value().data_ptr()), founds.data_ptr<bool>(), opt);
+          DEMB_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+    });
+    DEMB_CUDA_KERNEL_LAUNCH_CHECK();
+    return;
+  }
 
   DISPATCH_FLOAT_DATATYPE_FUNCTION(grad_type, g_t, [&] {
     DISPATCH_FLOAT_DATATYPE_FUNCTION(weight_type, w_t, [&] {
@@ -176,7 +282,8 @@ void dynamic_emb_adagrad_with_table(
   const at::Tensor grads,
   const float lr,
   const float eps,
-  DataType weight_type,const std::optional<uint64_t> score){
+  DataType weight_type,const std::optional<uint64_t> score,
+  const c10::optional<at::Tensor>& embs){
   if (n == 0) return;
 
   TORCH_CHECK(indices.is_cuda(), "indices must be a CUDA tensor");
@@ -188,7 +295,11 @@ void dynamic_emb_adagrad_with_table(
                                      at::TensorOptions().dtype(at::kLong).device(indices.device()));
 
   auto stream = at::cuda::getCurrentCUDAStream().stream();
-  find_pointers(ht, n, indices, vector_ptrs, founds);
+  if (embs.has_value()) {
+    find_or_insert_pointers(ht, n, indices, vector_ptrs, founds, score);
+  } else {
+    find_pointers(ht, n, indices, vector_ptrs, founds);
+  }
 
   auto& device_prop = DeviceProp::getDeviceProp(grads.device().index());
 
@@ -196,6 +307,51 @@ void dynamic_emb_adagrad_with_table(
   int64_t ev_nums = n;
 
   auto grad_type = scalartype_to_datatype(convertTypeMetaToScalarType(grads.dtype()));
+
+  if (embs.has_value()) {
+
+  DISPATCH_FLOAT_DATATYPE_FUNCTION(grad_type, g_t, [&] {
+    DISPATCH_FLOAT_DATATYPE_FUNCTION(weight_type, w_t, [&] {
+
+      AdaGradVecOptimizerV2<g_t,w_t> opt{lr, eps, ht->get_initial_optstate()};
+
+      if (dim % 4 == 0) {
+        const int max_grid_size = device_prop.num_sms * (device_prop.max_thread_per_sm / OPTIMIZER_BLOCKSIZE_VEC);
+        const int warp_per_block = OPTIMIZER_BLOCKSIZE_VEC/WARPSIZE;
+
+        int grid_size = 0;
+        if (ev_nums/warp_per_block < max_grid_size){
+            grid_size = (ev_nums-1)/warp_per_block+1;
+        }
+        else if (ev_nums/warp_per_block > max_grid_size*MULTIPLIER){
+            grid_size = max_grid_size*MULTIPLIER;
+        }
+        else{
+            grid_size = max_grid_size;
+        }
+
+        auto kernel = update4_kernel_v2<g_t, w_t, decltype(opt)>;
+        kernel<<<grid_size, OPTIMIZER_BLOCKSIZE_VEC, 0, stream>>>(
+          ev_nums, dim, reinterpret_cast<const g_t *>(grads.data_ptr()),
+          reinterpret_cast<w_t **>(vector_ptrs.data_ptr()), reinterpret_cast<w_t *>(embs.value().data_ptr()), founds.data_ptr<bool>(), opt);
+        DEMB_CUDA_KERNEL_LAUNCH_CHECK();
+      } else {
+
+        int block_size = dim > OPTIMIZER_BLOCKSIZE ? OPTIMIZER_BLOCKSIZE : dim;
+        int grid_size = ev_nums;
+
+        auto kernel = update_kernel_v2<g_t, w_t, decltype(opt)>;
+        kernel<<<grid_size, block_size, 0, stream>>>(
+          ev_nums, dim, reinterpret_cast<const g_t *>(grads.data_ptr()),
+          reinterpret_cast<w_t **>(vector_ptrs.data_ptr()), reinterpret_cast<w_t *>(embs.value().data_ptr()), founds.data_ptr<bool>(), opt);
+        DEMB_CUDA_KERNEL_LAUNCH_CHECK();
+      }
+    });
+  });
+  DEMB_CUDA_KERNEL_LAUNCH_CHECK();
+
+    return;
+  }
 
   DISPATCH_FLOAT_DATATYPE_FUNCTION(grad_type, g_t, [&] {
     DISPATCH_FLOAT_DATATYPE_FUNCTION(weight_type, w_t, [&] {
@@ -244,7 +400,8 @@ void dynamic_emb_rowwise_adagrad_with_table(
   const at::Tensor grads,
   const float lr,
   const float eps,
-  DataType weight_type,const std::optional<uint64_t> score) {
+  DataType weight_type,const std::optional<uint64_t> score,
+  const c10::optional<at::Tensor>& embs) {
   if (n == 0) return;
   TORCH_CHECK(indices.is_cuda(), "indices must be a CUDA tensor");
   TORCH_CHECK(grads.is_cuda(), "grads must be a CUDA tensor");
@@ -255,7 +412,11 @@ void dynamic_emb_rowwise_adagrad_with_table(
                                      at::TensorOptions().dtype(at::kLong).device(indices.device()));
 
   auto stream = at::cuda::getCurrentCUDAStream().stream();
-  find_pointers(ht, n, indices, vector_ptrs, founds);
+  if (embs.has_value()) {
+    find_or_insert_pointers(ht, n, indices, vector_ptrs, founds, score);
+  } else {
+    find_pointers(ht, n, indices, vector_ptrs, founds);
+  }
 
   auto& device_prop = DeviceProp::getDeviceProp(grads.device().index());
 
@@ -263,6 +424,51 @@ void dynamic_emb_rowwise_adagrad_with_table(
   int64_t ev_nums = n;
 
   auto grad_type = scalartype_to_datatype(convertTypeMetaToScalarType(grads.dtype()));
+
+  if (embs.has_value()) {
+
+    DISPATCH_FLOAT_DATATYPE_FUNCTION(grad_type, g_t, [&] {
+      DISPATCH_FLOAT_DATATYPE_FUNCTION(weight_type, w_t, [&] {
+
+        RowWiseAdaGradVecOptimizerV2<g_t, w_t> opt {lr, eps, ht->get_initial_optstate()};
+        if (dim % 4 == 0) {
+          const int max_grid_size = device_prop.num_sms * (device_prop.max_thread_per_sm / OPTIMIZER_BLOCKSIZE_VEC);
+          const int warp_per_block = OPTIMIZER_BLOCKSIZE_VEC / WARPSIZE;
+
+          int grid_size = 0;
+          if (ev_nums / warp_per_block < max_grid_size) {
+            grid_size = (ev_nums-1) / warp_per_block + 1;
+          }
+          else if (ev_nums / warp_per_block > max_grid_size * MULTIPLIER) {
+            grid_size = max_grid_size * MULTIPLIER;
+          } else {
+            grid_size = max_grid_size;
+          }
+
+          auto kernel = update4_kernel_v2<g_t, w_t, decltype(opt)>;
+          kernel<<<grid_size, OPTIMIZER_BLOCKSIZE_VEC, 0, stream>>>(
+            ev_nums, dim, reinterpret_cast<const g_t *>(grads.data_ptr()),
+            reinterpret_cast<w_t **>(vector_ptrs.data_ptr()), reinterpret_cast<w_t *>(embs.value().data_ptr()), founds.data_ptr<bool>(), opt);
+          DEMB_CUDA_KERNEL_LAUNCH_CHECK();
+
+        } else {
+
+          int block_size = dim > OPTIMIZER_BLOCKSIZE ? OPTIMIZER_BLOCKSIZE : dim;
+          int grid_size = ev_nums;
+          int shared_memory_bytes = block_size * sizeof(float);
+
+          auto kernel = update_kernel_v2<g_t, w_t, decltype(opt)>;
+          kernel<<<grid_size, block_size, shared_memory_bytes, stream>>>(
+            ev_nums, dim, reinterpret_cast<const g_t *>(grads.data_ptr()),
+            reinterpret_cast<w_t **>(vector_ptrs.data_ptr()), reinterpret_cast<w_t *>(embs.value().data_ptr()), founds.data_ptr<bool>(), opt);
+          DEMB_CUDA_KERNEL_LAUNCH_CHECK();
+        }
+      });
+    });
+    DEMB_CUDA_KERNEL_LAUNCH_CHECK();
+
+    return;
+  }
 
   DISPATCH_FLOAT_DATATYPE_FUNCTION(grad_type, g_t, [&] {
     DISPATCH_FLOAT_DATATYPE_FUNCTION(weight_type, w_t, [&] {
@@ -312,24 +518,24 @@ void bind_optimizer_kernel_op(py::module &m) {
   m.def("dynamic_emb_sgd_with_table", &dyn_emb::dynamic_emb_sgd_with_table,
         "SGD optimizer for Dynamic Emb", py::arg("table"),
         py::arg("n"), py::arg("indices"), py::arg("grads"),
-        py::arg("lr"), py::arg("weight_type"), py::arg("score") = py::none());
+        py::arg("lr"), py::arg("weight_type"), py::arg("score") = py::none(), py::arg("emb") = c10::nullopt);
 
   m.def("dynamic_emb_adam_with_table", &dyn_emb::dynamic_emb_adam_with_table,
         "Adam optimizer for Dynamic Emb", py::arg("ht"),
         py::arg("n"), py::arg("indices"), py::arg("grads"),
         py::arg("lr"), py::arg("beta1"),
         py::arg("beta2"), py::arg("eps"), py::arg("weight_decay"), py::arg("iter_num"),
-        py::arg("weight_type"), py::arg("score") = py::none());
+        py::arg("weight_type"), py::arg("score") = py::none(), py::arg("emb") = c10::nullopt);
 
   m.def("dynamic_emb_adagrad_with_table", &dyn_emb::dynamic_emb_adagrad_with_table,
         "Adagrad optimizer for Dynamic Emb", py::arg("ht"),
         py::arg("n"), py::arg("indices"), py::arg("grads"),py::arg("lr"),
         py::arg("eps"),
-        py::arg("weight_type"), py::arg("score") = py::none());
+        py::arg("weight_type"), py::arg("score") = py::none(), py::arg("emb") = c10::nullopt);
 
   m.def("dynamic_emb_rowwise_adagrad_with_table", &dyn_emb::dynamic_emb_rowwise_adagrad_with_table,
         "Row Wise Adagrad optimizer for Dynamic Emb", py::arg("ht"),
         py::arg("n"), py::arg("indices"), py::arg("grads"),py::arg("lr"),
         py::arg("eps"),
-        py::arg("weight_type"), py::arg("score") = py::none());
+        py::arg("weight_type"), py::arg("score") = py::none(), py::arg("emb") = c10::nullopt);
 }

--- a/corelib/dynamicemb/src/optimizer.h
+++ b/corelib/dynamicemb/src/optimizer.h
@@ -38,14 +38,16 @@ namespace dyn_emb {
 
 void dynamic_emb_sgd_with_table(std::shared_ptr<dyn_emb::DynamicVariableBase> table,
                                 const uint64_t n, const at::Tensor indices, const at::Tensor grads, 
-                                const float lr, DataType weight_type, const std::optional<uint64_t> score = std::nullopt);
+                                const float lr, DataType weight_type, const std::optional<uint64_t> score = std::nullopt, 
+                                const c10::optional<at::Tensor>& embs = c10::nullopt);
 
 void dynamic_emb_adam_with_table(
   std::shared_ptr<dyn_emb::DynamicVariableBase> ht,
   const uint64_t n, const at::Tensor indices, const at::Tensor grads, 
   const float lr, const float beta1, const float beta2, const float eps,
   const float weight_decay, const uint32_t iter_num, DataType weight_type, 
-  const std::optional<uint64_t> score = std::nullopt
+  const std::optional<uint64_t> score = std::nullopt,
+  const c10::optional<at::Tensor>& embs = c10::nullopt
 );
 
 void dynamic_emb_adagrad_with_table(
@@ -54,7 +56,8 @@ void dynamic_emb_adagrad_with_table(
   const at::Tensor grads,
   const float lr,
   const float eps,
-  DataType weight_type,const std::optional<uint64_t> score = std::nullopt);
+  DataType weight_type,const std::optional<uint64_t> score = std::nullopt,
+  const c10::optional<at::Tensor>& embs = c10::nullopt);
 
 void dynamic_emb_rowwise_adagrad_with_table(
   std::shared_ptr<dyn_emb::DynamicVariableBase> ht,
@@ -62,7 +65,8 @@ void dynamic_emb_rowwise_adagrad_with_table(
   const at::Tensor grads,
   const float lr,
   const float eps,
-  DataType weight_type,const std::optional<uint64_t> score = std::nullopt);
+  DataType weight_type,const std::optional<uint64_t> score = std::nullopt,
+  const c10::optional<at::Tensor>& embs = c10::nullopt);
 
 } // namespace dyn_emb
 #endif // OPTIMIZER_H

--- a/corelib/dynamicemb/src/optimizer_kernel.cuh
+++ b/corelib/dynamicemb/src/optimizer_kernel.cuh
@@ -437,5 +437,402 @@ __global__ void update_kernel(const uint32_t num_keys, const uint32_t dim, const
   }
 }
 
+template <typename grad_t, typename emb_t> struct OptimizierInputV2 {
+  const grad_t* grad_;
+  const emb_t* emb_;
+  emb_t* table_vector_;
+  const uint32_t dim;
+  bool initialized;
+
+  DEVICE_INLINE const grad_t* grad_ptr() const {
+    return grad_;
+  }
+
+  DEVICE_INLINE const emb_t* emb_input_ptr() const {
+    return emb_;
+  }
+
+  DEVICE_INLINE emb_t* emb_output_ptr() const {
+    return table_vector_;
+  }
+
+  DEVICE_INLINE bool state_initialized() const {
+    return initialized;
+  }
+
+  DEVICE_INLINE emb_t* state_ptr() const {
+    return table_vector_ + dim;
+  }
+};
+
+template <typename grad_t, typename emb_t, int kWarpSize = 32>
+struct SgdVecOptimizerV2 {
+  const float lr;
+
+  DEVICE_INLINE void update4(
+      const OptimizierInputV2<grad_t, emb_t> &input) {
+
+    constexpr int VecSize = 4;
+    const int lane_id = threadIdx.x % kWarpSize;
+
+    for (int i = 0; VecSize * (kWarpSize * i + lane_id) < input.dim;
+         ++i) {
+      int idx4 = VecSize * (kWarpSize * i + lane_id);
+      Vec4T<grad_t> grad_vec;
+      Vec4T<float> weight_vec;
+      grad_vec.load(input.grad_ptr() + idx4);
+      weight_vec.load(input.emb_input_ptr() + idx4);
+      weight_vec.accumulate_multiply(grad_vec, -lr);
+      weight_vec.store(input.emb_output_ptr() + idx4);
+    }
+  }
+
+  DEVICE_INLINE void update(
+      const OptimizierInputV2<grad_t, emb_t> &input) {
+
+    for (int i = threadIdx.x; i < input.dim; i += blockDim.x) {
+      grad_t tmp_grad = input.grad_ptr()[i];
+      float tmp_weight = input.emb_input_ptr()[i];
+      tmp_weight -= ((float)(tmp_grad)*lr);
+      input.emb_output_ptr()[i] = TypeConvertFunc<emb_t, float>::convert(tmp_weight);
+    }
+  }
+};
+
+template <typename grad_t, typename emb_t, int kWarpSize = 32>
+struct AdamVecOptimizerV2 {
+  const float lr;
+  const float beta1;
+  const float beta2;
+  const float eps;
+  const float weight_decay;
+  const uint32_t iter_num;
+
+  DEVICE_INLINE void update4(
+      const OptimizierInputV2<grad_t, emb_t> &input) {
+
+    constexpr int VecSize = 4;
+    const int lane_id = threadIdx.x % kWarpSize;
+    emb_t *m_ptr = input.state_ptr();
+    emb_t *v_ptr = m_ptr + input.dim;
+
+    Vec4T<float> weight_vec;
+    Vec4T<float> m_vec;
+    Vec4T<float> v_vec;
+    for (int i = 0; VecSize * (kWarpSize * i + lane_id) < input.dim; ++i) {
+      int idx4 = VecSize * (kWarpSize * i + lane_id);
+      weight_vec.load(input.emb_input_ptr() + idx4);
+      if (input.state_initialized()) {
+        m_vec.load(m_ptr + idx4);
+        v_vec.load(v_ptr + idx4);
+      } else {
+        m_vec.reset();
+        v_vec.reset();
+      }
+
+      // update m and v
+      {
+        Vec4T<float> grad_vec;
+        grad_vec.load(input.grad_ptr() + idx4);
+        {
+          m_vec.val.x = beta1 * m_vec.val.x + (1.0f - beta1) * grad_vec.val.x;
+          m_vec.val.y = beta1 * m_vec.val.y + (1.0f - beta1) * grad_vec.val.y;
+          m_vec.val.z = beta1 * m_vec.val.z + (1.0f - beta1) * grad_vec.val.z;
+          m_vec.val.w = beta1 * m_vec.val.w + (1.0f - beta1) * grad_vec.val.w;
+          m_vec.store(m_ptr + idx4);
+        }
+
+        {
+
+          v_vec.val.x = beta2 * v_vec.val.x +
+                        (1.0f - beta2) * grad_vec.val.x * grad_vec.val.x;
+          v_vec.val.y = beta2 * v_vec.val.y +
+                        (1.0f - beta2) * grad_vec.val.y * grad_vec.val.y;
+          v_vec.val.z = beta2 * v_vec.val.z +
+                        (1.0f - beta2) * grad_vec.val.z * grad_vec.val.z;
+          v_vec.val.w = beta2 * v_vec.val.w +
+                        (1.0f - beta2) * grad_vec.val.w * grad_vec.val.w;
+          v_vec.store(v_ptr + idx4);
+        }
+      }
+
+      // Get mhat and vhat
+      {
+        {
+          m_vec.val.x = m_vec.val.x / (1.0f - __powf(beta1, iter_num));
+          m_vec.val.y = m_vec.val.y / (1.0f - __powf(beta1, iter_num));
+          m_vec.val.z = m_vec.val.z / (1.0f - __powf(beta1, iter_num));
+          m_vec.val.w = m_vec.val.w / (1.0f - __powf(beta1, iter_num));
+        }
+
+        {
+          v_vec.val.x = v_vec.val.x / (1.0f - __powf(beta2, iter_num));
+          v_vec.val.y = v_vec.val.y / (1.0f - __powf(beta2, iter_num));
+          v_vec.val.z = v_vec.val.z / (1.0f - __powf(beta2, iter_num));
+          v_vec.val.w = v_vec.val.w / (1.0f - __powf(beta2, iter_num));
+        }
+        // Use m_vec as weight_update
+        {
+          m_vec.val.x = lr * ((m_vec.val.x / (sqrt(v_vec.val.x) + eps)) +
+                              weight_vec.val.x * weight_decay);
+          m_vec.val.y = lr * ((m_vec.val.y / (sqrt(v_vec.val.y) + eps)) +
+                              weight_vec.val.y * weight_decay);
+          m_vec.val.z = lr * ((m_vec.val.z / (sqrt(v_vec.val.z) + eps)) +
+                              weight_vec.val.z * weight_decay);
+          m_vec.val.w = lr * ((m_vec.val.w / (sqrt(v_vec.val.w) + eps)) +
+                              weight_vec.val.w * weight_decay);
+        }
+
+        weight_vec.val.x -= m_vec.val.x;
+        weight_vec.val.y -= m_vec.val.y;
+        weight_vec.val.z -= m_vec.val.z;
+        weight_vec.val.w -= m_vec.val.w;
+
+        weight_vec.store(input.emb_output_ptr() + idx4);
+      }
+    }
+  }
+
+  DEVICE_INLINE void update(
+      const OptimizierInputV2<grad_t, emb_t> &input) {
+
+    emb_t *m_ptr = input.state_ptr();
+    emb_t *v_ptr = m_ptr + input.dim;
+
+    for (int i = threadIdx.x; i < input.dim; i += blockDim.x) {
+      float tmp_grad = TypeConvertFunc<float, grad_t>::convert(input.grad_ptr()[i]);
+      float tmp_m = input.state_initialized() ? TypeConvertFunc<float, emb_t>::convert(m_ptr[i]) : 0.0f;
+      float tmp_v = input.state_initialized() ? TypeConvertFunc<float, emb_t>::convert(v_ptr[i]) : 0.0f;
+      float tmp_weight = TypeConvertFunc<float, emb_t>::convert(input.emb_input_ptr()[i]);
+
+      tmp_m = beta1 * tmp_m + (1.0f - beta1) * tmp_grad;
+      tmp_v = beta2 * tmp_v + (1.0f - beta2) * tmp_grad * tmp_grad;
+
+      float tmp_mhat = tmp_m / (1.0f - __powf(beta1, iter_num));
+      float tmp_vhat = tmp_v / (1.0f - __powf(beta2, iter_num));
+
+      tmp_weight -= lr * ((tmp_mhat / (sqrtf(tmp_vhat) + eps)) +
+                          weight_decay * tmp_weight);
+      input.emb_output_ptr()[i] = TypeConvertFunc<emb_t, float>::convert(tmp_weight);
+      m_ptr[i] = TypeConvertFunc<emb_t, float>::convert(tmp_m);
+      v_ptr[i] = TypeConvertFunc<emb_t, float>::convert(tmp_v);
+    }
+  }
+};
+
+template <typename grad_t, typename emb_t ,int kWarpSize = 32>
+struct AdaGradVecOptimizerV2 {
+  const float lr;
+  const float eps;
+  const float initial_accumulator;
+
+  DEVICE_INLINE void update4(const OptimizierInputV2<grad_t,emb_t> &input) {
+
+    constexpr int VecSize = 4;
+    const int lane_id = threadIdx.x%kWarpSize;
+    emb_t* gt_ptr = input.state_ptr();
+
+    Vec4T<float> weight_vec;
+    Vec4T<float> gt_vec;
+
+    for (int i = 0; VecSize * kWarpSize * i + VecSize * lane_id < input.dim; ++i) {
+        int idx4 = VecSize * kWarpSize * i + VecSize * lane_id;
+        weight_vec.load(input.emb_input_ptr() + idx4);
+        if (input.state_initialized()) {
+          gt_vec.load(gt_ptr + idx4);
+        } else {
+          gt_vec.reset(initial_accumulator);
+        }
+        
+
+        Vec4T<float> grad_vec;
+        grad_vec.load(input.grad_ptr() + idx4);
+        {
+            gt_vec.val.x += grad_vec.val.x * grad_vec.val.x;
+            gt_vec.val.y += grad_vec.val.y * grad_vec.val.y;
+            gt_vec.val.z += grad_vec.val.z * grad_vec.val.z;
+            gt_vec.val.w += grad_vec.val.w * grad_vec.val.w;
+            gt_vec.store(gt_ptr + idx4);
+        }
+
+        {
+            grad_vec.val.x = lr * grad_vec.val.x /(sqrtf(gt_vec.val.x) + eps);
+            grad_vec.val.y = lr * grad_vec.val.y /(sqrtf(gt_vec.val.y) + eps);
+            grad_vec.val.z = lr * grad_vec.val.z /(sqrtf(gt_vec.val.z) + eps);
+            grad_vec.val.w = lr * grad_vec.val.w /(sqrtf(gt_vec.val.w) + eps);
+        }
+
+        weight_vec.val.x -= grad_vec.val.x;
+        weight_vec.val.y -= grad_vec.val.y;
+        weight_vec.val.z -= grad_vec.val.z;
+        weight_vec.val.w -= grad_vec.val.w;
+
+        weight_vec.store(input.emb_output_ptr() + idx4);
+
+      }
+  }
+
+  DEVICE_INLINE void update(
+      const OptimizierInputV2<grad_t, emb_t> &input) {
+
+    emb_t* gt_ptr = input.state_ptr();
+
+    for (int i = threadIdx.x; i < input.dim; i+=blockDim.x) {
+      float tmp_grad =  TypeConvertFunc<float, grad_t>::convert(input.grad_ptr()[i]);
+      float tmp_gt = input.state_initialized() ? TypeConvertFunc<float, emb_t>::convert(gt_ptr[i]) : initial_accumulator;
+      float tmp_weight = TypeConvertFunc<float, emb_t>::convert(input.emb_input_ptr()[i]);
+
+      tmp_gt = tmp_gt + tmp_grad * tmp_grad;
+      tmp_grad = lr * tmp_grad / (sqrtf(tmp_gt) + eps);
+
+      tmp_weight -= tmp_grad;
+      input.emb_output_ptr()[i] = TypeConvertFunc<emb_t, float>::convert(tmp_weight);
+      gt_ptr[i] = TypeConvertFunc<emb_t, float>::convert(tmp_gt);
+    }
+  }
+};
+
+template <
+  typename grad_t,
+  typename emb_t,
+  int kWarpSize = 32>
+struct RowWiseAdaGradVecOptimizerV2 {
+  const float lr;
+  const float eps;
+  const float initial_accumulator;
+
+  ///TODO: whether can load grad once like online-softmax.
+  DEVICE_INLINE void update4(const OptimizierInputV2<grad_t, emb_t>& input) {
+
+    constexpr int VecSize = 4;
+    const int lane_id = threadIdx.x % kWarpSize;
+    emb_t* gt_ptr = input.state_ptr();
+
+    float tmp_gt = input.state_initialized() ? TypeConvertFunc<float, emb_t>::convert(*gt_ptr) : initial_accumulator;
+    float tmp_g_pow = 0;
+    ///TODO: vectorize
+    for (int i = lane_id; i < input.dim; i += kWarpSize) {
+      float tmp_g = TypeConvertFunc<float, grad_t>::convert(input.grad_ptr()[i]);
+      tmp_g_pow += tmp_g * tmp_g;
+    }
+
+    tmp_g_pow = warp_reduce_sum_xor(tmp_g_pow, kWarpSize);
+    tmp_g_pow /= input.dim;
+    tmp_gt += tmp_g_pow;
+
+    if (lane_id == 0) {
+      *gt_ptr = TypeConvertFunc<emb_t, float>::convert(tmp_gt);
+    }
+
+    Vec4T<float> weight_vec;
+    for (int i = 0; VecSize * (kWarpSize * i + lane_id) < input.dim; ++i) {
+      int idx4 = VecSize * (kWarpSize * i + lane_id);  
+      Vec4T<float> grad_vec;
+
+      grad_vec.load(input.grad_ptr() + idx4);
+      weight_vec.load(input.emb_input_ptr() + idx4);
+
+      {
+        grad_vec.val.x = lr * grad_vec.val.x /(sqrtf(tmp_gt) + eps);
+        grad_vec.val.y = lr * grad_vec.val.y /(sqrtf(tmp_gt) + eps);
+        grad_vec.val.z = lr * grad_vec.val.z /(sqrtf(tmp_gt) + eps);
+        grad_vec.val.w = lr * grad_vec.val.w /(sqrtf(tmp_gt) + eps);
+      }
+
+      weight_vec.val.x -= grad_vec.val.x;
+      weight_vec.val.y -= grad_vec.val.y;
+      weight_vec.val.z -= grad_vec.val.z;
+      weight_vec.val.w -= grad_vec.val.w;
+
+      weight_vec.store(input.emb_output_ptr() + idx4);
+    }
+  }
+
+  DEVICE_INLINE void update(const OptimizierInputV2<grad_t, emb_t>& input) {
+
+    extern __shared__ float sdata[];
+    const uint32_t tid = threadIdx.x;
+    const uint32_t blockSize = blockDim.x;
+    const unsigned int pow2_size = nextPow2(blockSize) >> 1;
+
+    emb_t* gt_ptr = input.state_ptr();
+
+    float tmp_gt = input.state_initialized() ? TypeConvertFunc<float, emb_t>::convert(*gt_ptr) : initial_accumulator;
+    float tmp_g_pow = 0;
+    for (int i = tid; i < input.dim; i += blockSize) {
+      float tmp_g = TypeConvertFunc<float, grad_t>::convert(input.grad_ptr()[i]);
+      tmp_g_pow += tmp_g * tmp_g;
+    }
+
+    sdata[tid] = tmp_g_pow;
+    __syncthreads();
+
+    if (pow2_size >= 1) {
+      for(unsigned s = pow2_size; s > 0; s >>= 1) {
+        if(tid < s && (tid + s) < blockSize) {
+          sdata[tid] += sdata[tid + s];
+        }
+        __syncthreads();
+      }
+    }
+
+    tmp_g_pow = sdata[0];
+    tmp_g_pow /= input.dim;
+    tmp_gt += tmp_g_pow;
+    if (tid == 0) {
+      *gt_ptr = TypeConvertFunc<emb_t, float>::convert(tmp_gt);
+    }
+
+    for (int i = tid; i < input.dim; i += blockSize) {
+      float tmp_grad = TypeConvertFunc<float, grad_t>::convert(input.grad_ptr()[i]);
+      float tmp_weight = TypeConvertFunc<float, emb_t>::convert(input.emb_input_ptr()[i]);
+
+      tmp_grad = lr * tmp_grad / (sqrtf(tmp_gt) + eps);
+
+      tmp_weight -= tmp_grad;
+      input.emb_output_ptr()[i] = TypeConvertFunc<emb_t, float>::convert(tmp_weight);
+    }
+  }
+};
+
+template <typename grad_t, typename emb_t, typename OptimizerFunc>
+__global__ void update4_kernel_v2(const uint32_t num_keys, const uint32_t dim, const grad_t *grad_evs,
+                               emb_t **weight_evs, const emb_t* emb_evs, const bool* masks, OptimizerFunc optimizer) {
+  constexpr int kWarpSize = 32;
+  const int warp_num_per_block = blockDim.x / kWarpSize;
+  const int warp_id_in_block = threadIdx.x / kWarpSize;
+
+  for (uint32_t ev_id = warp_num_per_block * blockIdx.x + warp_id_in_block;
+       ev_id < num_keys; ev_id += gridDim.x * warp_num_per_block) {
+    bool mask = masks[ev_id];
+    emb_t *weight_ptr = weight_evs[ev_id];
+    const grad_t *grad_ptr = grad_evs + ev_id * dim;
+    const emb_t* emb_ptr = emb_evs + ev_id * dim;
+    if ((!mask) and (weight_ptr == nullptr)) {
+      continue;
+    }
+    OptimizierInputV2<grad_t, emb_t> input {grad_ptr, emb_ptr, weight_ptr, dim, mask};
+    optimizer.update4(input);
+  }
+}
+
+template <typename grad_t, typename emb_t, typename OptimizerFunc>
+__global__ void update_kernel_v2(const uint32_t num_keys, const uint32_t dim, const grad_t *grad_evs, 
+                              emb_t **weight_evs, const emb_t* emb_evs, const bool* masks, OptimizerFunc optimizer) {
+  constexpr int kWarpSize = 32;
+
+  for (uint32_t ev_id = blockIdx.x; ev_id < num_keys; ev_id += gridDim.x) {
+    bool mask = masks[ev_id];
+    emb_t *weight_ptr = weight_evs[ev_id];
+    const grad_t *grad_ptr = grad_evs + ev_id * dim;
+    const emb_t* emb_ptr = emb_evs + ev_id * dim;
+    if ((!mask) and (weight_ptr == nullptr)) {
+      continue;
+    }
+    OptimizierInputV2<grad_t, emb_t> input {grad_ptr, emb_ptr, weight_ptr, dim, mask};
+    optimizer.update(input);
+  }
+}
+
 } // namespace dyn_emb
 #endif // OPTIMIZER_KERNEL_H

--- a/corelib/dynamicemb/src/unique_variable.cu
+++ b/corelib/dynamicemb/src/unique_variable.cu
@@ -226,6 +226,7 @@ void unique_op<KeyType, CounterType, empty_key, empty_val, hasher>::unique(
       <<<(len - 1) / BLOCK_SIZE_ + 1, BLOCK_SIZE_, 0, stream>>>(
           d_key, d_unique_key, d_output_index, len, keys_, vals_, capacity_,
           counter_, empty_key, empty_val, offset_ptr);
+  // replace counter_ with input d_output_counter
   cudaMemcpyAsync(d_output_counter, counter_, sizeof(CounterType),
                   cudaMemcpyDeviceToDevice, stream);
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->

```
fwd：unique -> hkv find -> init -> one2one
bwd: one2one_atomic
update: insert -> update
```

<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
