### PR TITLE
Fix ci docker image build

### DIFF
--- a/corelib/dynamicemb/setup.py
+++ b/corelib/dynamicemb/setup.py
@@ -27,33 +27,22 @@ subprocess.run(
 )
 
 # TODO: update when torchrec release compatible commit.
-compatible_versions = "1.1.0"
+compatible_versions = "1.2.0"
 
 
 def check_torchrec_version():
     try:
         import torchrec
 
-        version = torchrec.__version__
+        version = re.match(r'^\d+\.\d+\.\d+', torchrec.__version__).group()
         if version >= compatible_versions:
-            print(f"torchrec version {version} is installed.")
-            return True
+            raise RuntimeError(f"torchrec version {version} is installed.")
         else:
-            print(
+            raise RuntimeError(
                 f"torchrec version {version} is installed, but version >= {compatible_versions} is required."
             )
-            return False
     except ImportError:
-        print("torchrec is not installed.")
-        return False
-
-
-def install_torchrec():
-    print(f"Installing torchrec version {compatible_versions}...")
-    subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", f"torchrec=={compatible_versions}"]
-    )
-
+        raise RuntimeError("torchrec is not installed.")
 
 def find_source_files(directory, extension_pattern, exclude_dirs=[]):
     source_files = []
@@ -69,8 +58,7 @@ def find_source_files(directory, extension_pattern, exclude_dirs=[]):
     return source_files
 
 
-if not check_torchrec_version():
-    install_torchrec()
+check_torchrec_version()
 
 library_name = "dynamicemb"
 

--- a/corelib/dynamicemb/setup.py
+++ b/corelib/dynamicemb/setup.py
@@ -35,7 +35,8 @@ def check_torchrec_version():
 
         version = re.match(r"^\d+\.\d+\.\d+", torchrec.__version__).group()
         if version >= compatible_versions:
-            raise RuntimeError(f"torchrec version {version} is installed.")
+            print(f"torchrec version {version} is installed.")
+            return
         else:
             raise RuntimeError(
                 f"torchrec version {version} is installed, but version >= {compatible_versions} is required."

--- a/corelib/dynamicemb/setup.py
+++ b/corelib/dynamicemb/setup.py
@@ -16,7 +16,6 @@
 import os
 import re
 import subprocess
-import sys
 from pathlib import Path
 
 from setuptools import find_packages, setup
@@ -34,7 +33,7 @@ def check_torchrec_version():
     try:
         import torchrec
 
-        version = re.match(r'^\d+\.\d+\.\d+', torchrec.__version__).group()
+        version = re.match(r"^\d+\.\d+\.\d+", torchrec.__version__).group()
         if version >= compatible_versions:
             raise RuntimeError(f"torchrec version {version} is installed.")
         else:
@@ -43,6 +42,7 @@ def check_torchrec_version():
             )
     except ImportError:
         raise RuntimeError("torchrec is not installed.")
+
 
 def find_source_files(directory, extension_pattern, exclude_dirs=[]):
     source_files = []

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,12 +7,24 @@ ARG INFERENCEBUILD
 
 WORKDIR /workspace/deps
 
+RUN ARCH=$([ "${TARGETPLATFORM}" = "linux/arm64" ] && echo "aarch64" || echo "x86_64") && \
+    rm -rf /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1 && \
+    if [ "${INFERENCEBUILD}" == "1" ]; then \
+      ln -s /usr/local/cuda-12.8/targets/x86_64-linux/lib/stubs/libnvidia-ml.so /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1;  \
+    else \
+      if [ ${ARCH} = "aarch64" ]; then \
+          ln -s /usr/local/cuda-12.6/targets/sbsa-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
+      else \
+          ln -s /usr/local/cuda-12.6/targets/${ARCH}-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
+      fi \
+    fi
+
 RUN if [ "${INFERENCEBUILD}" != "1" ]; then \
       git clone -b core_v0.12.1 https://github.com/NVIDIA/Megatron-LM.git megatron-lm && \
       pip install -e ./megatron-lm; \
     fi
 
-RUN pip install torchx gin-config torchmetrics==1.0.3 typing-extensions iopath
+RUN pip install torchx gin-config torchmetrics==1.0.3 typing-extensions iopath pyvers
 
 RUN pip install --no-cache setuptools==69.5.1 setuptools-git-versioning scikit-build && \
   git clone --recursive -b v1.2.0 https://github.com/pytorch/FBGEMM.git fbgemm && \
