### PR TITLE
Remove HostAlloc in dataloader

### DIFF
--- a/examples/hstu/dataset/__init__.py
+++ b/examples/hstu/dataset/__init__.py
@@ -8,7 +8,7 @@ from torch.utils.data import DataLoader
 
 def get_data_loader(
     dataset: torch.utils.data.Dataset,
-    pin_memory: bool = True,
+    pin_memory: bool = False,
 ) -> DataLoader:
     loader = DataLoader(
         dataset,


### PR DESCRIPTION
## Description
This PR address #119 . When the `pin_memory` in [DataLoader](https://docs.pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader) is on, each batch will be explicitly pinned (requests a pinned memory buffer through `cudaHostAlloc` or through pinned memory pool.) 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
