### PR TITLE
Fix setup.py

### DIFF
--- a/corelib/hstu/hopper/setup.py
+++ b/corelib/hstu/hopper/setup.py
@@ -485,18 +485,10 @@ if not SKIP_CUDA_BUILD:
 
 setup(
     name=PACKAGE_NAME,
-    version="0.1.0" + "+cu" + str(bare_metal_version),
-    packages=find_packages(
-        exclude=(
-            "build",
-            "csrc",
-            "include",
-            "tests",
-            "dist",
-            "docs",
-            "benchmarks",
-        )
-    ),
+    version="0.1.1" + "+cu" + str(bare_metal_version),
+    packages=["hopper"],
+    package_dir={"hopper": "."},
+    package_data={"hopper": ["*.py"]},
     author="NVIDIA-DevTech",
     py_modules=["hstu_attn_interface"],
     description="HSTU Attention",


### PR DESCRIPTION
Before this fix, setup didn't pick up the changes in hstu_attn_iterface.py, and caused python interface - c++ incompatible issues in using the built wheel
<img width="1180" height="968" alt="image" src="https://github.com/user-attachments/assets/df03f4db-fd63-42e9-bd03-aa6bc461d639" />

This fix made sure hstu_attn_iterface.py deterministically being packed into the wheel, verified working in downstream


## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
