### PR TITLE
Add hash_roundrobin routing mode to mitigate modulo-aliasing imbalance

### DIFF
--- a/corelib/dynamicemb/DynamicEmb_APIs.md
+++ b/corelib/dynamicemb/DynamicEmb_APIs.md
@@ -97,7 +97,7 @@ For row-wise DynamicEmb sharding, the supported `dist_type` values are:
 - `roundrobin`
 - `hash_roundrobin`
 
-`hash_roundrobin` hashes the raw key before rank assignment and is intended to reduce sensitivity to pathological raw-key patterns that can break plain modulo-based `roundrobin`. It should be understood as a routing robustness improvement, not as a general solution to arbitrary hot-key or Zipf-skew load balancing.
+`hash_roundrobin` hashes the raw key before rank assignment and is intended to reduce sensitivity to pathological raw-key patterns that can break plain modulo-based `roundrobin`. It is an opt-in routing mode; the default remains `roundrobin` for compatibility with existing checkpoints. It should be understood as a routing robustness improvement, not as a general solution to arbitrary hot-key or Zipf-skew load balancing.
 
     ```python
     #How to import

--- a/corelib/dynamicemb/DynamicEmb_APIs.md
+++ b/corelib/dynamicemb/DynamicEmb_APIs.md
@@ -91,6 +91,14 @@ Wrapped TorchREC's `EmbeddingShardingPlanner` to perform sharding for dynamic em
 
 On construction it runs the internal preparation step described under [Sharding planner](#sharding-planner), then builds the TorchREC sub-planner and DynamicEmb shard metadata as before.
 
+For row-wise DynamicEmb sharding, the supported `dist_type` values are:
+
+- `continuous`
+- `roundrobin`
+- `hash_roundrobin`
+
+`hash_roundrobin` hashes the raw key before rank assignment and is intended to reduce sensitivity to pathological raw-key patterns that can break plain modulo-based `roundrobin`. It should be understood as a routing robustness improvement, not as a general solution to arbitrary hot-key or Zipf-skew load balancing.
+
     ```python
     #How to import
     from dynamicemb.planner import DynamicEmbeddingShardingPlanner

--- a/corelib/dynamicemb/dynamicemb/dynamicemb_config.py
+++ b/corelib/dynamicemb/dynamicemb/dynamicemb_config.py
@@ -40,6 +40,7 @@ from torchrec.types import DataType
 DEFAULT_INDEX_TYPE = torch.int64
 DYNAMICEMB_CSTM_SCORE_CHECK = "DYNAMICEMB_CSTM_SCORE_CHECK"
 BATCH_SIZE_PER_DUMP = 65536
+SUPPORTED_DIST_TYPES = ("continuous", "roundrobin", "hash_roundrobin")
 # Must match ``MappingEmbeddingGenerator`` mod in ``debug_init`` (initializer.cu).
 DEBUG_EMB_INITIALIZER_MOD = 100_000
 # Default hashtable bucket width in rows; keep in sync with
@@ -250,6 +251,10 @@ class DynamicEmbTableOptions:
         If not provided, will using DynamicEmbeddingTable as the Storage.
     index_type : Optional[torch.dtype], optional
         Index type of sparse features, will be set to DEFAULT_INDEX_TYPE(torch.int64) by default.
+    dist_type : str
+        Input distribution policy for row-wise sharding. Supported values are
+        ``continuous``, ``roundrobin``, and ``hash_roundrobin``. Defaults to
+        ``roundrobin``.
     admit_strategy : Optional[AdmissionStrategy], optional
         Admission strategy for controlling which keys are allowed to enter the embedding table.
         If provided, only keys that meet the strategy's criteria will be inserted into the table.
@@ -293,6 +298,7 @@ class DynamicEmbTableOptions:
     global_hbm_for_values: int = 0  # in bytes
     external_storage: Storage = None
     index_type: Optional[torch.dtype] = None
+    dist_type: str = "roundrobin"
     admit_strategy: Optional[AdmissionStrategy] = None
     admission_counter: Optional[Any] = None
 
@@ -300,6 +306,11 @@ class DynamicEmbTableOptions:
         assert (
             self.eval_initializer_args.mode == DynamicEmbInitializerMode.CONSTANT
         ), "eval_initializer_args must be constant initialization"
+        if self.dist_type not in SUPPORTED_DIST_TYPES:
+            raise ValueError(
+                f"Unsupported dist_type {self.dist_type!r}. "
+                f"Supported values: {SUPPORTED_DIST_TYPES}."
+            )
 
     def __eq__(self, other):
         if not isinstance(other, DynamicEmbTableOptions):
@@ -319,6 +330,7 @@ class DynamicEmbTableOptions:
         grouped_key["caching"] = self.caching
         grouped_key["external_storage"] = self.external_storage
         grouped_key["index_type"] = self.index_type
+        grouped_key["dist_type"] = self.dist_type
         grouped_key["score_strategy"] = self.score_strategy
         grouped_key["admit_strategy"] = self.admit_strategy
         return grouped_key

--- a/corelib/dynamicemb/dynamicemb/input_dist.py
+++ b/corelib/dynamicemb/dynamicemb/input_dist.py
@@ -122,6 +122,8 @@ def bucketize_kjt_before_all2all(
             dist_type = 0
         elif dist_type_str == "roundrobin":
             dist_type = 1
+        elif dist_type_str == "hash_roundrobin":
+            dist_type = 2
         else:
             raise ValueError("Not support dist type of ", dist_type_str)
         dist_type_list.append(dist_type)

--- a/corelib/dynamicemb/dynamicemb/key_value_table.py
+++ b/corelib/dynamicemb/dynamicemb/key_value_table.py
@@ -1082,6 +1082,7 @@ def _dump_table(
         meta_data = {}
         meta_data.update(state.optimizer.get_opt_args())
         meta_data["evict_strategy"] = str(state.evict_strategy)
+        meta_data["dist_type"] = state.options_list[table_id].dist_type
 
         if current_score is not None:
             meta_data["step_score"] = current_score
@@ -1242,6 +1243,14 @@ def _validate_load_meta(
     if evict_strategy and str(state.evict_strategy) != evict_strategy:
         raise ValueError(
             f"Evict strategy mismatch: {evict_strategy} != {state.evict_strategy}"
+        )
+    ckpt_dist_type = meta_data.get("dist_type", "roundrobin")
+    runtime_dist_type = state.options_list[table_id].dist_type
+    if runtime_dist_type != ckpt_dist_type:
+        raise ValueError(
+            "Input dist_type mismatch: checkpoint was dumped with "
+            f"{ckpt_dist_type!r}, but runtime table is configured with "
+            f"{runtime_dist_type!r}. Please load with a matching dist_type."
         )
 
     if score_file_path is None:

--- a/corelib/dynamicemb/dynamicemb/planner/planner.py
+++ b/corelib/dynamicemb/dynamicemb/planner/planner.py
@@ -89,7 +89,7 @@ class DynamicEmbParameterSharding(ParameterSharding):
 
     # introduced fields by DynamicEmbParameterSharding
     customized_compute_kernel: Optional[str] = DynamicEmbKernel
-    dist_type: str = "continuous"
+    dist_type: str = "roundrobin"
     dynamicemb_options: Optional[DynamicEmbTableOptions] = field(
         default_factory=DynamicEmbTableOptions
     )
@@ -343,7 +343,7 @@ class DynamicEmbeddingShardingPlanner:
                 ranks=[i for i in range(world_size)],
                 compute_kernel=EmbeddingComputeKernel.CUSTOMIZED_KERNEL.value,
                 customized_compute_kernel=DynamicEmbKernel,
-                dist_type="roundrobin",
+                dist_type=opts.dist_type,
                 dynamicemb_options=opts,
             )
             self._dyn_emb_plan[dyn_emb_name] = tmp_para_sharding

--- a/corelib/dynamicemb/dynamicemb/planner/planner.py
+++ b/corelib/dynamicemb/dynamicemb/planner/planner.py
@@ -343,7 +343,7 @@ class DynamicEmbeddingShardingPlanner:
                 ranks=[i for i in range(world_size)],
                 compute_kernel=EmbeddingComputeKernel.CUSTOMIZED_KERNEL.value,
                 customized_compute_kernel=DynamicEmbKernel,
-                dist_type="roundrobin",
+                dist_type="hash_roundrobin",
                 dynamicemb_options=opts,
             )
             self._dyn_emb_plan[dyn_emb_name] = tmp_para_sharding

--- a/corelib/dynamicemb/dynamicemb/planner/planner.py
+++ b/corelib/dynamicemb/dynamicemb/planner/planner.py
@@ -343,7 +343,7 @@ class DynamicEmbeddingShardingPlanner:
                 ranks=[i for i in range(world_size)],
                 compute_kernel=EmbeddingComputeKernel.CUSTOMIZED_KERNEL.value,
                 customized_compute_kernel=DynamicEmbKernel,
-                dist_type="hash_roundrobin",
+                dist_type="hash_roundrobin", # NOTE: changed from "roundrobin" in this release; existing checkpoints are incompatible
                 dynamicemb_options=opts,
             )
             self._dyn_emb_plan[dyn_emb_name] = tmp_para_sharding

