### PR TITLE
Fix: guard cudagraph-specific metadata logic when `use_cudagraph=False`

### DIFF
--- a/examples/hstu/model/inference_ranking_gr.py
+++ b/examples/hstu/model/inference_ranking_gr.py
@@ -303,8 +303,9 @@ class InferenceRankingGR(torch.nn.Module):
                     kv_cache_metadata,
                 )
 
-        # cudagraph preparation
-        copy_kvcache_metadata(self._kvcache_metadata, kv_cache_metadata)
+        if self.use_cudagraph:
+            # cudagraph preparation
+            copy_kvcache_metadata(self._kvcache_metadata, kv_cache_metadata)
         # preparation due to cudagraph codepath
         kv_cache_metadata.onload_history_kv_buffer = (
             self._kvcache_metadata.onload_history_kv_buffer[:]
@@ -392,7 +393,7 @@ class InferenceRankingGR(torch.nn.Module):
                     num_tokens,
                     jagged_data.values,
                     jagged_data,
-                    self._kvcache_metadata,
+                    kvcache_metadata,
                 )
                 jagged_data.values = hstu_output
 

--- a/examples/hstu/modules/paged_hstu_infer_layer.py
+++ b/examples/hstu/modules/paged_hstu_infer_layer.py
@@ -196,9 +196,11 @@ class PagedHSTUInferLayer(torch.nn.Module):
             0,  # NHD layout
         )
 
-        kv_cache_metadata.onload_history_kv_events[self.layer_idx].wait(
-            torch.cuda.current_stream()
-        )
+        if kv_cache_metadata.onload_history_kv_events is not None:
+            kv_cache_metadata.onload_history_kv_events[self.layer_idx].wait(
+                torch.cuda.current_stream()
+            )
+
         jagged_attn_output = hstu_attn.hstu_attn_varlen_func(
             query,
             key,


### PR DESCRIPTION
## Description

While running `inference_benchmark.py` with `use_cudagraph=False`, I encountered the following runtime error:

```
RuntimeError: The size of tensor a (3) must match the size of tensor b (9) at non-singleton dimension 0
```

This error is triggered by unconditionally calling `copy_kvcache_metadata(...)` and referencing internal metadata fields that are only valid under CUDA Graph mode. In particular, the tensors involved in `kv_indptr` and related structures have different assumptions in cudagraph and non-cudagraph paths.

The issue was originally mentioned in [#104](https://github.com/NVIDIA/recsys-examples/issues/104). While the typo fix from [#103](https://github.com/NVIDIA/recsys-examples/issues/103) was applied, this particular crash still occurs with cudagraph disabled.

## Fix

* Guarded `copy_kvcache_metadata(...)` and related metadata assignments with `if self.use_cudagraph`.
* Passed `kv_cache_metadata` (local instance) instead of `_kvcache_metadata` when calling `.predict(...)` in the non-cudagraph case.
* Added a `None` check before indexing into `onload_history_kv_events[...]` in `PagedHSTUInferLayer`.

## Verification

* ✅ `use_cudagraph=False`: benchmark runs successfully with no crash.
* ⚠️ `use_cudagraph=True`: still subject to the issue reported in [#104](https://github.com/NVIDIA/recsys-examples/issues/104), unrelated to this fix.

## Notes

This PR addresses only the `use_cudagraph=False` execution path.
I would like to confirm whether this handling aligns with the intended design.
If there is a preferred way to manage `KVCacheMetadata` consistently between cudagraph and non-cudagraph paths, I am happy to revise accordingly.

