### PR TITLE
Fix invalid pip option: replace --no-cache with --no-cache-dir

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN if [ "${INFERENCEBUILD}" != "1" ]; then \
 
 RUN pip install torchx gin-config torchmetrics==1.0.3 typing-extensions iopath pyvers
 
-RUN pip install --no-cache setuptools==69.5.1 setuptools-git-versioning scikit-build && \
+RUN pip install --no-cache-dir setuptools==69.5.1 setuptools-git-versioning scikit-build && \
   git clone --recursive -b v1.2.0 https://github.com/pytorch/FBGEMM.git fbgemm && \
   cd fbgemm/fbgemm_gpu && \
   python setup.py install --package_variant=cuda -DTORCH_CUDA_ARCH_LIST="7.0 7.5 8.0 9.0"


### PR DESCRIPTION
Fixes #124.

The original Dockerfile used `--no-cache`, which is not a valid pip option. This PR replaces it with the correct `--no-cache-dir`.
