### PR TITLE
Print detailed memory consumption of embedding and optimizer states

### DIFF
--- a/corelib/dynamicemb/dynamicemb/utils.py
+++ b/corelib/dynamicemb/dynamicemb/utils.py
@@ -13,9 +13,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import List, Optional, Union, cast
 
 import torch
+
+
+def tabulate(
+    table: List[List[Union[str, int]]],
+    headers: Optional[List[str]] = None,
+    sub_headers: bool = False,
+) -> str:
+    """
+    Format a table as a string.
+    Parameters:
+        table (list of lists or list of tuples): The data to be formatted as a table.
+        headers (list of strings, optional): The column headers for the table. If not provided, the first row of the table will be used as the headers.
+    Returns:
+        str: A string representation of the table.
+    """
+    if headers is None:
+        headers = table[0]
+        table = table[1:]
+    headers = cast(List[str], headers)
+    rows = []
+    # Determine the maximum width of each column
+    col_widths = [max([len(str(item)) for item in column]) for column in zip(*table)]
+    col_widths = [max(i, len(j)) for i, j in zip(col_widths, headers)]
+    # Format each row of the table
+    for row in table:
+        row_str = " | ".join(
+            [str(item).ljust(width) for item, width in zip(row, col_widths)]
+        )
+        rows.append(row_str)
+    # Add the header row and the separator line
+    rows.insert(
+        0,
+        " | ".join(
+            [header.center(width) for header, width in zip(headers, col_widths)]
+        ),
+    )
+
+    rows.insert(1, " | ".join(["-" * width for width in col_widths]))
+    if sub_headers:
+        rows.insert(3, " | ".join(["-" * width for width in col_widths]))
+    return "\n".join(rows)
 
 
 def assert_tensors_equal(


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
outout the follow information of memory consumption in dynamicemb:


```
table name |       | memory(MB) |             |       | hbm(MB)/cuda:0 |             |       |  dram(MB) |            
---------- | ----- | ---------- | ----------- | ----- | -------------- | ----------- | ----- | --------- | -----------
           | total | embedding  | optim_state | total | embedding      | optim_state | total | embedding | optim_state
---------- | ----- | ---------- | ----------- | ----- | -------------- | ----------- | ----- | --------- | -----------
t_0        | 49152 | 16384      | 32768       | 49152 | 16384          | 32768       | 0     | 0         | 0          
t_1        | 24576 | 8192       | 16384       | 24576 | 8192           | 16384       | 0     | 0         | 0          


table name |       | memory(MB) |             |       | hbm(MB)/cuda:0 |             |       |  dram(MB) |            
---------- | ----- | ---------- | ----------- | ----- | -------------- | ----------- | ----- | --------- | -----------
           | total | embedding  | optim_state | total | embedding      | optim_state | total | embedding | optim_state
---------- | ----- | ---------- | ----------- | ----- | -------------- | ----------- | ----- | --------- | -----------
t_2        | 3072  | 1024       | 2048        | 3072  | 1024           | 2048        | 0     | 0         | 0          
t_3        | 6144  | 2048       | 4096        | 6144  | 2048           | 4096        | 0     | 0         | 0      


table name |       | memory(MB) |             |       | hbm(MB)/cuda:1 |             |       |  dram(MB) |            
---------- | ----- | ---------- | ----------- | ----- | -------------- | ----------- | ----- | --------- | -----------
           | total | embedding  | optim_state | total | embedding      | optim_state | total | embedding | optim_state
---------- | ----- | ---------- | ----------- | ----- | -------------- | ----------- | ----- | --------- | -----------
t_0        | 49152 | 16384      | 32768       | 49152 | 16384          | 32768       | 0     | 0         | 0          
t_1        | 24576 | 8192       | 16384       | 24576 | 8192           | 16384       | 0     | 0         | 0          


table name |       | memory(MB) |             |       | hbm(MB)/cuda:1 |             |       |  dram(MB) |            
---------- | ----- | ---------- | ----------- | ----- | -------------- | ----------- | ----- | --------- | -----------
           | total | embedding  | optim_state | total | embedding      | optim_state | total | embedding | optim_state
---------- | ----- | ---------- | ----------- | ----- | -------------- | ----------- | ----- | --------- | -----------
t_2        | 3072  | 1024       | 2048        | 3072  | 1024           | 2048        | 0     | 0         | 0          
t_3        | 6144  | 2048       | 4096        | 6144  | 2048           | 4096        | 0     | 0         | 0  
```
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
