### PR TITLE
Fix empty batch hang fundamentally

### DIFF
--- a/corelib/dynamicemb/dynamicemb/shard/embedding.py
+++ b/corelib/dynamicemb/dynamicemb/shard/embedding.py
@@ -195,6 +195,21 @@ class ShardedDynamicEmbeddingCollection(ShardedEmbeddingCollection):
                 offsets = input_feature.offsets().to(torch.int64)
                 num_elements = indices.numel()
 
+                # Handle empty input
+                if num_elements == 0:
+                    dedup_features = KeyedJaggedTensor(
+                        keys=input_feature.keys(),
+                        lengths=input_feature.lengths(),
+                        offsets=input_feature.offsets(),
+                        values=indices,
+                    )
+                    ctx.input_features.append(input_feature)
+                    ctx.reverse_indices.append(
+                        torch.empty(0, dtype=torch.int64, device=self._device)
+                    )
+                    features_by_shards.append(dedup_features)
+                    continue
+
                 # Generate table_ids from jagged offsets (fully on GPU, no sync)
                 table_ids = expand_table_ids_cuda(
                     offsets,

--- a/corelib/dynamicemb/dynamicemb/shard/embedding.py
+++ b/corelib/dynamicemb/dynamicemb/shard/embedding.py
@@ -199,8 +199,8 @@ class ShardedDynamicEmbeddingCollection(ShardedEmbeddingCollection):
                 if num_elements == 0:
                     dedup_features = KeyedJaggedTensor(
                         keys=input_feature.keys(),
-                        lengths=input_feature.lengths(),
-                        offsets=input_feature.offsets(),
+                        lengths=input_feature.lengths().to(torch.int64),
+                        offsets=offsets,
                         values=indices,
                     )
                     ctx.input_features.append(input_feature)

--- a/corelib/dynamicemb/src/unique_op.cu
+++ b/corelib/dynamicemb/src/unique_op.cu
@@ -679,13 +679,13 @@ std::tuple<at::Tensor, at::Tensor> compute_dedup_lengths_cuda(
   // Handle empty case
   if (new_lengths_size == 0) {
     return std::make_tuple(
-        at::empty({0}, at::TensorOptions().dtype(at::kInt).device(device)),
+        at::empty({0}, at::TensorOptions().dtype(at::kLong).device(device)),
         at::zeros({1}, at::TensorOptions().dtype(at::kLong).device(device)));
   }
 
   // Allocate output tensors
   at::Tensor new_lengths = at::empty(
-      {new_lengths_size}, at::TensorOptions().dtype(at::kInt).device(device));
+      {new_lengths_size}, at::TensorOptions().dtype(at::kLong).device(device));
   at::Tensor new_offsets =
       at::empty({new_lengths_size + 1},
                 at::TensorOptions().dtype(at::kLong).device(device));
@@ -695,8 +695,8 @@ std::tuple<at::Tensor, at::Tensor> compute_dedup_lengths_cuda(
   get_new_length_and_offsets(
       reinterpret_cast<uint64_t *>(get_pointer<int64_t>(unique_offsets)),
       get_pointer<int64_t>(table_offsets_in_feature), num_tables,
-      new_lengths_size, local_batch_size, DataType::Int32, DataType::Int64,
-      get_pointer<int64_t>(new_offsets), get_pointer<int32_t>(new_lengths),
+      new_lengths_size, local_batch_size, DataType::Int64, DataType::Int64,
+      get_pointer<int64_t>(new_offsets), get_pointer<int64_t>(new_lengths),
       stream);
 
   return std::make_tuple(new_lengths, new_offsets);
@@ -816,7 +816,7 @@ Args:
 
 Returns:
     Tuple of (new_lengths, new_offsets)
-    - new_lengths: Length for each bucket (int32)
+    - new_lengths: Length for each bucket (int64)
     - new_offsets: Offset for each bucket (int64)
 )doc",
       py::arg("unique_offsets"), py::arg("table_offsets_in_feature"),

--- a/corelib/dynamicemb/test/test_batched_dynamic_embedding_tables_v2.py
+++ b/corelib/dynamicemb/test/test_batched_dynamic_embedding_tables_v2.py
@@ -1482,6 +1482,11 @@ def test_forward_train_eval(
     with torch.no_grad():
         bdebt.eval()
         embs_eval = bdebt(indices, offsets)
+
+    # corner case when all keys missed in eval.
+    indices_ne_all = indices + 1024
+    bdebt(indices_ne_all, offsets)
+
     torch.cuda.synchronize()
 
     # Train and eval should produce identical results for the same keys

--- a/corelib/dynamicemb/test/unit_tests/test_sequence_embedding_fw.py
+++ b/corelib/dynamicemb/test/unit_tests/test_sequence_embedding_fw.py
@@ -295,13 +295,38 @@ def run(args):
 
     debugger = Debugger()
 
-    for i in range(args.num_iterations):
-        sparse_feature = generate_sparse_feature(
-            feature_num=args.num_embedding_table,
-            num_embeddings_list=args.num_embeddings_per_feature,
-            multi_hot_sizes=args.multi_hot_sizes,
-            local_batch_size=args.batch_size // world_size,
-        )
+    local_batch_size = args.batch_size // world_size
+
+    for i in range(args.num_iterations + 1):
+        if i < args.num_iterations:
+            sparse_feature = generate_sparse_feature(
+                feature_num=args.num_embedding_table,
+                num_embeddings_list=args.num_embeddings_per_feature,
+                multi_hot_sizes=args.multi_hot_sizes,
+                local_batch_size=local_batch_size,
+            )
+        else:
+            # Extra iteration: rank 0 empty indices; other ranks (if any) non-empty.
+            rank = dist.get_rank()
+            if rank == 0:
+                feature_batch = args.num_embedding_table * local_batch_size
+                sparse_feature = torchrec.KeyedJaggedTensor(
+                    keys=[
+                        feature_idx_to_name(feature_idx)
+                        for feature_idx in range(args.num_embedding_table)
+                    ],
+                    values=torch.tensor([], dtype=torch.int64, device=device),
+                    lengths=torch.zeros(
+                        feature_batch, dtype=torch.int64, device=device
+                    ),
+                )
+            else:
+                sparse_feature = generate_sparse_feature(
+                    feature_num=args.num_embedding_table,
+                    num_embeddings_list=args.num_embeddings_per_feature,
+                    multi_hot_sizes=args.multi_hot_sizes,
+                    local_batch_size=local_batch_size,
+                )
         ret = model(sparse_feature)  # => this is awaitable
 
         feature_names = []


### PR DESCRIPTION
## Description

There is an issue when fed empty batch to the DMP model on a single rank while other rank's batch are not empty. 
It was fixed previously, and this PR provides:
- A test to reproduce the hang issue: [issue](https://github.com/NVIDIA/recsys-examples/issues/341)
- Fix the hang issue by provide the same data type of `dedup_features.lengths`: hang issue is because the data type mismatched due to different code path.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
