### PR TITLE
Quick fix for commands in Inference README

### DIFF
--- a/examples/hstu/inference/README.md
+++ b/examples/hstu/inference/README.md
@@ -86,11 +86,14 @@ Turn on option `INFERENCEBUILD=1` to skip Megatron installation, which is not re
 ## Example: Kuairand-1K
 
 ```
+~$ cd recsys-examples/examples/hstu
+~$ export PYTHONPATH=${PYTHONPATH}:$(realpath ../)
+~$ 
 ~$ # Proprocess the dataset for inference:
 ~$ python3 ./preprocessor.py --dataset_name "kuairand-1k" --inference
 ~$
 ~$ # Run the inference example
-~$ python3 ./inference_gr_ranking.py --gin_config_file ./kuairand_1k_inference_ranking.gin --checkpoint_dir ${PATH_TO_CHECKPOINT} --mode eval
+~$ python3 ./inference/inference_gr_ranking.py --gin_config_file ./inference/configs/kuairand_1k_inference_ranking.gin --checkpoint_dir ${PATH_TO_CHECKPOINT}  --mode eval
 ```
 
 ## Consistency Check for Inference

--- a/examples/hstu/inference/benchmark/README.md
+++ b/examples/hstu/inference/benchmark/README.md
@@ -8,8 +8,8 @@ We provide a set of benchmarks for HSTU Inference on end-to-end inference and pa
 ```bash
 ~$ cd recsys-examples/examples/hstu
 ~$ export PYTHONPATH=${PYTHONPATH}:$(realpath ../)
-~$ python3 ./benchmark/inference_benchmark.py
-~$ python3 ./benchmark/paged_hstu_with_kvcache_benchmark.py
+~$ python3 ./inference/benchmark/inference_benchmark.py
+~$ python3 ./inference/benchmark/paged_hstu_with_kvcache_benchmark.py
 ```
 
 ## Benchmark results


### PR DESCRIPTION
Fix the python commands to run the examples and the benchmarks in inference README.