--- a/corelib/dynamicemb/dynamicemb/planner/planner.py
+++ b/corelib/dynamicemb/dynamicemb/planner/planner.py
@@ -343,7 +343,7 @@ class DynamicEmbeddingShardingPlanner:
                 ranks=[i for i in range(world_size)],
                 compute_kernel=EmbeddingComputeKernel.CUSTOMIZED_KERNEL.value,
                 customized_compute_kernel=DynamicEmbKernel,
-                dist_type="hash_roundrobin", # NOTE: changed from "roundrobin" in this release; existing checkpoints are incompatible
+                dist_type="roundrobin",
                 dynamicemb_options=opts,
             )
             self._dyn_emb_plan[dyn_emb_name] = tmp_para_sharding

--- a/corelib/dynamicemb/example/README.md
+++ b/corelib/dynamicemb/example/README.md
@@ -10,6 +10,28 @@ bash ./run_example.sh
 
 - The [example.py](./example.py) will show you how to train and evaluate the embedding module, as well as dump, load and incremental dump the module, and this example also demonstrates how to customize embedding admissions.
 
+- Input distribution examples:
+```shell
+export NGPU=2
+
+# default input distribution: roundrobin
+torchrun --standalone --nproc_per_node=${NGPU} example.py --train
+
+# explicit roundrobin
+torchrun --standalone --nproc_per_node=${NGPU} example.py --train --dist_type roundrobin
+
+# opt-in hash-based routing
+torchrun --standalone --nproc_per_node=${NGPU} example.py --train --dist_type hash_roundrobin
+
+# continuous routing
+torchrun --standalone --nproc_per_node=${NGPU} example.py --train --dist_type continuous
+
+# run through the helper script (arguments are forwarded to example.py)
+bash ./run_example.sh --dist_type hash_roundrobin
+```
+
+`hash_roundrobin` is an opt-in routing mode intended to reduce sensitivity to pathological raw-key patterns that can break plain modulo-based `roundrobin`.
+
 
 - For detailed explanations of specific APIs and parameters, please refer to [API Doc](../DynamicEmb_APIs.md).
 

--- a/corelib/dynamicemb/example/example.py
+++ b/corelib/dynamicemb/example/example.py
@@ -5,7 +5,8 @@ import shutil
 import urllib.request
 import warnings
 import zipfile
-from typing import List
+from dataclasses import dataclass
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -59,25 +60,7 @@ warnings.filterwarnings(
     "ignore", message=".*torch.library.impl_abstract.*", category=FutureWarning
 )
 
-backend = "nccl"
-dist.init_process_group(backend=backend)
-
-# Set LOCAL_WORLD_SIZE if not available for proper topology configuration
-if "LOCAL_WORLD_SIZE" not in os.environ:
-    os.environ["LOCAL_WORLD_SIZE"] = str(torch.cuda.device_count())
-
-# Set LOCAL_RANK if not available (for consistency)
-if "LOCAL_RANK" not in os.environ:
-    os.environ["LOCAL_RANK"] = str(get_local_rank())
-
-# Set RANK if not available
-if "RANK" not in os.environ:
-    os.environ["RANK"] = str(dist.get_rank())
-
-local_rank = dist.get_rank()  # for one node
-world_size = dist.get_world_size()
-torch.cuda.set_device(local_rank)
-device = torch.device(f"cuda:{local_rank}")
+BACKEND = "nccl"
 # print with rank info
 original_print = builtins.print
 
@@ -89,9 +72,55 @@ def rank_print(*args, **kwargs):
 builtins.print = rank_print
 cache_ratio = 0.5  # assume we will use 50% of the HBM for cache
 
+@dataclass
+class RuntimeContext:
+    backend: str
+    rank: int
+    local_rank: int
+    world_size: int
+    device: torch.device
 
-def download_movielens(data_dir="./ml-1m"):
-    if dist.get_rank() == 0:  # Use global rank for multi-node consistency
+def init_runtime() -> RuntimeContext:
+    # Set LOCAL_WORLD_SIZE if not available for proper topology configuration.
+    if "LOCAL_WORLD_SIZE" not in os.environ:
+        os.environ["LOCAL_WORLD_SIZE"] = str(torch.cuda.device_count())
+
+    # Keep the example usable in non-torchrun single-process runs as well.
+    if "RANK" not in os.environ:
+        os.environ["RANK"] = "0"
+    if "WORLD_SIZE" not in os.environ:
+        os.environ["WORLD_SIZE"] = "1"
+    if "LOCAL_RANK" not in os.environ:
+        os.environ["LOCAL_RANK"] = os.environ.get("RANK", "0")
+
+    dist.init_process_group(backend=BACKEND)
+
+    rank = dist.get_rank()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = dist.get_world_size()
+
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    def rank_print(*args, **kwargs):
+        original_print(f"[RANK {rank}] ", *args, **kwargs)
+
+    builtins.print = rank_print
+    return RuntimeContext(
+        backend=BACKEND,
+        rank=rank,
+        local_rank=local_rank,
+        world_size=world_size,
+        device=device,
+    )
+
+def cleanup_runtime(runtime: Optional[RuntimeContext]) -> None:
+    builtins.print = original_print
+    if runtime is not None and dist.is_available() and dist.is_initialized():
+        dist.destroy_process_group()
+
+def download_movielens(runtime: RuntimeContext, data_dir="./ml-1m"):
+    if runtime.rank == 0:  # Use global rank for multi-node consistency
         os.makedirs(data_dir, exist_ok=True)
         if os.path.exists(os.path.join(data_dir, "ratings.dat")):
             print(f"MovieLens in {data_dir}")
@@ -167,6 +196,13 @@ def parse_args():
         type=int,
         default=0,
         help="Frequency threshold for admission strategy (0 disable admission strategy, >0 enable admission strategy and only keys appearing >= threshold will be stored in tables)",
+    )
+    parser.add_argument(
+        "--dist_type",
+        type=str,
+        choices=["continuous", "roundrobin", "hash_roundrobin"],
+        default="roundrobin",
+        help="DynamicEmb row-wise input distribution policy.",
     )
     return parser.parse_args()
 
@@ -415,7 +451,7 @@ def get_sharder(args, optimizer_type):
                 backward_precision=CommType.FP32,
             )
         )
-        if backend == "nccl"
+        if BACKEND == "nccl"
         else None
     )
 
