### PR TITLE
fix: unify dense tensor padding convention (dim-0 == batch_size)

### DIFF
--- a/examples/commons/distributed/batch_all2all.py
+++ b/examples/commons/distributed/batch_all2all.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Optional, Union
 
 import torch
 import torch.distributed as dist
-import torch.nn.functional as F
 from commons.sequence_batch.batch import BaseBatch
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
 
@@ -430,29 +429,9 @@ def pad_and_all2all_batch(
     local_batch_size = batch.batch_size
 
     if world_size == 1:
-        if batch.actual_batch_size >= local_batch_size:
-            return batch
-
-        # Still need to pad dense tensors for incomplete batches so that
-        # downstream reshape(batch_size, -1) is valid — same as allgather path.
-        def _pad_dense(
-            tensor_or_kjt: Union[torch.Tensor, KeyedJaggedTensor],
-        ) -> Union[torch.Tensor, KeyedJaggedTensor]:
-            if isinstance(tensor_or_kjt, KeyedJaggedTensor):
-                return tensor_or_kjt
-            elif isinstance(tensor_or_kjt, torch.Tensor):
-                t = tensor_or_kjt
-                pad_size = (
-                    local_batch_size * (t.numel() // batch.actual_batch_size)
-                    - t.numel()
-                )
-                return F.pad(t, (0, pad_size)) if pad_size > 0 else t
-            else:
-                raise ValueError(f"Unsupported type: {type(tensor_or_kjt)}")
-
-        new_batch = batch._apply_to_tensors_or_kjt(_pad_dense, inplace=False)
-        new_batch.actual_batch_size = recv_ids.numel()
-        return new_batch
+        # Under the unified convention, dense tensors already have
+        # dim-0 == batch_size, so no padding is needed.
+        return batch
 
     # ---- Phase 1: KJT fields — fused all-to-all via _all2all_kjt_list ----
     kjt_field_names: List[str] = []
@@ -472,27 +451,16 @@ def pad_and_all2all_batch(
     )
 
     # ---- Phase 2: Dense tensor fields — all-to-all via _all2all_dense_tensor ----
-    # When actual_batch_size < batch_size, dense tensors have fewer rows
-    # than local_batch_size.  Pad them to local_batch_size before sending
-    # so that _all2all_dense_tensor's reshape is valid and padding samples
-    # (assigned by KK) carry zero values.
-    pad_dense = batch.actual_batch_size < local_batch_size
-
+    # Under the unified convention, dense tensors already have dim-0 ==
+    # batch_size (== local_batch_size), so no padding is needed.
     def all2all_field(
         tensor_or_kjt: Union[torch.Tensor, KeyedJaggedTensor],
     ) -> Union[torch.Tensor, KeyedJaggedTensor]:
         if isinstance(tensor_or_kjt, KeyedJaggedTensor):
             return tensor_or_kjt  # already handled in Phase 1
         elif isinstance(tensor_or_kjt, torch.Tensor):
-            t = tensor_or_kjt
-            if pad_dense:
-                pad_size = (
-                    local_batch_size * (t.numel() // batch.actual_batch_size)
-                    - t.numel()
-                )
-                t = F.pad(t, (0, pad_size))
             return _all2all_dense_tensor(
-                t,
+                tensor_or_kjt,
                 dst_rank,
                 recv_counts,
                 local_batch_size,

--- a/examples/commons/distributed/batch_allgather.py
+++ b/examples/commons/distributed/batch_allgather.py
@@ -1,26 +1,13 @@
-import math
 from dataclasses import fields
 from typing import Dict, List, Tuple, Union
 
 import torch
-import torch.nn.functional as F
 from commons.ops.collective_ops import (
     gather_along_first_dim,
     keyed_jagged_tensor_list_allgather,
 )
 from commons.sequence_batch.batch import BaseBatch
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
-
-
-def _elems_per_sample(t: torch.Tensor, actual_batch_size: int) -> int:
-    """Return the number of flat elements per sample in *t*.
-
-    When *actual_batch_size* > 0 we can simply divide; when the batch is
-    empty we fall back to the product of all dimensions after dim-0.
-    """
-    if actual_batch_size > 0:
-        return t.numel() // actual_batch_size
-    return math.prod(t.shape[1:]) if t.dim() > 1 else 1
 
 
 def pad_and_allgather_batch(
@@ -35,17 +22,9 @@ def pad_and_allgather_batch(
     (1 for lengths, 1 for values) via :func:`keyed_jagged_tensor_list_allgather`.
     Dense tensor fields are gathered separately.
 
-    If ``actual_batch_size < batch_size`` on any rank, dense tensors
-    are zero-padded to ``batch_size`` before gathering so that all
-    ranks contribute the same dim-0 and global sample indices remain
-    valid for the subsequent ``index_select``.
-
-    **world_size == 1 fast-path**: When the process group contains only
-    one rank, no collective communication is performed.  Dense tensors
-    are still zero-padded to ``batch_size`` when ``actual_batch_size <
-    batch_size`` (incomplete batch) and ``actual_batch_size`` is set to
-    ``batch_size`` for consistency with the multi-rank code path.  KJT
-    fields are returned as-is.
+    Under the unified dense-padding convention, all dense tensor fields
+    have dim-0 == ``batch_size`` (zero-padded by the dataloader), so no
+    additional padding is needed before communication.
 
     Args:
         return_padding_flag: When True, an extra AllGather is performed
@@ -62,35 +41,14 @@ def pad_and_allgather_batch(
     device = batch.features.values().device
     global_batch_size = batch.batch_size * world_size
 
-    # ---- Fast path: world_size == 1 — only pad dense tensors, no collectives ----
+    # ---- Fast path: world_size == 1 — no collectives needed ----
     if world_size == 1:
-        if batch.actual_batch_size < batch.batch_size:
-            orig_actual_bs = batch.actual_batch_size
-
-            def _pad_dense(
-                tensor_or_kjt: Union[torch.Tensor, KeyedJaggedTensor],
-            ) -> Union[torch.Tensor, KeyedJaggedTensor]:
-                if isinstance(tensor_or_kjt, KeyedJaggedTensor):
-                    return tensor_or_kjt
-                elif isinstance(tensor_or_kjt, torch.Tensor):
-                    t = tensor_or_kjt
-                    eps = _elems_per_sample(t, orig_actual_bs)
-                    pad_size = batch.batch_size * eps - t.numel()
-                    return F.pad(t, (0, pad_size)) if pad_size > 0 else t
-                else:
-                    raise ValueError(f"Unsupported type: {type(tensor_or_kjt)}")
-
-            new_batch = batch._apply_to_tensors_or_kjt(_pad_dense, inplace=False)
-            new_batch.actual_batch_size = global_batch_size
-        else:
-            new_batch = batch
-
         if not return_padding_flag:
-            return new_batch
+            return batch
         is_padding = (
             torch.arange(batch.batch_size, device=device) >= batch.actual_batch_size
         )
-        return new_batch, is_padding
+        return batch, is_padding
 
     # ---- Phase 1: collect KJT fields and fused AllGather them ----
     kjt_field_names: List[str] = []
@@ -106,18 +64,14 @@ def pad_and_allgather_batch(
         zip(kjt_field_names, kjt_outputs)
     )
 
-    # ---- Phase 2: gather dense tensors (pad if needed) ----
-    pad_dense = batch.actual_batch_size < batch.batch_size
-
+    # ---- Phase 2: gather dense tensors ----
+    # Under the unified convention, dense tensors already have dim-0 ==
+    # batch_size (zero-padded by the dataloader), so no additional padding
+    # is needed — just AllGather directly.
     def allgather_field(tensor_or_kjt: Union[torch.Tensor, KeyedJaggedTensor]):
         if isinstance(tensor_or_kjt, KeyedJaggedTensor):
             return tensor_or_kjt
         elif isinstance(tensor_or_kjt, torch.Tensor):
-            if pad_dense:
-                eps = _elems_per_sample(tensor_or_kjt, batch.actual_batch_size)
-                pad_size = batch.batch_size * eps - tensor_or_kjt.numel()
-                padded = F.pad(tensor_or_kjt, (0, pad_size))
-                return gather_along_first_dim(padded, pg_group)
             return gather_along_first_dim(tensor_or_kjt, pg_group)
         else:
             raise ValueError(f"Unsupported type: {type(tensor_or_kjt)}")

--- a/examples/commons/distributed/batch_shuffler.py
+++ b/examples/commons/distributed/batch_shuffler.py
@@ -82,6 +82,11 @@ def _sort_partitions_padding_last(
 def _strip_dense_padding(batch: BaseBatch, actual_bs: int) -> BaseBatch:
     """Remove trailing padding rows from dense tensors, keep KJTs intact.
 
+    Under the unified dense-padding convention, every dense tensor has
+    ``batch.batch_size`` in dim-0 (stored flat as ``batch_size * eps``
+    elements).  This function reshapes each dense tensor to
+    ``[batch_size, eps]``, slices ``[:actual_bs]``, and flattens back.
+
     Relies on ``_sort_partitions_padding_last`` having placed real samples
     before padding samples so that a simple ``[:actual_bs]`` slice suffices.
 
@@ -91,7 +96,7 @@ def _strip_dense_padding(batch: BaseBatch, actual_bs: int) -> BaseBatch:
 
     Returns:
         A new ``BaseBatch`` where each dense tensor has ``actual_bs`` rows
-        and KJT fields are unchanged.
+        (flat: ``actual_bs * eps`` elements) and KJT fields are unchanged.
     """
     full_bs = batch.batch_size
 

--- a/examples/commons/sequence_batch/batch.py
+++ b/examples/commons/sequence_batch/batch.py
@@ -13,21 +13,22 @@ class BaseBatch(Pipelineable):
 
     Invariants (especially for incomplete / padded batches):
 
-    * ``batch_size`` — full size **including** padding samples.  This is
-      the KJT dimension: ``len(kjt.lengths()) == batch_size * num_keys``.
+    * ``batch_size`` — full size **including** padding samples.  Both KJTs
+      and dense tensors use this dimension:
+      - KJT: ``len(kjt.lengths()) == batch_size * num_keys``
+      - Dense: dim-0 == ``batch_size`` (trailing rows are zero-padding)
     * ``actual_batch_size`` — number of **real** (non-padding) samples.
-      This is the dense-tensor dimension: each dense tensor has
-      ``actual_batch_size`` rows (dim-0).
+      Samples at indices ``[actual_batch_size, batch_size)`` are padding.
     * For complete batches the two values are equal.
     """
 
     features: KeyedJaggedTensor
-    batch_size: int  # KJT dimension (includes padding)
+    batch_size: int  # both KJT and dense dimension (includes padding)
     feature_to_max_seqlen: Dict[str, int]
 
     contextual_feature_names: List[str] = field(default_factory=list)
     labels: Optional[KeyedJaggedTensor] = None
-    actual_batch_size: Optional[int] = None  # dense dimension (real samples only)
+    actual_batch_size: Optional[int] = None  # number of real (non-padding) samples
 
     def __post_init__(self):
         if len(set(self.features.keys())) != len(list(self.features.keys())):
@@ -130,7 +131,7 @@ class BaseBatch(Pipelineable):
             tensor: torch.Tensor, indices: torch.Tensor
         ) -> torch.Tensor:
             return (
-                tensor.reshape(self.actual_batch_size, -1)
+                tensor.reshape(self.batch_size, -1)
                 .index_select(dim=0, index=indices)
                 .reshape(-1)
             )

--- a/examples/hstu/test/tensor_parallel/test_tp_ranking_gr.py
+++ b/examples/hstu/test/tensor_parallel/test_tp_ranking_gr.py
@@ -278,11 +278,15 @@ def test_tp_gr_ranking_forward_backward_update(
             tp_ranking_gr, debug_ranking_gr, debug_ranking_gr_fp32
         )
         for i, batch in enumerate(history_batches):
-            _, (losses, logits, _, _) = debug_pipeline.progress(debug_pipeline_batches)
-            _, (losses_fp32, logits_fp32, _, _) = debug_pipeline_fp32.progress(
+            _, _, (losses, logits, _, _) = debug_pipeline.progress(
+                debug_pipeline_batches
+            )
+            _, _, (losses_fp32, logits_fp32, _, _) = debug_pipeline_fp32.progress(
                 debug_pipeline_batches_fp32
             )
-            _, (tp_losses, tp_logits, _, _) = tp_pipeline.progress(iter_history_batches)
+            _, _, (tp_losses, tp_logits, _, _) = tp_pipeline.progress(
+                iter_history_batches
+            )
             torch.distributed.barrier(device_ids=[torch.cuda.current_device()])
             compare_tpN_to_debug_weights(
                 tp_ranking_gr, debug_ranking_gr, debug_ranking_gr_fp32

--- a/examples/tests/commons/test_distributed.py
+++ b/examples/tests/commons/test_distributed.py
@@ -41,10 +41,13 @@ def generate_batch(
 
     feature_values = torch.randint(0, 100000, (feature_lengths.sum().item(),)).cuda()
     if dense_label:
-        labels = (
-            torch.arange(
-                actual_batch_size * num_features, device=torch.device("cuda")
-            ).view(-1)
+        # Dense labels have dim-0 == batch_size (unified convention).
+        # Real samples get meaningful values; padding rows are zeros.
+        labels = torch.zeros(
+            batch_size * num_features, device=torch.device("cuda"), dtype=torch.long
+        )
+        labels[: actual_batch_size * num_features] = (
+            torch.arange(actual_batch_size * num_features, device=torch.device("cuda"))
             // num_features
         )
     else:
@@ -161,8 +164,8 @@ def test_batch_allgather(
                     f"got {stripped.labels.numel()}"
                 )
                 assert torch.equal(
-                    stripped.labels, batch.labels
-                ), "Stripped dense labels should match original unpadded labels"
+                    stripped.labels, batch.labels[: actual_bs * num_features]
+                ), "Stripped dense labels should match original real labels"
 
 
 @pytest.mark.parametrize("batch_size", [128])


### PR DESCRIPTION
## Summary

Fix NCCL AllGather deadlock caused by inconsistent dense tensor padding in `pad_and_allgather_batch`. All dense tensor fields in `BaseBatch` now have dim-0 == `batch_size` (zero-padded by the dataloader), eliminating the ambiguity that caused `_elems_per_sample` to compute wrong padding sizes for pre-padded tensors.

Closes #361

## Changes

- **`batch_allgather.py`**: Remove `_elems_per_sample` and dense padding logic from `allgather_field` — dense tensors are already at `batch_size`, just AllGather directly
- **`batch_all2all.py`**: Remove dense padding logic from `all2all_field` and world_size==1 fast path
- **`batch.py`**: Update `BaseBatch` docstring (dense dim-0 == `batch_size`), fix `index_select_dense_tensor` to use `batch_size` instead of `actual_batch_size`
- **`batch_shuffler.py`**: Update `_strip_dense_padding` docstring
- **`test_distributed.py`**: Update `generate_batch` to pad dense labels to `[batch_size]`

Net: **-108 lines** of padding/reshaping logic removed.

## Root Cause

`pad_and_allgather_batch` assumed dense tensors had `actual_batch_size` elements and computed `eps = numel // actual_batch_size` to determine padding. But `num_candidates` was already padded to `[batch_size]` by the dataloader, so `128 // 11 = 11` (wrong, should be 1), producing a `[1408]` tensor while other ranks sent `[128]` → NCCL size mismatch → deadlock.

## Design Document

# Batch Padding & Shuffle Design

This document describes how padding, shuffling, and load balancing work together in the distributed training pipeline.

## 1. Batch Structure

`BaseBatch` holds two types of data:

| Field Type | Dimension | Padding |
|---|---|---|
| **KJT** (KeyedJaggedTensor) | `batch_size * num_keys` lengths | Padding samples have `length=0` |
| **Dense Tensor** | `batch_size` in dim-0 (flat: `batch_size * eps` elements) | Padding rows are zeros |

**Key invariant**: Both KJT and dense tensors always have `batch_size` in their batch dimension. `actual_batch_size` only records how many leading samples are real (non-padding).

```
batch_size = 128          # full size including padding
actual_batch_size = 100   # first 100 samples are real

KJT lengths:   [L0, L1, ..., L99, 0, 0, ..., 0]   (128 entries, last 28 are zero)
Dense tensor:  [V0, V1, ..., V99, 0, 0, ..., 0]   (128 entries, last 28 are zero)
```

## 2. Why KJT Padding Is Required

KJT lengths **must** be padded to `batch_size` with zeros because:

1. **AllGather symmetry**: `keyed_jagged_tensor_list_allgather` requires all ranks to contribute the same number of length entries.
2. **KK partitioning**: The Karmarkar-Karp algorithm requires `len(workloads) % world_size == 0`. Workloads are derived from KJT lengths, so the global batch must be `batch_size * world_size`.
3. **FBGEMM ops**: `keyed_jagged_index_select_dim1` requires the `batch_size` argument to match the lengths dimension.
4. **Global indexing**: After AllGather, `index_select` uses global indices (0 to `global_batch_size - 1`). Without padding, indices would be invalid.

Padding samples have `length=0`, producing zero values in the KJT. The HSTU attention kernel naturally skips these (zero-length sequences produce no attention output).

## 3. Why Dense Padding Is Required

Dense tensors **must** have dim-0 == `batch_size` because:

1. **AllGather symmetry**: `gather_along_first_dim` / `all_gather_into_tensor` requires all ranks to send the same tensor shape. If one rank has fewer rows, NCCL hangs.
2. **`index_select` correctness**: `BaseBatch.index_select` reshapes dense tensors as `[batch_size, -1]` before indexing. If dim-0 != `batch_size`, the reshape fails.
3. **Consistency with KJT**: After shuffle, `_strip_dense_padding` uses `reshape(batch_size, -1)[:actual_bs]` to extract real rows. This requires dim-0 == `batch_size`.

The dataloader is responsible for padding dense tensors to `batch_size` (e.g., `pad_tensor()` in `hstu_sequence_dataset.py`).

## 4. Shuffle Pipeline

### 4.1 Two-Phase Async Shuffle

The shuffle has two phases, designed to overlap with forward/backward:

```
Phase 1 (on _memcpy_stream, during forward):
  1. Compute per-sample workloads from KJT lengths
  2. AllGather workloads across all ranks
  3. Submit Karmarkar-Karp algorithm to background thread

Phase 2 (on _memcpy_stream, after forward):
  4. Wait for KK result (partition indices)
  5. AllGather batch data (KJT + dense)
  6. index_select to pick this rank's assigned samples
  7. Strip dense padding
```

### 4.2 Karmarkar-Karp (KK) Algorithm

KK partitions the **global batch** (`batch_size * world_size` samples, including padding) into `world_size` equal-size groups, minimizing the max workload across groups.

- Input: `[W0, W1, ..., W_{global_bs-1}]` where padding samples have `W=0`
- Output: `partitions[rank] = [idx_0, idx_1, ..., idx_{batch_size-1}]`
- Each rank gets exactly `batch_size` indices (some may point to padding samples)

### 4.3 `_sort_partitions_padding_last`

After KK, each rank's indices may interleave real and padding samples:

```
Before sort: [3, 17, 0, 12, 8, 15, 2, 20]
                      ^padding     ^padding

After sort:  [3, 17, 12, 8, 2, 20, 0, 15]
              |--- real ---|  |-padding-|
```

This ensures `[:actual_bs]` slicing extracts exactly the real samples, enabling `_strip_dense_padding` to work with a simple slice.

### 4.4 `_strip_dense_padding`

After shuffle + index_select, the batch has `batch_size` samples (some padding). `_strip_dense_padding` removes trailing padding rows from dense tensors:

```python
t.reshape(batch_size, -1)[:actual_bs].reshape(-1)
```

KJT fields are **not** stripped — they keep `batch_size` lengths (with zeros for padding). This is safe because downstream ops (attention, embedding) handle zero-length sequences.

## 5. Communication Pattern

```
AllGather path:
  Local batch [bs] → AllGather → Global batch [bs * W] → index_select [bs] → strip [actual_bs]

All2All path:
  Local batch [bs] → All2All (send to target ranks) → Local batch [bs] → strip [actual_bs]
```

Both paths produce a batch where:
- KJT has `batch_size` samples (padded)
- Dense tensors have `actual_bs` rows (stripped)
- `actual_batch_size` is set to `actual_bs`

## 6. Loss Computation

After shuffle, the model processes `actual_bs` real samples. The loss is computed only on these samples:

```python
# Pipeline handles this via num_loss_tokens():
global_tokens = batch.num_loss_tokens()  # counts only real samples
torch.distributed.all_reduce(global_tokens)
loss = local_loss_sum * dp_size / global_tokens  # normalize by real token count
```

Padding samples either:
- Produce zero loss (because their features/labels are zeros), or
- Are excluded by `_strip_dense_padding` before entering the model

## Test Plan

- [x] `test_distributed.py` — 52 cases (4 GPU), all passed
- [x] `test_batch_shuffler_factory` — passed (4 GPU)
- [x] `pretrain_gr_ranking` 4-GPU movielen integration test — 1000 iters + eval, AUC=0.80, no hang
- [ ] CI pipeline

## CI

- [Pipeline #48488310](https://gitlab-master.nvidia.com/Devtech-Compute/distributed-recommender/-/pipelines/48488310) — 2026-04-14