### PR TITLE
Fix rab num heads

### DIFF
--- a/corelib/hstu/csrc/hstu_attn/hstu_api.cpp
+++ b/corelib/hstu/csrc/hstu_attn/hstu_api.cpp
@@ -662,7 +662,7 @@ std::vector<at::Tensor> hstu_varlen_bwd(
     it is directly defined here as the size of (max_seqlen_k, seqlen_k_rounded) to be compatible with both equal and unequal lengths of q and kv.
     Some tiles will not write back so we give zeros.
     */
-    dRab = torch::zeros({batch_size, num_heads, max_seqlen_k, seqlen_k_rounded}, opts);
+    dRab = torch::zeros({batch_size, num_heads_rab, max_seqlen_k, seqlen_k_rounded}, opts);
   }
 
   set_params_dgrad(&params,


### PR DESCRIPTION
Addresses Issue #219 .

Note that this is already fixed in [commit](https://github.com/jiayus-nvidia/FBGEMM/commit/debcd7002ac9ef1406d22cf778f07e98b270c55b#diff-684cc9e11000faceef90c02bc8de8c0d782e434743ccaa68ff2846e96d418ced)

In the future, we might deprecate hstu under corelib but use kernels from fbgemm_gpu.