### PR TITLE
Update Readme about hstu installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ git clone -b core_r0.9.0 https://github.com/NVIDIA/Megatron-LM.git megatron-lm &
 pip install -e ./megatron-lm
 ```
 
-We provide our custom HSTU CUDA operators for enhanced performance. You can optionally install these operators using the following command to boost performance:
+We provide our custom HSTU CUDA operators for enhanced performance. You need to install these operators using the following command:
 
 ```bash
 cd /workspace/recsys-examples/examples/hstu && \

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ git clone -b core_r0.9.0 https://github.com/NVIDIA/Megatron-LM.git megatron-lm &
 pip install -e ./megatron-lm
 ```
 
+We provide our custom HSTU CUDA operators for enhanced performance. You can optionally install these operators using the following command to boost performance:
+
+```bash
+cd /workspace/recsys-examples/examples/hstu && \
+python setup.py install
+```
+
 # Get Started
 The examples we supported:
 - [HSTU recommender examples](./examples/hstu/README.md)

--- a/examples/hstu/modules/hstu_block.py
+++ b/examples/hstu/modules/hstu_block.py
@@ -22,9 +22,7 @@ from torchrec.sparse.jagged_tensor import JaggedTensor
 try:
     from ops.cuda_ops.JaggedTensorOpFunction import jagged_2D_tensor_concat
     HSTU_CUDA_OPS = True
-    print("HSTU CUDA Ops is enabled")
 except ImportError:
-    print("HSTU CUDA Ops is disabled")
     from ops.jagged_tensor_op import concat_2D_jagged_tensors
     HSTU_CUDA_OPS = False
 

--- a/examples/hstu/modules/hstu_block.py
+++ b/examples/hstu/modules/hstu_block.py
@@ -11,6 +11,7 @@ from modules.fused_hstu_layer import FusedHSTULayer
 from modules.jagged_data import JaggedData
 from modules.native_hstu_layer import HSTULayer
 from modules.position_encoder import HSTUPositionalEncoder
+from ops.cuda_ops.JaggedTensorOpFunction import jagged_2D_tensor_concat
 from ops.length_to_offsets import length_to_complete_offsets
 from ops.triton_ops.triton_jagged import (  # type: ignore[attr-defined]
     triton_concat_2D_jagged,
@@ -18,13 +19,6 @@ from ops.triton_ops.triton_jagged import (  # type: ignore[attr-defined]
 )
 from torchrec.sparse.jagged_tensor import JaggedTensor
 
-
-try:
-    from ops.cuda_ops.JaggedTensorOpFunction import jagged_2D_tensor_concat
-    HSTU_CUDA_OPS = True
-except ImportError:
-    from ops.jagged_tensor_op import concat_2D_jagged_tensors
-    HSTU_CUDA_OPS = False
 
 class HSTUBlock(MegatronModule):
     """
@@ -118,70 +112,41 @@ class HSTUBlock(MegatronModule):
                 batch.feature_to_max_seqlen[name]
                 for name in batch.contextual_feature_names
             ]
-            if HSTU_CUDA_OPS:
-                contextual_jts = [
-                    embeddings[name] for name in batch.contextual_feature_names
-                ]
-                all_values = [jt.values() for jt in contextual_jts] + [sequence_embeddings]
-                all_offsets = [jt.offsets() for jt in contextual_jts] + [
-                    sequence_embeddings_lengths_offsets
-                ]
-                all_max_seqlens = contextual_max_seqlens + [sequence_max_seqlen]
-                (
-                    sequence_embeddings,
-                    sequence_embeddings_lengths_after_concat,
-                ) = jagged_2D_tensor_concat(
-                    all_values,
-                    all_offsets,
-                    all_max_seqlens,
-                )
-                contextual_max_seqlen = max(
-                    len(batch.contextual_feature_names), sum(contextual_max_seqlens)
-                )
+            contextual_jts = [
+                embeddings[name] for name in batch.contextual_feature_names
+            ]
+            all_values = [jt.values() for jt in contextual_jts] + [sequence_embeddings]
+            all_offsets = [jt.offsets() for jt in contextual_jts] + [
+                sequence_embeddings_lengths_offsets
+            ]
+            all_max_seqlens = contextual_max_seqlens + [sequence_max_seqlen]
+            (
+                sequence_embeddings,
+                sequence_embeddings_lengths_after_concat,
+            ) = jagged_2D_tensor_concat(
+                all_values,
+                all_offsets,
+                all_max_seqlens,
+            )
+            contextual_max_seqlen = max(
+                len(batch.contextual_feature_names), sum(contextual_max_seqlens)
+            )
 
-                contextual_seqlen = (
-                    sequence_embeddings_lengths_after_concat - sequence_embeddings_lengths
-                )
-                sequence_embeddings_lengths = sequence_embeddings_lengths_after_concat
+            contextual_seqlen = (
+                sequence_embeddings_lengths_after_concat - sequence_embeddings_lengths
+            )
+            sequence_embeddings_lengths = sequence_embeddings_lengths_after_concat
 
-                sequence_embeddings_lengths_offsets = (
-                    torch.ops.fbgemm.asynchronous_complete_cumsum(
-                        sequence_embeddings_lengths
-                    )
+            sequence_embeddings_lengths_offsets = (
+                torch.ops.fbgemm.asynchronous_complete_cumsum(
+                    sequence_embeddings_lengths
                 )
+            )
 
-                contextual_seqlen_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
-                    contextual_seqlen
-                )
-            else:
-                contextual_embedding, contextual_seqlen = concat_2D_jagged_tensors(
-                jagged_tensors=[
-                    embeddings[name] for name in batch.contextual_feature_names
-                ],
-                max_seqlens=contextual_max_seqlens,
-                )
+            contextual_seqlen_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
+                contextual_seqlen
+            )
 
-                contextual_max_seqlen = max(
-                    len(batch.contextual_feature_names), sum(contextual_max_seqlens)
-                )
-                contextual_seqlen_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
-                    contextual_seqlen
-                )
-
-                sequence_embeddings = triton_concat_2D_jagged(
-                    max_seq_len=contextual_max_seqlen + sequence_max_seqlen,
-                    values_a=contextual_embedding,
-                    values_b=sequence_embeddings,
-                    offsets_a=contextual_seqlen_offsets,
-                    offsets_b=sequence_embeddings_lengths_offsets,
-                )
-
-                sequence_embeddings_lengths = (
-                    contextual_seqlen + sequence_embeddings_lengths
-                )
-                sequence_embeddings_lengths_offsets = (
-                    contextual_seqlen_offsets + sequence_embeddings_lengths_offsets
-                )
             sequence_max_seqlen = sequence_max_seqlen + contextual_max_seqlen
 
         if self._positional_encoder is not None:

--- a/examples/hstu/modules/hstu_block.py
+++ b/examples/hstu/modules/hstu_block.py
@@ -11,7 +11,6 @@ from modules.fused_hstu_layer import FusedHSTULayer
 from modules.jagged_data import JaggedData
 from modules.native_hstu_layer import HSTULayer
 from modules.position_encoder import HSTUPositionalEncoder
-from ops.cuda_ops.JaggedTensorOpFunction import jagged_2D_tensor_concat
 from ops.length_to_offsets import length_to_complete_offsets
 from ops.triton_ops.triton_jagged import (  # type: ignore[attr-defined]
     triton_concat_2D_jagged,
@@ -19,6 +18,15 @@ from ops.triton_ops.triton_jagged import (  # type: ignore[attr-defined]
 )
 from torchrec.sparse.jagged_tensor import JaggedTensor
 
+
+try:
+    from ops.cuda_ops.JaggedTensorOpFunction import jagged_2D_tensor_concat
+    HSTU_CUDA_OPS = True
+    print("HSTU CUDA Ops is enabled")
+except ImportError:
+    print("HSTU CUDA Ops is disabled")
+    from ops.jagged_tensor_op import concat_2D_jagged_tensors
+    HSTU_CUDA_OPS = False
 
 class HSTUBlock(MegatronModule):
     """
@@ -112,41 +120,70 @@ class HSTUBlock(MegatronModule):
                 batch.feature_to_max_seqlen[name]
                 for name in batch.contextual_feature_names
             ]
-            contextual_jts = [
-                embeddings[name] for name in batch.contextual_feature_names
-            ]
-            all_values = [jt.values() for jt in contextual_jts] + [sequence_embeddings]
-            all_offsets = [jt.offsets() for jt in contextual_jts] + [
-                sequence_embeddings_lengths_offsets
-            ]
-            all_max_seqlens = contextual_max_seqlens + [sequence_max_seqlen]
-            (
-                sequence_embeddings,
-                sequence_embeddings_lengths_after_concat,
-            ) = jagged_2D_tensor_concat(
-                all_values,
-                all_offsets,
-                all_max_seqlens,
-            )
-            contextual_max_seqlen = max(
-                len(batch.contextual_feature_names), sum(contextual_max_seqlens)
-            )
-
-            contextual_seqlen = (
-                sequence_embeddings_lengths_after_concat - sequence_embeddings_lengths
-            )
-            sequence_embeddings_lengths = sequence_embeddings_lengths_after_concat
-
-            sequence_embeddings_lengths_offsets = (
-                torch.ops.fbgemm.asynchronous_complete_cumsum(
-                    sequence_embeddings_lengths
+            if HSTU_CUDA_OPS:
+                contextual_jts = [
+                    embeddings[name] for name in batch.contextual_feature_names
+                ]
+                all_values = [jt.values() for jt in contextual_jts] + [sequence_embeddings]
+                all_offsets = [jt.offsets() for jt in contextual_jts] + [
+                    sequence_embeddings_lengths_offsets
+                ]
+                all_max_seqlens = contextual_max_seqlens + [sequence_max_seqlen]
+                (
+                    sequence_embeddings,
+                    sequence_embeddings_lengths_after_concat,
+                ) = jagged_2D_tensor_concat(
+                    all_values,
+                    all_offsets,
+                    all_max_seqlens,
                 )
-            )
+                contextual_max_seqlen = max(
+                    len(batch.contextual_feature_names), sum(contextual_max_seqlens)
+                )
 
-            contextual_seqlen_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
-                contextual_seqlen
-            )
+                contextual_seqlen = (
+                    sequence_embeddings_lengths_after_concat - sequence_embeddings_lengths
+                )
+                sequence_embeddings_lengths = sequence_embeddings_lengths_after_concat
 
+                sequence_embeddings_lengths_offsets = (
+                    torch.ops.fbgemm.asynchronous_complete_cumsum(
+                        sequence_embeddings_lengths
+                    )
+                )
+
+                contextual_seqlen_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
+                    contextual_seqlen
+                )
+            else:
+                contextual_embedding, contextual_seqlen = concat_2D_jagged_tensors(
+                jagged_tensors=[
+                    embeddings[name] for name in batch.contextual_feature_names
+                ],
+                max_seqlens=contextual_max_seqlens,
+                )
+
+                contextual_max_seqlen = max(
+                    len(batch.contextual_feature_names), sum(contextual_max_seqlens)
+                )
+                contextual_seqlen_offsets = torch.ops.fbgemm.asynchronous_complete_cumsum(
+                    contextual_seqlen
+                )
+
+                sequence_embeddings = triton_concat_2D_jagged(
+                    max_seq_len=contextual_max_seqlen + sequence_max_seqlen,
+                    values_a=contextual_embedding,
+                    values_b=sequence_embeddings,
+                    offsets_a=contextual_seqlen_offsets,
+                    offsets_b=sequence_embeddings_lengths_offsets,
+                )
+
+                sequence_embeddings_lengths = (
+                    contextual_seqlen + sequence_embeddings_lengths
+                )
+                sequence_embeddings_lengths_offsets = (
+                    contextual_seqlen_offsets + sequence_embeddings_lengths_offsets
+                )
             sequence_max_seqlen = sequence_max_seqlen + contextual_max_seqlen
 
         if self._positional_encoder is not None:


### PR DESCRIPTION
## Description
Add description to Readme about hstu cuda op installation.
If users don't want to install hstu cuda op extensions, hstu_block.py also work well.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
