### PR TITLE
refactor: remove redundant apply_optimizer_in_backward in sharding.py

### DIFF
--- a/examples/commons/distributed/sharding.py
+++ b/examples/commons/distributed/sharding.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # pyre-strict
-from typing import Any, Dict, Tuple, Type, Union
+from typing import Any, Dict, Tuple, Union
 
 import torch
 import torch.distributed as dist
@@ -42,7 +42,6 @@ from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.module import Float16Module
 from torch import distributed as dist
-from torch.optim.optimizer import Optimizer
 from torchrec.distributed.composable.table_batched_embedding_slice import (
     TableBatchedEmbeddingSlice,
 )
@@ -164,7 +163,6 @@ def apply_dmp(
     pipeline_type: str = "native",
 ):
     enable_prefetch_pipeline = pipeline_type == "prefetch"
-    
     assert (
         sparse_optimizer_param.optimizer_str in _optimizer_str_to_optim_type
     ), f"embedding optimizer only support {list(_optimizer_str_to_optim_type.keys())}"


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

## Summary
Remove the redundant `apply_optimizer_in_backward` call in `sharding.py`.
## ContextAs discussed in #322, both `apply_optimizer_in_backward` and `fused_params` are used to add optimizer for embeddings. However, `fused_params` already has the capability to handle optimizer parameters and absorbs the params that `apply_optimizer_in_backward` provides.
Since `apply_optimizer_in_backward` has higher priority than `fused_params` but serves the same purpose, it is redundant in this context.
## Changes- Remove `apply_optimizer_in_backward` call from `examples/commons/distributed/sharding.py` (lines 236-272)- Keep `fused_params` as the sole optimizer configuration method
## Testing- [ ] Verified no syntax errors- [ ] Ran related tests (if applicable)
Closes #322

## CI

- [Pipeline #46582393](https://gitlab-master.nvidia.com/Devtech-Compute/distributed-recommender/-/pipelines/46582393) — 2026-03-20 05:57 UTC