@@ -454,6 +490,8 @@ def get_planner(
     bucket_capacity = 128
     # KVCounter hash bucket width (not ``DynamicEmbTableOptions.bucket_capacity``).
     kv_counter_bucket_capacity = 1024
+
+    print(f"Using DynamicEmb dist_type={args.dist_type}")
 
     dict_const = {}
 
@@ -504,6 +542,7 @@ def get_planner(
                 initializer_args=DynamicEmbInitializerArgs(
                     mode=DynamicEmbInitializerMode.NORMAL
                 ),
+                dist_type=args.dist_type,
                 score_strategy=DynamicEmbScoreStrategy.STEP,
                 caching=caching,
                 training=training,
@@ -544,7 +583,7 @@ def get_planner(
     )
 
 
-def apply_dmp(model, args, training):
+def apply_dmp(model, args, runtime: RuntimeContext, training):
     """
     The initialization of embedding lookup module in dynamicemb is almost consistent with torchrec.
         1. Firstly, you should configure the global parameters of an embedding table using `EmbeddingCollection`.
@@ -576,7 +615,7 @@ def apply_dmp(model, args, training):
     The following steps demonstrate how to obtain `DynamicEmbParameterSharding` by `DynamicEmbeddingShardingPlanner`.
     """
     planner = get_planner(
-        device,
+        runtime.device,
         eb_configs,
         args.batch_size,
         optimizer_type=optimizer_type,
@@ -597,7 +636,7 @@ def apply_dmp(model, args, training):
     """
     dmp = DistributedModelParallel(
         module=model,
-        device=device,
+        device=runtime.device,
         # pyre-ignore
         sharders=[sharder],
         plan=plan,
@@ -605,7 +644,7 @@ def apply_dmp(model, args, training):
     return dmp
 
 
-def create_model(args, training=True):
+def create_model(args, runtime: RuntimeContext, training=True):
     # Define the configuration parameters for the embedding table,
     # including its name, embedding dimension, total number of embeddings, and feature name.
     eb_configs = [
@@ -668,18 +707,18 @@ def create_model(args, training=True):
         over_arch_layer_sizes=mlp_dims,
     )
 
-    model = apply_dmp(model, args, training)
+    model = apply_dmp(model, args, runtime, training)
 
     return model
 
 
-def train_one_epoch(model, train_loader, optimizer, loss_fn, epoch, total_epochs):
+def train_one_epoch(model, train_loader, optimizer, loss_fn, epoch, total_epochs, runtime: RuntimeContext):
     model.train()
     total_loss = 0
 
     for batch_idx, (features, labels) in enumerate(train_loader):
-        features = features.to(device)
-        labels = labels.to(device)
+        features = features.to(runtime.device)
+        labels = labels.to(runtime.device)
 
         outputs = model(features)
         loss = loss_fn(outputs, labels)
@@ -699,13 +738,13 @@ def train_one_epoch(model, train_loader, optimizer, loss_fn, epoch, total_epochs
     print(f"Epoch {epoch+1}/{total_epochs}, Average Loss: {avg_loss:.4f}")
 
 
-def test_one_epoch(model, test_loader, loss_fn, epoch, total_epochs):
+def test_one_epoch(model, test_loader, loss_fn, epoch, total_epochs, runtime: RuntimeContext):
     model.eval()
     test_loss = 0
     with torch.inference_mode():
         for features, labels in test_loader:
-            features = features.to(device)
-            labels = labels.to(device)
+            features = features.to(runtime.device)
+            labels = labels.to(runtime.device)
 
             outputs = model(features)
             loss = loss_fn(outputs, labels)
@@ -715,14 +754,14 @@ def test_one_epoch(model, test_loader, loss_fn, epoch, total_epochs):
     print(f"Epoch {epoch+1}/{total_epochs}, Test Loss: {avg_test_loss:.4f}")
 
 
-def train(args):
+def train(args, runtime: RuntimeContext):
     train_dataset = MovieLensDataset(args.data_path, split="train")
     test_dataset = MovieLensDataset(args.data_path, split="test")
     train_sampler = DistributedSampler(
-        train_dataset, num_replicas=world_size, rank=dist.get_rank(), shuffle=True
+        train_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=True
     )
     test_sampler = DistributedSampler(
-        test_dataset, num_replicas=world_size, rank=dist.get_rank(), shuffle=False
+        test_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=False
     )
 
     train_loader = DataLoader(
@@ -743,24 +782,24 @@ def train(args):
         sampler=test_sampler,
     )
 
-    model = create_model(args)
-    model.to(device)
+    model = create_model(args, runtime)
+    model.to(runtime.device)
 
     optimizer = Adam(model.parameters(), lr=args.lr)
     criterion = nn.MSELoss()
 
     for epoch in range(args.epochs):
         train_sampler.set_epoch(epoch)
-        train_one_epoch(model, train_loader, optimizer, criterion, epoch, args.epochs)
-        test_one_epoch(model, test_loader, criterion, epoch, args.epochs)
+        train_one_epoch(model, train_loader, optimizer, criterion, epoch, args.epochs, runtime)
+        test_one_epoch(model, test_loader, criterion, epoch, args.epochs, runtime)
 
 
-def dump(args):
+def dump(args, runtime: RuntimeContext):
     os.makedirs(args.save_dir, exist_ok=True)
     train_dataset = MovieLensDataset(args.data_path, split="train")
     # Use global rank for proper data distribution across all processes
     train_sampler = DistributedSampler(
-        train_dataset, num_replicas=world_size, rank=dist.get_rank(), shuffle=True
+        train_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=True
     )
 
     train_loader = DataLoader(
@@ -772,15 +811,15 @@ def dump(args):
         sampler=train_sampler,
     )
 
-    model = create_model(args)
-    model.to(device)
+    model = create_model(args, runtime)
+    model.to(runtime.device)
 
     optimizer = Adam(model.parameters(), lr=args.lr)
     criterion = nn.MSELoss()
 
     for epoch in range(args.epochs):
         train_sampler.set_epoch(epoch)
-        train_one_epoch(model, train_loader, optimizer, criterion, epoch, args.epochs)
+        train_one_epoch(model, train_loader, optimizer, criterion, epoch, args.epochs, runtime)
 
         # ShardedDyanmicEmbeddingCollection.state_dict() will return a dummy tensor.
         torch.save(
@@ -789,18 +828,18 @@ def dump(args):
                 "optimizer_state_dict": optimizer.state_dict(),
             },
             os.path.join(
-                args.save_dir, f"model_epoch_{epoch+1}_rank{dist.get_rank()}.pt"
+                args.save_dir, f"model_epoch_{epoch+1}_rank{runtime.rank}.pt"
             ),
         )
     DynamicEmbDump(os.path.join(args.save_dir, "dynamicemb"), model, optim=True)
 
 
-def load(args):
+def load(args, runtime: RuntimeContext):
     os.makedirs(args.save_dir, exist_ok=True)
     test_dataset = MovieLensDataset(args.data_path, split="test")
     # Use global rank for proper data distribution across all processes
     test_sampler = DistributedSampler(
-        test_dataset, num_replicas=world_size, rank=dist.get_rank(), shuffle=False
+        test_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=False
     )
 
     test_loader = DataLoader(
@@ -812,8 +851,8 @@ def load(args):
         sampler=test_sampler,
     )
 
-    model = create_model(args)
-    model.to(device)
+    model = create_model(args, runtime)
+    model.to(runtime.device)
 
     optimizer = Adam(model.parameters(), lr=args.lr)
     criterion = nn.MSELoss()
@@ -821,7 +860,7 @@ def load(args):
     # load
     checkpoint = torch.load(
         os.path.join(
-            args.save_dir, f"model_epoch_{args.epochs}_rank{dist.get_rank()}.pt"
+            args.save_dir, f"model_epoch_{args.epochs}_rank{runtime.rank}.pt"
         ),
         weights_only=True,
     )
@@ -831,24 +870,24 @@ def load(args):
 
     DynamicEmbLoad(os.path.join(args.save_dir, "dynamicemb"), model, optim=True)
 
-    test_one_epoch(model, test_loader, criterion, 0, 1)
+    test_one_epoch(model, test_loader, criterion, 0, 1, runtime)
 
-    dist.barrier(device_ids=[local_rank])
+    dist.barrier(device_ids=[runtime.local_rank])
     # Only global rank 0 should clean up, not local rank 0 on each node
-    if dist.get_rank() == 0:
+    if runtime.rank == 0:
         try:
             shutil.rmtree(args.save_dir)
         except Exception as e:
             print(f"Warning: Failed to remove {args.save_dir}: {e}")
-    dist.barrier(device_ids=[local_rank])
+    dist.barrier(device_ids=[runtime.local_rank])
 
 
-def inc_dump(args):
+def inc_dump(args, runtime: RuntimeContext):
     os.makedirs(args.save_dir, exist_ok=True)
     train_dataset = MovieLensDataset(args.data_path, split="train")
     # Use global rank for proper data distribution across all processes
     train_sampler = DistributedSampler(
-        train_dataset, num_replicas=world_size, rank=dist.get_rank(), shuffle=True
+        train_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=True
     )
 
     train_loader = DataLoader(
@@ -860,8 +899,8 @@ def inc_dump(args):
         sampler=train_sampler,
     )
 
-    model = create_model(args)
-    model.to(device)
+    model = create_model(args, runtime)
+    model.to(runtime.device)
 
     optimizer = Adam(model.parameters(), lr=args.lr)
     criterion = nn.MSELoss()
@@ -874,8 +913,8 @@ def inc_dump(args):
         total_loss = 0
 
         for batch_idx, (features, labels) in enumerate(train_loader):
-            features = features.to(device)
-            labels = labels.to(device)
+            features = features.to(runtime.device)
+            labels = labels.to(runtime.device)
 
             outputs = model(features)
             loss = criterion(outputs, labels)
@@ -908,22 +947,25 @@ def inc_dump(args):
 
 def main():
     args = parse_args()
-    torch.cuda.manual_seed(args.seed)
-    np.random.seed(args.seed)
-    if dist.get_rank() == 0:  # Use global rank for multi-node consistency
-        download_movielens(args.data_path)
-    dist.barrier(device_ids=[local_rank])
-    if args.train:
-        train(args)
-    if args.dump:
-        dump(args)
-    if args.load:
-        load(args)
-    if args.incremental_dump:
-        inc_dump(args)
+    runtime: Optional[RuntimeContext] = None
+    try:
+        runtime = init_runtime()
+        torch.cuda.manual_seed(args.seed)
+        np.random.seed(args.seed)
+        if runtime.rank == 0:  # Use global rank for multi-node consistency
+            download_movielens(runtime, args.data_path)
+        dist.barrier(device_ids=[runtime.local_rank])
+        if args.train:
+            train(args, runtime)
+        if args.dump:
+            dump(args, runtime)
+        if args.load:
+            load(args, runtime)
+        if args.incremental_dump:
+            inc_dump(args, runtime)
+    finally:
+        cleanup_runtime(runtime)
 
 
 if __name__ == "__main__":
     main()
-
-dist.destroy_process_group()

--- a/corelib/dynamicemb/src/sparse_block_bucketize_features.cu
+++ b/corelib/dynamicemb/src/sparse_block_bucketize_features.cu
@@ -26,6 +26,17 @@ using Tensor = at::Tensor;
 
 namespace dyn_emb {
 
+// Hash function for load-balanced key distribution
+// Uses MurmurHash3 finalizer for good avalanche properties
+__forceinline__ __device__ uint64_t hash_key(uint64_t key) {
+  key ^= key >> 33;
+  key *= 0xff51afd7ed558ccdULL;
+  key ^= key >> 33;
+  key *= 0xc4ceb9fe1a85ec53ULL;
+  key ^= key >> 33;
+  return key;
+}
+
 __forceinline__ __device__ int atomicAdd(int *address, int val) {
   return ::atomicAdd(address, val);
 }
@@ -224,8 +235,7 @@ __launch_bounds__(kMaxThreads) void _block_bucketize_sparse_features_cuda_kernel
   const auto stride = gridDim.x * blockDim.y;
   for (auto b_t = bt_start; b_t < lengths_size; b_t += stride) {
     const auto t = length_to_feature_idx ? length_to_feature_idx[b_t] : b_t / B;
-    bool use_roundrobin =
-        dist_type_per_feature ? dist_type_per_feature[t] : false;
+    int32_t dist_type = dist_type_per_feature ? dist_type_per_feature[t] : 0;
     index_t blk_size = block_sizes_data[t];
     offset_t rowstart = (b_t == 0 ? 0 : offsets_data[b_t - 1]);
     offset_t rowend = offsets_data[b_t];
@@ -241,12 +251,13 @@ __launch_bounds__(kMaxThreads) void _block_bucketize_sparse_features_cuda_kernel
       for (auto i = rowstart + threadIdx.x; i < rowend; i += blockDim.x) {
         uindex_t idx = static_cast<uindex_t>(indices_data[i]);
         uindex_t p = 0;
-        if (use_roundrobin) {
-
-          p = idx % my_size;
-        } else {
-          p = idx < blk_size * my_size ? idx / blk_size : idx % my_size;
-        }
+	if (dist_type == 1) {
+	    p = idx % my_size;
+        } else if (dist_type == 2){
+	    p = static_cast<uindex_t>(hash_key(static_cast<uint64_t>(idx))) % my_size;
+	} else {
+	    p = idx < blk_size * my_size ? idx / blk_size : idx % my_size;
+	}
         atomicAdd(&new_lengths_data[p * lengths_size + b_t], 1);
       }
       return;
@@ -302,8 +313,7 @@ __launch_bounds__(kMaxThreads) void _block_bucketize_sparse_features_cuda_kernel
   using uoffset_t = std::make_unsigned_t<offset_t>;
   CUDA_1D_KERNEL_LOOP(b_t, lengths_size) {
     const auto t = length_to_feature_idx ? length_to_feature_idx[b_t] : b_t / B;
-    bool use_roundrobin =
-        dist_type_per_feature ? dist_type_per_feature[t] : false;
+    int32_t dist_type = dist_type_per_feature ? dist_type_per_feature[t] : 0;
     index_t blk_size = block_sizes_data[t];
     offset_t rowstart = (b_t == 0 ? 0 : offsets_data[b_t - 1]);
     offset_t rowend = offsets_data[b_t];
@@ -320,8 +330,11 @@ __launch_bounds__(kMaxThreads) void _block_bucketize_sparse_features_cuda_kernel
       uindex_t p = 0;
       uindex_t new_idx = 0;
       if (!use_block_bucketize_pos) {
-        if (use_roundrobin) {
+        if (dist_type == 1) {
           p = idx % my_size;
+          new_idx = idx;
+	} else if (dist_type == 2) {
+          p = static_cast<uindex_t>(hash_key(static_cast<uint64_t>(idx))) % my_size;
           new_idx = idx;
         } else {
           p = idx < blk_size * my_size ? idx / blk_size : idx % my_size;
@@ -330,12 +343,7 @@ __launch_bounds__(kMaxThreads) void _block_bucketize_sparse_features_cuda_kernel
       } else {
         uindex_t lb = indices_to_lb[i];
         p = lb < my_size ? lb : idx % my_size;
-        new_idx =
-            lb < my_size
-                ? idx -
-                      block_bucketize_pos_concat[lb +
-                                                 block_bucketize_pos_offsets[t]]
-                : idx / my_size;
+        new_idx = lb < my_size ? idx - block_bucketize_pos_concat[lb + block_bucketize_pos_offsets[t]]: idx / my_size;
       }
       uoffset_t pos = new_offsets_data[p * lengths_size + b_t];
       new_indices_data[pos] = new_idx;

--- a/corelib/dynamicemb/src/sparse_block_bucketize_features.cu
+++ b/corelib/dynamicemb/src/sparse_block_bucketize_features.cu
@@ -253,7 +253,7 @@ __launch_bounds__(kMaxThreads) void _block_bucketize_sparse_features_cuda_kernel
         uindex_t p = 0;
 	if (dist_type == 1) {
 	    p = idx % my_size;
-        } else if (dist_type == 2){
+        } else if (dist_type == 2) {
 	    p = static_cast<uindex_t>(hash_key(static_cast<uint64_t>(idx))) % my_size;
 	} else {
 	    p = idx < blk_size * my_size ? idx / blk_size : idx % my_size;

--- a/corelib/dynamicemb/test/test_batched_dynamic_embedding_tables_v2.py
+++ b/corelib/dynamicemb/test/test_batched_dynamic_embedding_tables_v2.py
@@ -35,6 +35,7 @@ from dynamicemb import (
 from dynamicemb.batched_dynamicemb_tables import (
     BatchedDynamicEmbeddingTablesV2,
     encode_checkpoint_file_path,
+    encode_meta_json_file_path,
 )
 from dynamicemb.dynamicemb_config import (
     DEBUG_EMB_INITIALIZER_MOD,
@@ -1072,6 +1073,7 @@ class PyDictStorage(Storage[DynamicEmbTableOptions, BaseDynamicEmbeddingOptimize
         if include_meta:
             meta_data = {}
             meta_data.update(self.optimizer.get_opt_args())
+            meta_data["dist_type"] = self.options[table_id].dist_type
             with open(meta_file_path, "w") as f:
                 json.dump(meta_data, f)
 
@@ -1122,6 +1124,14 @@ class PyDictStorage(Storage[DynamicEmbTableOptions, BaseDynamicEmbeddingOptimize
                 and self.optimizer.get_opt_args().get("opt_type", None) != opt_type
             ):
                 include_optim = False
+            ckpt_dist_type = meta_data.get("dist_type", "roundrobin")
+            runtime_dist_type = self.options[table_id].dist_type
+            if runtime_dist_type != ckpt_dist_type:
+                raise ValueError(
+                    "Input dist_type mismatch: checkpoint was dumped with "
+                    f"{ckpt_dist_type!r}, but runtime table is configured with "
+                    f"{runtime_dist_type!r}. Please load with a matching dist_type."
+                )
             if include_optim:
                 self.optimizer.set_opt_args(meta_data)
 
@@ -2422,6 +2432,256 @@ def test_multi_table_dump_load(opt_type, opt_params, tmp_path):
     torch.testing.assert_close(vals1_src[idx1_src], vals1_dst[idx1_dst])
 
     print("test_multi_table_dump_load passed")
+
+def _make_multi_table_bdeb_for_dump_load(
+    opt_type: EmbOptimType,
+    opt_params: Dict[str, Any],
+    dims: List[int],
+    table_names: List[str],
+    feature_table_map: List[int],
+    max_capacity: int,
+    key_type: torch.dtype,
+    value_type: torch.dtype,
+    device_id: int,
+    dist_type: str = "roundrobin",
+) -> BatchedDynamicEmbeddingTablesV2:
+    opts = []
+    for dim in dims:
+        opts.append(
+            DynamicEmbTableOptions(
+                dim=dim,
+                init_capacity=max_capacity,
+                max_capacity=max_capacity,
+                index_type=key_type,
+                embedding_dtype=value_type,
+                device_id=device_id,
+                score_strategy=DynamicEmbScoreStrategy.STEP,
+                caching=False,
+                local_hbm_for_values=1024**3,
+                dist_type=dist_type,
+            )
+        )
+    return BatchedDynamicEmbeddingTablesV2(
+        table_names=table_names,
+        table_options=opts,
+        feature_table_map=feature_table_map,
+        pooling_mode=DynamicEmbPoolingMode.SUM,
+        optimizer=opt_type,
+        use_index_dedup=True,
+        **opt_params,
+    )
+
+
+def _train_multi_table_bdeb_once(
+    bdeb: BatchedDynamicEmbeddingTablesV2,
+    key_type: torch.dtype,
+    device: torch.device,
+) -> None:
+    indices = torch.tensor(
+        [0, 1, 2, 3, 10, 11, 12, 13], dtype=key_type, device=device
+    )
+    offsets = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8], dtype=key_type, device=device)
+
+    for _ in range(3):
+        embs = bdeb(indices, offsets)
+        loss = embs.mean()
+        loss.backward()
+        torch.cuda.synchronize()
+
+
+@pytest.mark.parametrize("dist_type", ["roundrobin", "hash_roundrobin"])
+def test_multi_table_dump_load_preserves_dist_type(dist_type, tmp_path):
+    import torch.distributed as dist
+
+    assert torch.cuda.is_available()
+    device_id = 0
+    torch.cuda.set_device(device_id)
+    if not dist.is_initialized():
+        dist.init_process_group(
+            backend="nccl",
+            init_method="tcp://127.0.0.1:29500",
+            rank=0,
+            world_size=1,
+        )
+
+    device = torch.device(f"cuda:{device_id}")
+    dims = [8, 16]
+    table_names = ["table0", "table1"]
+    feature_table_map = [0, 1]
+    key_type = torch.int64
+    value_type = torch.float32
+    max_capacity = 1024
+    opt_type = EmbOptimType.SGD
+    opt_params = {"learning_rate": 0.3}
+
+    bdeb_src = _make_multi_table_bdeb_for_dump_load(
+        opt_type,
+        opt_params,
+        dims,
+        table_names,
+        feature_table_map,
+        max_capacity,
+        key_type,
+        value_type,
+        device_id,
+        dist_type=dist_type,
+    )
+    _train_multi_table_bdeb_once(bdeb_src, key_type, device)
+
+    save_dir = str(tmp_path)
+    bdeb_src.dump(save_dir)
+    meta_path = encode_meta_json_file_path(save_dir, table_names[0])
+    with open(meta_path, "r") as f:
+        meta_data = json.load(f)
+    assert meta_data["dist_type"] == dist_type
+
+    bdeb_dst = _make_multi_table_bdeb_for_dump_load(
+        opt_type,
+        opt_params,
+        dims,
+        table_names,
+        feature_table_map,
+        max_capacity,
+        key_type,
+        value_type,
+        device_id,
+        dist_type=dist_type,
+    )
+    bdeb_dst.load(save_dir)
+
+    keys0_src, vals0_src = bdeb_src.export_keys_values("table0", device)
+    keys0_dst, vals0_dst = bdeb_dst.export_keys_values("table0", device)
+    idx0_src = keys0_src.argsort()
+    idx0_dst = keys0_dst.argsort()
+    torch.testing.assert_close(keys0_src[idx0_src], keys0_dst[idx0_dst])
+    torch.testing.assert_close(vals0_src[idx0_src], vals0_dst[idx0_dst])
+
+
+def test_multi_table_load_rejects_dist_type_mismatch(tmp_path):
+    import torch.distributed as dist
+
+    assert torch.cuda.is_available()
+    device_id = 0
+    torch.cuda.set_device(device_id)
+    if not dist.is_initialized():
+        dist.init_process_group(
+            backend="nccl",
+            init_method="tcp://127.0.0.1:29500",
+            rank=0,
+            world_size=1,
+        )
+
+    device = torch.device(f"cuda:{device_id}")
+    dims = [8, 16]
+    table_names = ["table0", "table1"]
+    feature_table_map = [0, 1]
+    key_type = torch.int64
+    value_type = torch.float32
+    max_capacity = 1024
+    opt_type = EmbOptimType.SGD
+    opt_params = {"learning_rate": 0.3}
+
+    bdeb_src = _make_multi_table_bdeb_for_dump_load(
+        opt_type,
+        opt_params,
+        dims,
+        table_names,
+        feature_table_map,
+        max_capacity,
+        key_type,
+        value_type,
+        device_id,
+        dist_type="roundrobin",
+    )
+    _train_multi_table_bdeb_once(bdeb_src, key_type, device)
+
+    save_dir = str(tmp_path)
+    bdeb_src.dump(save_dir)
+
+    bdeb_dst = _make_multi_table_bdeb_for_dump_load(
+        opt_type,
+        opt_params,
+        dims,
+        table_names,
+        feature_table_map,
+        max_capacity,
+        key_type,
+        value_type,
+        device_id,
+        dist_type="hash_roundrobin",
+    )
+    with pytest.raises(ValueError, match="Input dist_type mismatch"):
+        bdeb_dst.load(save_dir)
+
+
+def test_multi_table_load_legacy_metadata_defaults_to_roundrobin(tmp_path):
+    import torch.distributed as dist
+
+    assert torch.cuda.is_available()
+    device_id = 0
+    torch.cuda.set_device(device_id)
+    if not dist.is_initialized():
+        dist.init_process_group(
+            backend="nccl",
+            init_method="tcp://127.0.0.1:29500",
+            rank=0,
+            world_size=1,
+        )
+
+    device = torch.device(f"cuda:{device_id}")
+    dims = [8, 16]
+    table_names = ["table0", "table1"]
+    feature_table_map = [0, 1]
+    key_type = torch.int64
+    value_type = torch.float32
+    max_capacity = 1024
+    opt_type = EmbOptimType.SGD
+    opt_params = {"learning_rate": 0.3}
+
+    bdeb_src = _make_multi_table_bdeb_for_dump_load(
+        opt_type,
+        opt_params,
+        dims,
+        table_names,
+        feature_table_map,
+        max_capacity,
+        key_type,
+        value_type,
+        device_id,
+        dist_type="roundrobin",
+    )
+    _train_multi_table_bdeb_once(bdeb_src, key_type, device)
+
+    save_dir = str(tmp_path)
+    bdeb_src.dump(save_dir)
+    for table_name in table_names:
+        meta_path = encode_meta_json_file_path(save_dir, table_name)
+        with open(meta_path, "r") as f:
+            meta_data = json.load(f)
+        meta_data.pop("dist_type", None)
+        with open(meta_path, "w") as f:
+            json.dump(meta_data, f)
+
+    bdeb_dst = _make_multi_table_bdeb_for_dump_load(
+        opt_type,
+        opt_params,
+        dims,
+        table_names,
+        feature_table_map,
+        max_capacity,
+        key_type,
+        value_type,
+        device_id,
+        dist_type="roundrobin",
+    )
+    bdeb_dst.load(save_dir)
+
+    keys1_src, vals1_src = bdeb_src.export_keys_values("table1", device)
+    keys1_dst, vals1_dst = bdeb_dst.export_keys_values("table1", device)
+    idx1_src = keys1_src.argsort()
+    idx1_dst = keys1_dst.argsort()
+    torch.testing.assert_close(keys1_src[idx1_src], keys1_dst[idx1_dst])
+    torch.testing.assert_close(vals1_src[idx1_src], vals1_dst[idx1_dst])
 
 
 def _dtype_element_size(dtype: torch.dtype) -> int:

--- a/corelib/dynamicemb/test/unit_test.sh
+++ b/corelib/dynamicemb/test/unit_test.sh
@@ -9,6 +9,7 @@ FWD_BWD_TEST_FILES=(
     "test/unit_tests/test_pooled_embedding.sh"
     "test/unit_tests/test_twin_module.sh"
     "test/unit_tests/test_alignment.sh"
+    "test/unit_tests/test_hash_roundrobin_kuairand.py"
     "test/unit_tests/test_hybrid_storage_export.sh"
     "test/unit_tests/test_vmm_tensor.py"
 )

--- a/corelib/dynamicemb/test/unit_tests/test_embedding_dump_load.py
+++ b/corelib/dynamicemb/test/unit_tests/test_embedding_dump_load.py
@@ -278,6 +278,7 @@ def apply_dmp(
     optimizer_kwargs: Dict[str, Any],
     device: torch.device,
     score_strategy: DynamicEmbScoreStrategy = DynamicEmbScoreStrategy.LFU,
+    dist_type: str = "roundrobin",
     use_index_dedup: bool = False,
     caching: bool = False,
     cache_capacity_ratio: float = 0.5,
@@ -313,6 +314,7 @@ def apply_dmp(
         dynamicemb_options_dict[eb_config.name] = DynamicEmbTableOptions(
             global_hbm_for_values=global_hbm,
             score_strategy=score_strategy,
+            dist_type=dist_type,
             initializer_args=DynamicEmbInitializerArgs(
                 mode=DynamicEmbInitializerMode.CONSTANT,
                 value=1e-1,
@@ -356,6 +358,7 @@ def create_model(
     embedding_dim: int,
     optimizer_kwargs: Dict[str, Any],
     score_strategy: DynamicEmbScoreStrategy = DynamicEmbScoreStrategy.LFU,
+    dist_type: str = "roundrobin",
     use_index_dedup: bool = False,
     caching: bool = False,
     cache_capacity_ratio: float = 0.5,
@@ -393,6 +396,7 @@ def create_model(
         optimizer_kwargs,
         torch.device(f"cuda:{torch.cuda.current_device()}"),
         score_strategy=score_strategy,
+        dist_type=dist_type,
         use_index_dedup=use_index_dedup,
         caching=caching,
         cache_capacity_ratio=cache_capacity_ratio,
@@ -444,6 +448,27 @@ def check_counter_table_checkpoint(x, y):
                     frequencies, score_out
                 ), f"counter frequency mismatch for table_id={table_id}"
 
+def assert_dist_type_path(model: nn.Module, expected_dist_type: str) -> None:
+    seen_sharding = False
+    seen_input_dist = False
+
+    for _, _, sharded_module in find_sharded_modules(model):
+        for sharding in sharded_module._sharding_type_to_sharding.values():
+            if hasattr(sharding, "_dist_type_per_feature"):
+                assert set(sharding._dist_type_per_feature.values()) == {
+                    expected_dist_type
+                }
+                seen_sharding = True
+
+        for input_dist in getattr(sharded_module, "_input_dists", []):
+            if hasattr(input_dist, "_dist_type_per_feature"):
+                assert set(input_dist._dist_type_per_feature.values()) == {
+                    expected_dist_type
+                }
+                seen_input_dist = True
+
+    assert seen_sharding, "Did not find any DynamicEmb sharding carrying dist_type."
+    assert seen_input_dist, "Did not find any input_dist carrying dist_type."
 
 @click.command()
 @click.option("--num-embedding-collections", type=int, required=True)
@@ -462,6 +487,12 @@ def check_counter_table_checkpoint(x, y):
     type=click.Choice(["timestamp", "step", "lfu"]),
     required=True,
 )
+@click.option(
+    "--dist-type",
+    type=click.Choice(["continuous", "roundrobin", "hash_roundrobin"]),
+    default="roundrobin",
+    show_default=True,
+)
 @click.option("--optim", type=bool, required=True)
 @click.option("--counter", type=bool, required=True)
 def test_model_load_dump(
@@ -471,6 +502,7 @@ def test_model_load_dump(
     embedding_dim: int,
     optimizer_type: str,
     score_strategy: str,
+    dist_type: str,
     mode: str,
     save_path: str,
     optim: bool,
@@ -499,6 +531,7 @@ def test_model_load_dump(
         embedding_dim=embedding_dim,
         optimizer_kwargs=optimizer_kwargs,
         score_strategy=score_strategy_,
+        dist_type=dist_type,        
         admit_strategy=FrequencyAdmissionStrategy(
             threshold=2 if counter else 1,
         ),
@@ -518,9 +551,13 @@ def test_model_load_dump(
         score_strategy=score_strategy,
         scores_collection=expect_scores_collection,
     )
-
+    
+    asserted_ref_dist_type = False
     for kjt in kjts:
         ret = ref_model(kjt)
+        if not asserted_ref_dist_type:
+            assert_dist_type_path(ref_model, dist_type)
+            asserted_ref_dist_type = True
         loss = (
             ret.sum() * dist.get_world_size()
         )  # scale the loss by world size to make the gradients consistent between different gpu settings
@@ -538,6 +575,7 @@ def test_model_load_dump(
             embedding_dim=embedding_dim,
             optimizer_kwargs=optimizer_kwargs,
             score_strategy=score_strategy_,
+            dist_type=dist_type,
             admit_strategy=FrequencyAdmissionStrategy(
                 threshold=2 if counter else 1,
             ),
@@ -641,8 +679,12 @@ def test_model_load_dump(
         model = model.eval()
 
         with torch.inference_mode():
+            asserted_loaded_dist_type = False
             for kjt in kjts:
                 ret = model(kjt)
+                if not asserted_loaded_dist_type:
+                    assert_dist_type_path(model, dist_type)
+                    asserted_loaded_dist_type = True
                 ref_ret = ref_model(kjt)
                 assert torch.allclose(ret, ref_ret)
 

--- a/corelib/dynamicemb/test/unit_tests/test_embedding_dump_load.sh
+++ b/corelib/dynamicemb/test/unit_tests/test_embedding_dump_load.sh
@@ -36,6 +36,39 @@ for num_gpus in ${NUM_GPUS[@]}; do
   done
 done
 
+echo "Running hash_roundrobin opt-in smoke"
+torchrun \
+  --nnodes 1 \
+  --nproc_per_node 1 \
+  ./test/unit_tests/test_embedding_dump_load.py \
+  --optimizer-type sgd \
+  --score-strategy step \
+  --dist-type hash_roundrobin \
+  --mode "dump" \
+  --optim False \
+  --counter False \
+  --save-path "debug_weight_hash_roundrobin_smoke" \
+  --num-embedding-collections 1 \
+  --num-embeddings 1000000 \
+  --multi-hot-sizes 10 \
+  --embedding-dim 16 || exit 1
+
+torchrun \
+  --nnodes 1 \
+  --nproc_per_node 1 \
+  ./test/unit_tests/test_embedding_dump_load.py \
+  --optimizer-type sgd \
+  --score-strategy step \
+  --dist-type hash_roundrobin \
+  --mode "load" \
+  --optim False \
+  --counter False \
+  --save-path "debug_weight_hash_roundrobin_smoke" \
+  --num-embedding-collections 1 \
+  --num-embeddings 1000000 \
+  --multi-hot-sizes 10 \
+  --embedding-dim 16 || exit 1
+
 for num_load_gpus in ${NUM_GPUS[@]}; do
   for num_dump_gpus in ${NUM_GPUS[@]}; do
     for optimizer_type in ${OPTIMIZER_TYPE[@]}; do  

--- a/corelib/dynamicemb/test/unit_tests/test_hash_roundrobin_kuairand.py
+++ b/corelib/dynamicemb/test/unit_tests/test_hash_roundrobin_kuairand.py
@@ -1,0 +1,390 @@
+import csv
+import os
+from collections import Counter
+
+import numpy as np
+import pytest
+import torch
+
+
+HASH_SIZE = 10_000_000
+KUAIRAND_1K_FEATURES = {
+    "video_id": 49332,
+    "user_id": 1000,
+}
+
+
+def hash_key_cpu(keys_np: np.ndarray) -> np.ndarray:
+    k = np.asarray(keys_np, dtype=np.uint64)
+    k = k ^ (k >> np.uint64(33))
+    k = k * np.uint64(0xFF51AFD7ED558CCD)
+    k = k ^ (k >> np.uint64(33))
+    k = k * np.uint64(0xC4CEB9FE1A85EC53)
+    k = k ^ (k >> np.uint64(33))
+    return k
+
+
+def assign_owner_cpu(
+    indices: np.ndarray,
+    my_size: int,
+    dist_type: str,
+    blk_size: int,
+) -> np.ndarray:
+    if dist_type == "continuous":
+        return np.where(
+            indices < blk_size * my_size,
+            indices // blk_size,
+            indices % my_size,
+        ).astype(np.int64)
+    if dist_type == "roundrobin":
+        return (indices % my_size).astype(np.int64)
+    if dist_type == "hash_roundrobin":
+        return (hash_key_cpu(indices) % np.uint64(my_size)).astype(np.int64)
+    raise ValueError(f"Unsupported dist_type: {dist_type}")
+
+
+def owner_histogram_cpu(
+    indices: np.ndarray,
+    my_size: int,
+    dist_type: str,
+    blk_size: int,
+) -> np.ndarray:
+    owners = assign_owner_cpu(indices, my_size, dist_type, blk_size)
+    return np.bincount(owners, minlength=my_size)
+
+
+def imbalance_ratio(hist: np.ndarray) -> float:
+    expected = hist.sum() / len(hist)
+    return float((hist.max() - hist.min()) / expected)
+
+
+def max_min_ratio(hist: np.ndarray) -> float:
+    return float(hist.max() / max(hist.min(), 1))
+
+
+def try_load_kuairand_indices():
+    possible_paths = [
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "examples",
+            "hstu",
+            "training",
+            "data",
+            "KuaiRand-1K",
+            "data",
+        ),
+        os.path.join(
+            os.environ.get("KUAIRAND_DATA_PATH", ""),
+            "KuaiRand-1K",
+            "data",
+        ),
+    ]
+
+    for base_path in possible_paths:
+        log_files = [
+            os.path.join(base_path, "log_standard_4_08_to_4_21_1k.csv"),
+            os.path.join(base_path, "log_standard_4_22_to_5_08_1k.csv"),
+        ]
+        if all(os.path.exists(f) for f in log_files):
+            all_video_ids = []
+            all_user_ids = []
+            for log_file in log_files:
+                with open(log_file, "r") as f:
+                    reader = csv.DictReader(f)
+                    for row in reader:
+                        all_user_ids.append(int(row["user_id"]))
+                        all_video_ids.append(int(row["video_id"]))
+            return {
+                "user_id": np.array(all_user_ids, dtype=np.int64),
+                "video_id": np.array(all_video_ids, dtype=np.int64),
+            }
+    return None
+
+
+def generate_zipf_logical_indices(
+    feature_name: str,
+    num_interactions: int = 4_369_953,
+) -> np.ndarray:
+    np.random.seed(42)
+    num_unique = KUAIRAND_1K_FEATURES[feature_name]
+    exponent = 1.5 if feature_name == "user_id" else 1.8
+
+    ranks = np.arange(1, num_unique + 1)
+    probs = 1.0 / (ranks**exponent)
+    probs /= probs.sum()
+    return np.random.choice(ranks, size=num_interactions, replace=True, p=probs).astype(
+        np.int64
+    )
+
+
+def make_adversarial_modulo_aliasing_keys(
+    logical_ids: np.ndarray,
+    my_size: int,
+    residue: int = 0,
+) -> np.ndarray:
+    logical_ids = np.asarray(logical_ids, dtype=np.int64)
+    if my_size <= 0:
+        raise ValueError(f"my_size must be positive, got {my_size}")
+    if residue < 0:
+        raise ValueError(f"residue must be non-negative, got {residue}")
+
+    max_int64 = np.iinfo(np.int64).max
+    max_logical_id = (max_int64 - residue) // my_size
+    if logical_ids.size > 0 and logical_ids.max() > max_logical_id:
+        raise OverflowError(
+            f"adversarial remap would overflow int64: max logical id "
+            f"{logical_ids.max()} > {max_logical_id}"
+        )
+
+    return logical_ids * my_size + residue
+
+
+def remap_frequency_histogram_to_adversarial_keys(
+    logical_indices: np.ndarray,
+    my_size: int,
+    residue: int = 0,
+) -> np.ndarray:
+    return make_adversarial_modulo_aliasing_keys(logical_indices, my_size, residue)
+
+
+def print_distribution_summary(title: str, hist: np.ndarray) -> None:
+    print(title)
+    print(f"  Distribution: {hist.tolist()}")
+    print(f"  Imbalance: {imbalance_ratio(hist):.2%}")
+    print(f"  Max/Min: {max_min_ratio(hist):.2f}x")
+
+
+@pytest.mark.parametrize("my_size", [4, 8])
+def test_hash_roundrobin_breaks_modulo_aliasing_cpu(my_size):
+    logical_ids = np.arange(50_000, dtype=np.int64)
+    indices = make_adversarial_modulo_aliasing_keys(logical_ids, my_size, residue=0)
+    blk_size = HASH_SIZE // my_size
+
+    rr_hist = owner_histogram_cpu(indices, my_size, "roundrobin", blk_size)
+    hr_hist = owner_histogram_cpu(indices, my_size, "hash_roundrobin", blk_size)
+
+    print_distribution_summary(f"\nroundrobin aliasing (my_size={my_size})", rr_hist)
+    print_distribution_summary(
+        f"\nhash_roundrobin aliasing (my_size={my_size})", hr_hist
+    )
+
+    assert rr_hist.max() == len(indices)
+    assert rr_hist.min() == 0
+    assert imbalance_ratio(hr_hist) < 0.30
+    assert max_min_ratio(hr_hist) < 1.50
+
+
+@pytest.mark.parametrize("feature_name", ["user_id", "video_id"])
+@pytest.mark.parametrize("my_size", [4, 8])
+def test_hash_roundrobin_is_pattern_robust_under_same_logical_load(
+    feature_name,
+    my_size,
+):
+    logical_indices = generate_zipf_logical_indices(feature_name)
+    blk_size = HASH_SIZE // my_size
+
+    natural_indices = logical_indices.copy()
+    adversarial_indices = remap_frequency_histogram_to_adversarial_keys(
+        logical_indices,
+        my_size,
+        residue=0,
+    )
+
+    natural_rr = owner_histogram_cpu(natural_indices, my_size, "roundrobin", blk_size)
+    adversarial_rr = owner_histogram_cpu(
+        adversarial_indices,
+        my_size,
+        "roundrobin",
+        blk_size,
+    )
+    natural_hr = owner_histogram_cpu(
+        natural_indices,
+        my_size,
+        "hash_roundrobin",
+        blk_size,
+    )
+    adversarial_hr = owner_histogram_cpu(
+        adversarial_indices,
+        my_size,
+        "hash_roundrobin",
+        blk_size,
+    )
+
+    print_distribution_summary(
+        f"\n{feature_name} natural roundrobin (my_size={my_size})",
+        natural_rr,
+    )
+    print_distribution_summary(
+        f"\n{feature_name} adversarial roundrobin (my_size={my_size})",
+        adversarial_rr,
+    )
+    print_distribution_summary(
+        f"\n{feature_name} natural hash_roundrobin (my_size={my_size})",
+        natural_hr,
+    )
+    print_distribution_summary(
+        f"\n{feature_name} adversarial hash_roundrobin (my_size={my_size})",
+        adversarial_hr,
+    )
+
+    rr_natural_imb = imbalance_ratio(natural_rr)
+    rr_adversarial_imb = imbalance_ratio(adversarial_rr)
+    hr_natural_imb = imbalance_ratio(natural_hr)
+    hr_adversarial_imb = imbalance_ratio(adversarial_hr)
+
+    rr_imb_increase = rr_adversarial_imb - rr_natural_imb
+    hr_imb_increase = hr_adversarial_imb - hr_natural_imb
+
+    assert rr_adversarial_imb > rr_natural_imb + 0.50
+    assert hr_adversarial_imb < rr_adversarial_imb
+    assert hr_imb_increase < rr_imb_increase
+
+
+@pytest.mark.parametrize("feature_name", ["user_id", "video_id"])
+def test_key_frequency_skew(feature_name):
+    real_data = try_load_kuairand_indices()
+    if real_data is None:
+        indices = generate_zipf_logical_indices(feature_name)
+    else:
+        indices = real_data[feature_name]
+
+    freq = Counter(indices.tolist())
+    counts = np.array(sorted(freq.values(), reverse=True))
+
+    total = counts.sum()
+    top1_pct = counts[0] / total * 100
+    top10_pct = counts[:10].sum() / total * 100
+    top100_pct = counts[:100].sum() / total * 100
+    gini = 1 - 2 * np.trapz(
+        np.cumsum(sorted(counts)) / total,
+        np.linspace(0, 1, len(counts)),
+    )
+
+    print(f"\n=== Key Frequency Skew: {feature_name} ===")
+    print(f"Unique keys: {len(counts)}")
+    print(f"Top-1 key:   {top1_pct:.2f}% of all interactions")
+    print(f"Top-10 keys: {top10_pct:.2f}% of all interactions")
+    print(f"Top-100 keys:{top100_pct:.2f}% of all interactions")
+    print(f"Gini coefficient: {gini:.4f}")
+
+    assert gini > 0.3
+
+
+@pytest.mark.parametrize("feature_name", ["user_id", "video_id"])
+@pytest.mark.parametrize("my_size", [4, 8])
+def test_real_or_zipf_histogram_with_adversarial_remap(feature_name, my_size):
+    real_data = try_load_kuairand_indices()
+    if real_data is None:
+        logical_indices = generate_zipf_logical_indices(feature_name)
+    else:
+        logical_indices = real_data[feature_name]
+
+    adversarial_indices = remap_frequency_histogram_to_adversarial_keys(
+        logical_indices,
+        my_size,
+        residue=0,
+    )
+    blk_size = HASH_SIZE // my_size
+
+    rr_hist = owner_histogram_cpu(
+        adversarial_indices,
+        my_size,
+        "roundrobin",
+        blk_size,
+    )
+    hr_hist = owner_histogram_cpu(
+        adversarial_indices,
+        my_size,
+        "hash_roundrobin",
+        blk_size,
+    )
+
+    print_distribution_summary(
+        f"\n{feature_name} adversarial-remap roundrobin (my_size={my_size})",
+        rr_hist,
+    )
+    print_distribution_summary(
+        f"\n{feature_name} adversarial-remap hash_roundrobin (my_size={my_size})",
+        hr_hist,
+    )
+
+    assert imbalance_ratio(hr_hist) < imbalance_ratio(rr_hist)
+    assert max_min_ratio(hr_hist) < max_min_ratio(rr_hist)
+
+
+@pytest.mark.parametrize("feature_name", ["user_id", "video_id"])
+@pytest.mark.parametrize("my_size", [4, 8])
+def test_bucketize_kernel_matches_cpu_reference(feature_name, my_size):
+    try:
+        from dynamicemb_extensions import block_bucketize_sparse_features
+    except ImportError:
+        pytest.skip("dynamicemb_extensions not available")
+
+    logical_indices = generate_zipf_logical_indices(feature_name, num_interactions=200_000)
+    adversarial_indices = remap_frequency_histogram_to_adversarial_keys(
+        logical_indices,
+        my_size,
+        residue=0,
+    )
+
+    batch_size = min(50_000, len(adversarial_indices))
+    sample_idx = np.random.choice(
+        len(adversarial_indices),
+        size=batch_size,
+        replace=False,
+    )
+    batch_indices = adversarial_indices[sample_idx].astype(np.int64)
+
+    indices = torch.tensor(batch_indices, dtype=torch.int64, device="cuda")
+    lengths = torch.tensor([batch_size], dtype=torch.int64, device="cuda")
+    block_sizes = torch.tensor(
+        [HASH_SIZE // my_size],
+        dtype=torch.int64,
+        device="cuda",
+    )
+
+    for dist_type_val, dist_type_name in [
+        (1, "roundrobin"),
+        (2, "hash_roundrobin"),
+    ]:
+        dist_type_per_feature = torch.tensor(
+            [dist_type_val],
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+        result = block_bucketize_sparse_features(
+            lengths,
+            indices,
+            bucketize_pos=False,
+            sequence=False,
+            dist_type_per_feature=dist_type_per_feature,
+            block_sizes=block_sizes,
+            my_size=my_size,
+            max_B=1,
+        )
+
+        new_lengths = result[0].cpu().numpy()
+        new_indices = result[1]
+        rank_counts = new_lengths[:my_size]
+        total_output = rank_counts.sum()
+
+        cpu_hist = owner_histogram_cpu(
+            batch_indices,
+            my_size,
+            dist_type_name,
+            HASH_SIZE // my_size,
+        )
+
+        print(f"\n{dist_type_name} kernel (my_size={my_size}, {feature_name}):")
+        print(f"  CUDA per-rank counts: {rank_counts.tolist()}")
+        print(f"  CPU  per-rank counts: {cpu_hist.tolist()}")
+
+        assert total_output == batch_size
+        assert torch.all(new_indices >= 0).item()
+        assert rank_counts.tolist() == cpu_hist.tolist()
+


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

## Summary

This PR adds `hash_roundrobin` as a new DynamicEmb RW routing mode and makes it the default for DynamicEmb row-wise planning.

The goal is narrow: fix load imbalance caused by pathological raw-key patterns that can break plain modulo-based `roundrobin`. The new mode hashes the raw key first, then assigns the owner rank from the hashed key.

This PR does **not** claim to solve general hot-key or Zipf-skew load balancing.

## Changes

- add `hash_roundrobin` support in the DynamicEmb input-distribution path
- map `hash_roundrobin` to `dist_type = 2` for the CUDA extension path
- “adds hash_roundrobin as an opt-in RW routing mode”, default remains roundrobin
- add a regression test file covering:
  - CPU reference owner mapping
  - adversarial modulo-aliasing patterns
  - same logical workload with different raw-key encodings
  - CUDA kernel parity against CPU reference
  - comparative real/Zipf-style robustness checks
- add the new regression test to the regular `test/unit_test.sh` flow
- document supported `dist_type` values and clarify the intended scope of `hash_roundrobin`

## Why

Issue #350 points out that plain `roundrobin` can become imbalanced when raw keys follow special patterns. Hashing the raw key before RW rank assignment makes the routing much less sensitive to those patterns while preserving the existing overall bucketization flow.

## Validation

Validated on a clean rebuild in the target Ubuntu Docker environment.

- `python3 -m pytest -svv test/unit_tests/test_hash_roundrobin_kuairand.py`
  - `16 passed`
- `CUDA_VISIBLE_DEVICES=0,1 torchrun --nnodes 1 --nproc_per_node 2 ./test/unit_tests/test_sequence_embedding_fw.py --print_sharding_plan --optimizer_type "adam" --use_index_dedup True`
  - passed on `NVIDIA RTX A6000`

## Notes

- The new benchmark is intentionally framed around **pattern robustness**, which is what issue #350 asks for.
- Real/Zipf-style checks are kept as **comparative robustness** validation, not as a claim of universal fairness.

