### PR TITLE
Ignore torchrec's memory budget when plan for dynamicemb.

### DIFF
--- a/corelib/dynamicemb/DynamicEmb_APIs.md
+++ b/corelib/dynamicemb/DynamicEmb_APIs.md
@@ -112,6 +112,7 @@ Wrapped TorchREC's `EmbeddingShardingPlanner` to perform sharding for dynamic em
         topology : Optional[Topology], optional
             The topology of GPU and Host memory. If None, a default topology will be created. Defaults to None.
             The creation and usage are consistent with the same types in TorchREC.
+            Note: The memory budget does not include the consumption of dynamicemb.
         batch_size : Optional[int], optional
             The batch size for training. Defaults to None, will set 512 in Planner.
         enumerator : Optional[Enumerator], optional

--- a/corelib/dynamicemb/src/hkv_variable.cuh
+++ b/corelib/dynamicemb/src/hkv_variable.cuh
@@ -511,10 +511,10 @@ HKVVariable<KeyType, ValueType, Strategy>::HKVVariable(
   set_curand_states(&curand_states_, stream);
   hkv_table_option_.init_capacity = init_capacity;
   hkv_table_option_.max_capacity = max_capacity;
-  hkv_table_option_.max_hbm_for_vectors =
-      max_hbm_for_vectors; // nv::merlin::GB(max_hbm_for_vectors);
-  hkv_table_option_.max_bucket_size = max_bucket_size;
   hkv_table_option_.dim = dim + get_optimizer_state_dim<ValueType>(optimizer_type, dim);
+  int64_t max_hbm_needed = hkv_table_option_.max_capacity * hkv_table_option_.dim * sizeof (ValueType);
+  hkv_table_option_.max_hbm_for_vectors = max_hbm_needed < max_hbm_for_vectors ? max_hbm_needed : max_hbm_for_vectors;
+  hkv_table_option_.max_bucket_size = max_bucket_size;
   hkv_table_option_.max_load_factor = max_load_factor;
   hkv_table_option_.block_size = block_size;
   hkv_table_option_.io_block_size = io_block_size;


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
When we plan reserved HBM/DDR for both dynamicemb and torchrec, we adopt the fellow method:
```
1. Compute dynamicemb's needed.
2. Remove dynamicemb's consumption from the total budget(implemented by torchrec's topology).
3. Plan for torchrec using new budget.
```
In previous version(non-fused), the optimizer states' consumption is always not considered.
At present, we put embedding and optimizer states together, we can't detemine how many optimizer states needed when plan as we don't know the optimizer type.

So my solution is, if users use:
- dynamicemb only: just provide the global_hbm_for_values.
- both dynamicemb and torchrec: provide the global_hbm_for_values for dynamicemb; provide the topology for torchrec.

That means the dynamicemb's consumption is no longer covered by torchrec's memory budget.

Optional:
1.  users specify the optimizer type in DynamicEmbTableOptions: 
- they have to set the optimizer_type twice(another is in fused_params);
- Need to update existed example and tests.
2. hack the DynamicEmbeddingShardingPlanner
- lazy initialization  in collective_plan and get optimizer type from Sharder's fused_params.

<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
