### PR TITLE
Upgrade to Torch 2.11 with Cuda 13.1

### DIFF
--- a/corelib/dynamicemb/dynamicemb/planner/rw_sharding.py
+++ b/corelib/dynamicemb/dynamicemb/planner/rw_sharding.py
@@ -18,6 +18,7 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
+import torchrec
 from torch import distributed as dist
 from torchrec.distributed.embedding_kernel import BaseEmbedding
 from torchrec.distributed.embedding_lookup import (
@@ -62,6 +63,8 @@ class GroupedEmbeddingsLookup(_GroupedEmbeddingsLookup):
             """
             fallback to base class
             """
+            if torchrec.__version__.startswith('1.2.0'):
+                return super()._create_embedding_kernel(config=config, pg=pg, device=device)
             return super()._create_embedding_kernel(config=config, pg=pg, device=device, env=env)
         else:
             self._need_prefetch = True
@@ -163,6 +166,8 @@ class GroupedPooledEmbeddingsLookup(_GroupedPooledEmbeddingsLookup):
             """
             fallback to base class
             """
+            if torchrec.__version__.startswith('1.2.0'):
+                return super()._create_embedding_kernel(config, device, pg, sharding_type)
             return super()._create_embedding_kernel(config, device, pg, sharding_type, env)
         else:
             return BatchedDynamicEmbeddingBag(

--- a/corelib/dynamicemb/dynamicemb/planner/rw_sharding.py
+++ b/corelib/dynamicemb/dynamicemb/planner/rw_sharding.py
@@ -16,6 +16,7 @@
 # pyre-strict
 
 from typing import Any, Dict, List, Optional, Tuple, Union
+from packaging.version import Version
 
 import torch
 import torchrec
@@ -63,7 +64,7 @@ class GroupedEmbeddingsLookup(_GroupedEmbeddingsLookup):
             """
             fallback to base class
             """
-            if torchrec.__version__.startswith('1.2.0'):
+            if Version(torchrec.__version__) < Version('1.5.0'):
                 return super()._create_embedding_kernel(config=config, pg=pg, device=device)
             return super()._create_embedding_kernel(config=config, pg=pg, device=device, env=env)
         else:
@@ -166,7 +167,7 @@ class GroupedPooledEmbeddingsLookup(_GroupedPooledEmbeddingsLookup):
             """
             fallback to base class
             """
-            if torchrec.__version__.startswith('1.2.0'):
+            if Version(torchrec.__version__) < Version('1.5.0'):
                 return super()._create_embedding_kernel(config, device, pg, sharding_type)
             return super()._create_embedding_kernel(config, device, pg, sharding_type, env)
         else:

--- a/corelib/dynamicemb/dynamicemb/planner/rw_sharding.py
+++ b/corelib/dynamicemb/dynamicemb/planner/rw_sharding.py
@@ -56,12 +56,13 @@ class GroupedEmbeddingsLookup(_GroupedEmbeddingsLookup):
         config: GroupedEmbeddingConfig,
         pg: Optional[dist.ProcessGroup],
         device: Optional[torch.device],
+        env: Optional[ShardingEnv] = None,
     ) -> BaseEmbedding:
         if config.compute_kernel is not EmbeddingComputeKernel.CUSTOMIZED_KERNEL:
             """
             fallback to base class
             """
-            return super()._create_embedding_kernel(config=config, pg=pg, device=device)
+            return super()._create_embedding_kernel(config=config, pg=pg, device=device, env=env)
         else:
             self._need_prefetch = True
             return BatchedDynamicEmbedding(
@@ -156,12 +157,13 @@ class GroupedPooledEmbeddingsLookup(_GroupedPooledEmbeddingsLookup):
         device: Optional[torch.device],
         pg: Optional[dist.ProcessGroup],
         sharding_type: Optional[ShardingType],
+        env: Optional[ShardingEnv] = None,
     ) -> BaseEmbedding:
         if config.compute_kernel is not EmbeddingComputeKernel.CUSTOMIZED_KERNEL:
             """
             fallback to base class
             """
-            return super()._create_embedding_kernel(config, device, pg, sharding_type)
+            return super()._create_embedding_kernel(config, device, pg, sharding_type, env)
         else:
             return BatchedDynamicEmbeddingBag(
                 config=config,

--- a/corelib/dynamicemb/setup.py
+++ b/corelib/dynamicemb/setup.py
@@ -109,8 +109,6 @@ def get_extensions():
             "--expt-extended-lambda",
             "--use_fast_math",
             "-gencode",
-            "arch=compute_70,code=sm_70",
-            "-gencode",
             "arch=compute_75,code=sm_75",
             "-gencode",
             "arch=compute_80,code=sm_80",

--- a/corelib/dynamicemb/src/index_calculation.cu
+++ b/corelib/dynamicemb/src/index_calculation.cu
@@ -19,13 +19,14 @@ All rights reserved. # SPDX-License-Identifier: Apache-2.0
 #include "index_calculation.h"
 #include "utils.h"
 #include <torch/extension.h>
+#include <thrust/iterator/transform_iterator.h>
 
 namespace dyn_emb {
 
 namespace {
 
 struct CastI32ToI64 {
-  __device__ __forceinline__ int64_t operator()(int32_t x) const {
+  __host__ __device__ __forceinline__ int64_t operator()(int32_t x) const {
     return static_cast<int64_t>(x);
   }
 };
@@ -52,9 +53,7 @@ at::Tensor segmented_sum_cuda(at::Tensor data, at::Tensor offsets) {
   const int32_t *d_data = data.data_ptr<int32_t>();
   int64_t *d_out = output.data_ptr<int64_t>();
 
-  CastI32ToI64 cast_op;
-  cub::TransformInputIterator<int64_t, CastI32ToI64, const int32_t *> cast_iter(
-      d_data, cast_op);
+  auto cast_iter = thrust::make_transform_iterator(d_data, CastI32ToI64{});
 
   size_t temp_storage_bytes = 0;
   cub::DeviceSegmentedReduce::Sum(nullptr, temp_storage_bytes, cast_iter, d_out,

--- a/corelib/dynamicemb/src/index_calculation.h
+++ b/corelib/dynamicemb/src/index_calculation.h
@@ -59,7 +59,7 @@ void select_index_async(int64_t num_items, bool const *d_flags, T *d_output,
                         at::Device const &device, cudaStream_t const &stream) {
   void *d_temp_storage = nullptr;
   size_t temp_storage_bytes = 0;
-  cub::CountingInputIterator<T> counting_iter(0);
+  thrust::counting_iterator<T> counting_iter(0);
 
   // 1. get the size of temp storage.
   cub::DeviceSelect::Flagged(d_temp_storage, temp_storage_bytes, counting_iter,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:25.06-py3
+ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:26.02-py3
 ARG DEVEL_IMAGE=devel
 
 FROM ${BASE_IMAGE} AS devel
@@ -15,15 +15,15 @@ RUN if [ "${TRITONSERVER_BUILD}" = "1" ]; then \
 
 RUN if [ "${TRITONSERVER_BUILD}" = "1" ]; then \
       pip3 install pandas rich cloudpickle psutil && \
-      pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu129; \
+      pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu131; \
     fi
 
 RUN ARCH=$([ "${TARGETPLATFORM}" = "linux/arm64" ] && echo "aarch64" || echo "x86_64") && \
     rm -rf /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1 && \
     if [ ${ARCH} = "aarch64" ]; then \
-      ln -s /usr/local/cuda-12.9/targets/sbsa-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
+      ln -s /usr/local/cuda-13.1/targets/sbsa-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
     else \
-      ln -s /usr/local/cuda-12.9/targets/${ARCH}-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
+      ln -s /usr/local/cuda-13.1/targets/${ARCH}-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
     fi
 
 RUN if [ "${INFERENCEBUILD}" != "1" ]; then \
@@ -32,19 +32,19 @@ RUN if [ "${INFERENCEBUILD}" != "1" ]; then \
     fi
 
 RUN pip install torchx gin-config torchmetrics==1.0.3 typing-extensions iopath pyvers
+RUN pip install cloudpickle
 RUN pip install triton==3.6.0
+RUN pip install nvidia-cutlass-dsl==4.3.0
 
 RUN pip install --no-cache-dir setuptools-git-versioning scikit-build && \
-  git clone --recursive -b v1.2.0 https://github.com/pytorch/FBGEMM.git fbgemm && \
+  git clone --recursive -b v1.5.0 https://github.com/pytorch/FBGEMM.git fbgemm && \
   cd fbgemm/fbgemm_gpu && \
-  python setup.py install --package_variant=cuda -DTORCH_CUDA_ARCH_LIST="7.0 7.5 8.0 9.0"
+  python setup.py install --build-target=default --build-variant=cuda -DTORCH_CUDA_ARCH_LIST="7.5 8.0 9.0a"
 
 RUN pip install --no-deps tensordict orjson && \
-  git clone --recursive -b v1.2.0 https://github.com/pytorch/torchrec.git torchrec && \
+  git clone --recursive -b v1.5.0-rc2 https://github.com/pytorch/torchrec.git torchrec && \
   cd torchrec && \
   pip install --no-deps .
-
-RUN pip install nvidia-cutlass-dsl==4.3.0
 
 
 # for dev
@@ -85,4 +85,4 @@ RUN cd /workspace/deps && rm -rf nvcomp && \
     rm  nvcomp-linux-x86_64-5.1.0.21_cuda12-archive.tar.xz 
   
 RUN cd /workspace/recsys-examples/examples/commons && \
-    TORCH_CUDA_ARCH_LIST="7.0 7.5 8.0 8.6 9.0" python3 setup.py install
+    TORCH_CUDA_ARCH_LIST="7.5 8.0 8.6 9.0" python3 setup.py install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,8 +56,14 @@ RUN apt update -y --fix-missing && \
 
 RUN pip install --no-cache pre-commit
 
-RUN ARCH=$(uname -m) && \
-    ln -sf /usr/local/cuda-13/targets/${ARCH}-linux/include/cccl/cuda \
+RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+      CUDA_TARGET_ARCH=sbsa; \
+    elif [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
+      CUDA_TARGET_ARCH=x86_64; \
+    else \
+      CUDA_TARGET_ARCH=$(uname -m); \
+    fi && \
+    ln -sf /usr/local/cuda-13/targets/${CUDA_TARGET_ARCH}-linux/include/cccl/cuda \
     /usr/local/cuda/include/cuda
 
 # Install fbgemm_gpu_hstu (package: fbgemm_gpu_hstu, import: hstu) from submodule

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN if [ "${TRITONSERVER_BUILD}" = "1" ]; then \
 
 RUN if [ "${TRITONSERVER_BUILD}" = "1" ]; then \
       pip3 install pandas rich cloudpickle psutil && \
-      pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu131; \
+      pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130; \
     fi
 
 RUN ARCH=$([ "${TARGETPLATFORM}" = "linux/arm64" ] && echo "aarch64" || echo "x86_64") && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN pip install --no-cache-dir setuptools-git-versioning scikit-build && \
   python setup.py install --build-target=default --build-variant=cuda -DTORCH_CUDA_ARCH_LIST="7.5 8.0 9.0"
 
 RUN pip install --no-deps tensordict orjson && \
-  git clone --recursive -b v1.5.0-rc2 https://github.com/pytorch/torchrec.git torchrec && \
+  git clone --recursive -b release/V1.5.0 https://github.com/pytorch/torchrec.git torchrec && \
   cd torchrec && \
   pip install --no-deps .
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,9 +21,9 @@ RUN if [ "${TRITONSERVER_BUILD}" = "1" ]; then \
 RUN ARCH=$([ "${TARGETPLATFORM}" = "linux/arm64" ] && echo "aarch64" || echo "x86_64") && \
     rm -rf /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1 && \
     if [ ${ARCH} = "aarch64" ]; then \
-      ln -s /usr/local/cuda-13.1/targets/sbsa-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
+      ln -s /usr/local/cuda-13/targets/sbsa-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
     else \
-      ln -s /usr/local/cuda-13.1/targets/${ARCH}-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
+      ln -s /usr/local/cuda-13/targets/${ARCH}-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
     fi
 
 RUN if [ "${INFERENCEBUILD}" != "1" ]; then \
@@ -39,7 +39,7 @@ RUN pip install nvidia-cutlass-dsl==4.3.0
 RUN pip install --no-cache-dir setuptools-git-versioning scikit-build && \
   git clone --recursive -b v1.5.0 https://github.com/pytorch/FBGEMM.git fbgemm && \
   cd fbgemm/fbgemm_gpu && \
-  python setup.py install --build-target=default --build-variant=cuda -DTORCH_CUDA_ARCH_LIST="7.5 8.0 9.0a"
+  python setup.py install --build-target=default --build-variant=cuda -DTORCH_CUDA_ARCH_LIST="7.5 8.0 9.0"
 
 RUN pip install --no-deps tensordict orjson && \
   git clone --recursive -b v1.5.0-rc2 https://github.com/pytorch/torchrec.git torchrec && \
@@ -56,6 +56,10 @@ RUN apt update -y --fix-missing && \
 
 RUN pip install --no-cache pre-commit
 
+RUN ARCH=$(uname -m) && \
+    ln -sf /usr/local/cuda-13/targets/${ARCH}-linux/include/cccl/cuda \
+    /usr/local/cuda/include/cuda
+
 # Install fbgemm_gpu_hstu (package: fbgemm_gpu_hstu, import: hstu) from submodule
 COPY third_party/FBGEMM /workspace/deps/fbgemm_hstu
 RUN cd /workspace/deps/fbgemm_hstu/fbgemm_gpu/experimental/hstu && \
@@ -66,7 +70,7 @@ RUN cd /workspace/deps/fbgemm_hstu/fbgemm_gpu/experimental/hstu && \
     HSTU_DISABLE_DRAB=TRUE \
     HSTU_DISABLE_FP16=TRUE \
     HSTU_ARCH_LIST="8.0 9.0" \
-    pip install . && \
+    pip install --no-build-isolation . && \
     rm -rf /workspace/deps/fbgemm_hstu
 
 FROM ${DEVEL_IMAGE} AS build


### PR DESCRIPTION
This pull request focuses on upgrading the CUDA, PyTorch, TorchRec, and FBGEMM dependencies, as well as updating related build and source files to ensure compatibility with the new versions. It also includes several code changes to migrate from CUB to Thrust APIs and to improve compatibility with the updated libraries.

**Dependency and Docker environment upgrades:**

* Updated the base Docker image to CUDA 13.1 and PyTorch 2.11 (`nvcr.io/nvidia/pytorch:26.02-py3`), switched to the CUDA 13 toolkit in all relevant paths, and updated the PyTorch, TorchRec, and FBGEMM versions to their latest releases. Also updated the CUDA architectures list for builds. 

**Source code and compatibility changes:**

* Migrated from CUB to Thrust APIs in CUDA source files, replacing `cub::TransformInputIterator` and `cub::CountingInputIterator` with `thrust::make_transform_iterator` and `thrust::counting_iterator` for better compatibility with CUDA 13.

**TorchRec and FBGEMM integration:**

* Updated submodules and Docker build steps to use TorchRec v1.5.0-rc2 and FBGEMM v1.5.0, and adjusted build arguments for CUDA architectures accordingly. 

* Updated `rw_sharding.py` to handle changes in the latest TorchRec API, including version checks for the `env` parameter and conditional logic for different TorchRec versions. Meanwhile, they also keep compatible with TorchRec v1.2.0.

These changes collectively modernize the build environment and codebase, ensuring compatibility with the latest CUDA and PyTorch ecosystem libraries.