### PR TITLE
fix missing import

### DIFF
--- a/corelib/dynamicemb/dynamicemb/dump_load.py
+++ b/corelib/dynamicemb/dynamicemb/dump_load.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import logging
 import warnings
 from collections import deque
 from typing import Dict, List, Optional, Tuple


### PR DESCRIPTION
fix missing import of `logging`, which is used at line 149

https://github.com/NVIDIA/recsys-examples/blob/b10b7fcfe32855a914100e85b18c6c9d3df316d1/corelib/dynamicemb/dynamicemb/dump_load.py#L149

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