@@ -23,22 +35,6 @@ RUN pip install --no-deps tensordict orjson && \
   git clone --recursive -b v1.2.0 https://github.com/pytorch/torchrec.git torchrec && \
   cd torchrec && \
   pip install --no-deps .
-
-RUN if [ "${INFERENCEBUILD}" == "1" ]; then \
-    test -f /usr/local/cuda-12.8/targets/x86_64-linux/lib/stubs/libnvidia-ml.so &&  ( \
-        rm -f /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1  && \
-        ln -s /usr/local/cuda-12.8/targets/x86_64-linux/lib/stubs/libnvidia-ml.so /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1  \
-    ); \
-  fi
-
-RUN ARCH=$([ "${TARGETPLATFORM}" = "linux/arm64" ] && echo "aarch64" || echo "x86_64") && \
-  if [ ! -f /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1 ]; then \
-    if [ ${ARCH} = "aarch64" ]; then \
-      ln -s /usr/local/cuda-12.6/targets/sbsa-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
-    else \
-      ln -s /usr/local/cuda-12.6/targets/${ARCH}-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
-    fi \
-  fi
 
 # for dev
 RUN apt update -y --fix-missing && \

--- a/examples/hstu/dataset/sequence_dataset.py
+++ b/examples/hstu/dataset/sequence_dataset.py
@@ -30,7 +30,6 @@ import json
 import math
 from collections import defaultdict
 from typing import Dict, Iterator, List, Optional, Tuple
-import os.path
 
 import numpy as np
 import pandas as pd

--- a/examples/hstu/preprocessor.py
+++ b/examples/hstu/preprocessor.py
@@ -303,9 +303,7 @@ class DLRMKuaiRandProcessor(DataProcessor):
                 os.path.join(base_path, "log_standard_4_08_to_4_21_pure.csv"),
                 os.path.join(base_path, "log_standard_4_22_to_5_08_pure.csv"),
             ]
-            self._user_features_file = (
-                os.path.join(base_path, "user_features_pure.csv")
-            )
+            self._user_features_file = os.path.join(base_path, "user_features_pure.csv")
 
         elif prefix == "KuaiRand-1K":
             self._log_files = [
@@ -417,6 +415,7 @@ dataset_names = (
     "kuairand-27k",
 )
 
+
 def get_common_preprocessors(dataset_path: str):
     """
     Get common data preprocessors.
@@ -456,13 +455,12 @@ def get_common_preprocessors(dataset_path: str):
         file_name="KuaiRand-27K.tar.gz",
         prefix="KuaiRand-27K",
     )
-    return {key: locals()[f"{key}_dp".replace('-', '_')] for key in dataset_names}
+    return {key: locals()[f"{key}_dp".replace("-", "_")] for key in dataset_names}
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Preprocessor")
-    parser.add_argument(
-        "--dataset_name", choices=list(dataset_names) + ["all"]
-    )
+    parser.add_argument("--dataset_name", choices=list(dataset_names) + ["all"])
     parser.add_argument(
         "--dataset_path",
         type=str,

--- a/examples/hstu/training/gin_config_args.py
+++ b/examples/hstu/training/gin_config_args.py
@@ -102,7 +102,7 @@ class DynamicEmbeddingArgs(EmbeddingArgs):
 class DatasetArgs:
     dataset_name: str
     max_sequence_length: int
-    dataset_path: str = None
+    dataset_path: Optional[str] = None
     max_num_candidates: int = 0
     shuffle: bool = False
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
In short, an official fbgemm_gpu is installed by dynamicemb due to some coincidences and it covered our self building fbgemm_gpu thus causing the CI error. 
Here is the detailed process. When installing `torchrec`, it will try to install `fbgemm_gpu`. So we are using `--no-deps` to install `torchrec` to skip official `fbgemm_gpu` installing. But torchrec 1.2.0 added a new dependency called `pyvers`. So after installing `torchrec` 1.2.0, it still can not work correctly and gets import error. But in `dynamicemb` it will use import to detect whether `torchrec` is installed and try to install torchrec if it's missing. So in the end, the reinstallation of torchrec is triggered by `dynamicemb` and triggers installation of official `fbgemm_gpu`.


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
