### PR TITLE
[dynamicemb] Fix Torch 2.11 DataLoader worker initialization in MovieLens example

### DIFF
--- a/corelib/dynamicemb/example/example.py
+++ b/corelib/dynamicemb/example/example.py
@@ -84,7 +84,7 @@ def init_runtime() -> RuntimeContext:
     if "WORLD_SIZE" not in os.environ:
         os.environ["WORLD_SIZE"] = "1"
     if "LOCAL_RANK" not in os.environ:
-        os.environ["LOCAL_RANK"] = os.environ.get("RANK", "0")
+        os.environ["LOCAL_RANK"] = "0"
 
     dist.init_process_group(backend=BACKEND)
 
@@ -194,7 +194,7 @@ def parse_args():
     parser.add_argument(
         "--num_workers",
         type=int,
-        default=4,
+        default= 0,
         help="DataLoader worker count. Use spawn-based workers when > 0.",
     )
     return parser.parse_args()

--- a/corelib/dynamicemb/example/example.py
+++ b/corelib/dynamicemb/example/example.py
@@ -5,7 +5,8 @@ import shutil
 import urllib.request
 import warnings
 import zipfile
-from typing import List
+from dataclasses import dataclass
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -37,7 +38,7 @@ from torch.optim import Adam
 from torch.utils.data import DataLoader, Dataset
 from torch.utils.data.distributed import DistributedSampler
 from torchrec import DataType
-from torchrec.distributed.comm import get_local_rank, get_local_size
+from torchrec.distributed.comm import get_local_size
 from torchrec.distributed.fbgemm_qcomm_codec import (
     CommType,
     QCommsConfig,
@@ -59,39 +60,61 @@ warnings.filterwarnings(
     "ignore", message=".*torch.library.impl_abstract.*", category=FutureWarning
 )
 
-backend = "nccl"
-dist.init_process_group(backend=backend)
-
-# Set LOCAL_WORLD_SIZE if not available for proper topology configuration
-if "LOCAL_WORLD_SIZE" not in os.environ:
-    os.environ["LOCAL_WORLD_SIZE"] = str(torch.cuda.device_count())
-
-# Set LOCAL_RANK if not available (for consistency)
-if "LOCAL_RANK" not in os.environ:
-    os.environ["LOCAL_RANK"] = str(get_local_rank())
-
-# Set RANK if not available
-if "RANK" not in os.environ:
-    os.environ["RANK"] = str(dist.get_rank())
-
-local_rank = dist.get_rank()  # for one node
-world_size = dist.get_world_size()
-torch.cuda.set_device(local_rank)
-device = torch.device(f"cuda:{local_rank}")
-# print with rank info
+BACKEND = "nccl"
 original_print = builtins.print
+CACHE_RATIO = 0.5  # assume we will use 50% of the HBM for cache
 
 
-def rank_print(*args, **kwargs):
-    original_print(f"[RANK {local_rank}] ", *args, **kwargs)
+@dataclass
+class RuntimeContext:
+    backend: str
+    rank: int
+    local_rank: int
+    world_size: int
+    device: torch.device
+
+def init_runtime() -> RuntimeContext:
+    # Set LOCAL_WORLD_SIZE if not available for proper topology configuration.
+    if "LOCAL_WORLD_SIZE" not in os.environ:
+        os.environ["LOCAL_WORLD_SIZE"] = str(torch.cuda.device_count())
+
+    # Keep the example usable in non-torchrun single-process runs as well.
+    if "RANK" not in os.environ:
+        os.environ["RANK"] = "0"
+    if "WORLD_SIZE" not in os.environ:
+        os.environ["WORLD_SIZE"] = "1"
+    if "LOCAL_RANK" not in os.environ:
+        os.environ["LOCAL_RANK"] = os.environ.get("RANK", "0")
+
+    dist.init_process_group(backend=BACKEND)
+
+    rank = dist.get_rank()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = dist.get_world_size()
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    def rank_print(*args, **kwargs):
+        original_print(f"[RANK {rank}] ", *args, **kwargs)
+
+    builtins.print = rank_print
+    return RuntimeContext(
+        backend=BACKEND,
+        rank=rank,
+        local_rank=local_rank,
+        world_size=world_size,
+        device=device,
+    )
 
 
-builtins.print = rank_print
-cache_ratio = 0.5  # assume we will use 50% of the HBM for cache
+def cleanup_runtime(runtime: Optional[RuntimeContext]) -> None:
+    builtins.print = original_print
+    if runtime is not None and dist.is_available() and dist.is_initialized():
+        dist.destroy_process_group()
 
 
-def download_movielens(data_dir="./ml-1m"):
-    if dist.get_rank() == 0:  # Use global rank for multi-node consistency
+def download_movielens(runtime: RuntimeContext, data_dir="./ml-1m"):
+    if runtime.rank == 0:  # Use global rank for multi-node consistency
         os.makedirs(data_dir, exist_ok=True)
         if os.path.exists(os.path.join(data_dir, "ratings.dat")):
             print(f"MovieLens in {data_dir}")
@@ -167,6 +190,12 @@ def parse_args():
         type=int,
         default=0,
         help="Frequency threshold for admission strategy (0 disable admission strategy, >0 enable admission strategy and only keys appearing >= threshold will be stored in tables)",
+    )
+    parser.add_argument(
+        "--num_workers",
+        type=int,
+        default=4,
+        help="DataLoader worker count. Use spawn-based workers when > 0.",
     )
     return parser.parse_args()
 
@@ -315,6 +344,19 @@ def collate_fn(batch):
 
     return kjt, torch.tensor(labels, dtype=torch.float)
 
+def build_dataloader(dataset, sampler, args):
+    loader_kwargs = {
+        "batch_size": args.batch_size,
+        "shuffle": False,
+        "collate_fn": collate_fn,
+        "num_workers": args.num_workers,
+        "sampler": sampler,
+        "pin_memory": torch.cuda.is_available(),
+    }
+    if args.num_workers > 0:
+        loader_kwargs["multiprocessing_context"] = "spawn"
+        loader_kwargs["persistent_workers"] = True
+    return DataLoader(dataset, **loader_kwargs)
 
 class MovieLensModel(nn.Module):
     def __init__(
@@ -415,7 +457,7 @@ def get_sharder(args, optimizer_type):
                 backward_precision=CommType.FP32,
             )
         )
-        if backend == "nccl"
+        if BACKEND == "nccl"
         else None
     )
 
@@ -465,7 +507,7 @@ def get_planner(
             bucket_capacity,
         )
         if caching:
-            global_hbm_for_values = int(value_bytes * cache_ratio)
+            global_hbm_for_values = int(value_bytes * CACHE_RATIO)
         else:
             global_hbm_for_values = int(value_bytes)
 
@@ -544,7 +586,7 @@ def get_planner(
     )
 
 
-def apply_dmp(model, args, training):
+def apply_dmp(model, args, runtime: RuntimeContext, training):
     """
     The initialization of embedding lookup module in dynamicemb is almost consistent with torchrec.
         1. Firstly, you should configure the global parameters of an embedding table using `EmbeddingCollection`.
@@ -576,7 +618,7 @@ def apply_dmp(model, args, training):
     The following steps demonstrate how to obtain `DynamicEmbParameterSharding` by `DynamicEmbeddingShardingPlanner`.
     """
     planner = get_planner(
-        device,
+        runtime.device,
         eb_configs,
         args.batch_size,
         optimizer_type=optimizer_type,
@@ -597,7 +639,7 @@ def apply_dmp(model, args, training):
     """
     dmp = DistributedModelParallel(
         module=model,
-        device=device,
+        device=runtime.device,
         # pyre-ignore
         sharders=[sharder],
         plan=plan,
@@ -605,7 +647,7 @@ def apply_dmp(model, args, training):
     return dmp
 
 
-def create_model(args, training=True):
+def create_model(args, runtime: RuntimeContext, training=True):
     # Define the configuration parameters for the embedding table,
     # including its name, embedding dimension, total number of embeddings, and feature name.
     eb_configs = [
@@ -668,18 +710,20 @@ def create_model(args, training=True):
         over_arch_layer_sizes=mlp_dims,
     )
 
-    model = apply_dmp(model, args, training)
+    model = apply_dmp(model, args, runtime, training)
 
     return model
 
 
-def train_one_epoch(model, train_loader, optimizer, loss_fn, epoch, total_epochs):
+def train_one_epoch(
+    model, train_loader, optimizer, loss_fn, epoch, total_epochs, runtime: RuntimeContext
+):
     model.train()
     total_loss = 0
 
     for batch_idx, (features, labels) in enumerate(train_loader):
-        features = features.to(device)
-        labels = labels.to(device)
+        features = features.to(runtime.device)
+        labels = labels.to(runtime.device)
 
         outputs = model(features)
         loss = loss_fn(outputs, labels)
@@ -699,13 +743,13 @@ def train_one_epoch(model, train_loader, optimizer, loss_fn, epoch, total_epochs
     print(f"Epoch {epoch+1}/{total_epochs}, Average Loss: {avg_loss:.4f}")
 
 
-def test_one_epoch(model, test_loader, loss_fn, epoch, total_epochs):
+def test_one_epoch(model, test_loader, loss_fn, epoch, total_epochs, runtime: RuntimeContext):
     model.eval()
     test_loss = 0
     with torch.inference_mode():
         for features, labels in test_loader:
-            features = features.to(device)
-            labels = labels.to(device)
+            features = features.to(runtime.device)
+            labels = labels.to(runtime.device)
 
             outputs = model(features)
             loss = loss_fn(outputs, labels)
@@ -715,72 +759,54 @@ def test_one_epoch(model, test_loader, loss_fn, epoch, total_epochs):
     print(f"Epoch {epoch+1}/{total_epochs}, Test Loss: {avg_test_loss:.4f}")
 
 
-def train(args):
+def train(args, runtime: RuntimeContext):
     train_dataset = MovieLensDataset(args.data_path, split="train")
     test_dataset = MovieLensDataset(args.data_path, split="test")
     train_sampler = DistributedSampler(
-        train_dataset, num_replicas=world_size, rank=dist.get_rank(), shuffle=True
+        train_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=True
     )
     test_sampler = DistributedSampler(
-        test_dataset, num_replicas=world_size, rank=dist.get_rank(), shuffle=False
+        test_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=False
     )
 
-    train_loader = DataLoader(
-        train_dataset,
-        batch_size=args.batch_size,
-        shuffle=False,
-        collate_fn=collate_fn,
-        num_workers=0,
-        sampler=train_sampler,
-    )
+    train_loader = build_dataloader(train_dataset, train_sampler, args)
+    test_loader = build_dataloader(test_dataset, test_sampler, args)
 
-    test_loader = DataLoader(
-        test_dataset,
-        batch_size=args.batch_size,
-        shuffle=False,
-        collate_fn=collate_fn,
-        num_workers=0,
-        sampler=test_sampler,
-    )
-
-    model = create_model(args)
-    model.to(device)
+    model = create_model(args, runtime)
+    model.to(runtime.device)
 
     optimizer = Adam(model.parameters(), lr=args.lr)
     criterion = nn.MSELoss()
 
     for epoch in range(args.epochs):
         train_sampler.set_epoch(epoch)
-        train_one_epoch(model, train_loader, optimizer, criterion, epoch, args.epochs)
-        test_one_epoch(model, test_loader, criterion, epoch, args.epochs)
+        train_one_epoch(
+            model, train_loader, optimizer, criterion, epoch, args.epochs, runtime
+        )
+        test_one_epoch(model, test_loader, criterion, epoch, args.epochs, runtime)
 
 
-def dump(args):
+def dump(args, runtime: RuntimeContext):
     os.makedirs(args.save_dir, exist_ok=True)
     train_dataset = MovieLensDataset(args.data_path, split="train")
     # Use global rank for proper data distribution across all processes
     train_sampler = DistributedSampler(
-        train_dataset, num_replicas=world_size, rank=dist.get_rank(), shuffle=True
+        train_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=True
     )
 
-    train_loader = DataLoader(
-        train_dataset,
-        batch_size=args.batch_size,
-        shuffle=False,
-        collate_fn=collate_fn,
-        num_workers=0,
-        sampler=train_sampler,
-    )
+    train_loader = build_dataloader(train_dataset, train_sampler, args)
 
-    model = create_model(args)
-    model.to(device)
+    model = create_model(args, runtime)
+    model.to(runtime.device)
 
     optimizer = Adam(model.parameters(), lr=args.lr)
     criterion = nn.MSELoss()
 
     for epoch in range(args.epochs):
         train_sampler.set_epoch(epoch)
-        train_one_epoch(model, train_loader, optimizer, criterion, epoch, args.epochs)
+        train_one_epoch(
+            model, train_loader, optimizer, criterion, epoch, args.epochs, runtime
+        )
 
         # ShardedDyanmicEmbeddingCollection.state_dict() will return a dummy tensor.
         torch.save(
@@ -789,31 +815,24 @@ def dump(args):
                 "optimizer_state_dict": optimizer.state_dict(),
             },
             os.path.join(
-                args.save_dir, f"model_epoch_{epoch+1}_rank{dist.get_rank()}.pt"
+                args.save_dir, f"model_epoch_{epoch+1}_rank{runtime.rank}.pt"
             ),
         )
     DynamicEmbDump(os.path.join(args.save_dir, "dynamicemb"), model, optim=True)
 
 
-def load(args):
+def load(args, runtime: RuntimeContext):
     os.makedirs(args.save_dir, exist_ok=True)
     test_dataset = MovieLensDataset(args.data_path, split="test")
     # Use global rank for proper data distribution across all processes
     test_sampler = DistributedSampler(
-        test_dataset, num_replicas=world_size, rank=dist.get_rank(), shuffle=False
+        test_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=False
     )
 
-    test_loader = DataLoader(
-        test_dataset,
-        batch_size=args.batch_size,
-        shuffle=False,
-        collate_fn=collate_fn,
-        num_workers=0,
-        sampler=test_sampler,
-    )
+    test_loader = build_dataloader(test_dataset, test_sampler, args)
 
-    model = create_model(args)
-    model.to(device)
+    model = create_model(args, runtime)
+    model.to(runtime.device)
 
     optimizer = Adam(model.parameters(), lr=args.lr)
     criterion = nn.MSELoss()
@@ -821,7 +840,7 @@ def load(args):
     # load
     checkpoint = torch.load(
         os.path.join(
-            args.save_dir, f"model_epoch_{args.epochs}_rank{dist.get_rank()}.pt"
+            args.save_dir, f"model_epoch_{args.epochs}_rank{runtime.rank}.pt"
         ),
         weights_only=True,
     )
@@ -831,37 +850,30 @@ def load(args):
 
     DynamicEmbLoad(os.path.join(args.save_dir, "dynamicemb"), model, optim=True)
 
-    test_one_epoch(model, test_loader, criterion, 0, 1)
+    test_one_epoch(model, test_loader, criterion, 0, 1, runtime)
 
-    dist.barrier(device_ids=[local_rank])
+    dist.barrier(device_ids=[runtime.local_rank])
     # Only global rank 0 should clean up, not local rank 0 on each node
-    if dist.get_rank() == 0:
+    if runtime.rank == 0:
         try:
             shutil.rmtree(args.save_dir)
         except Exception as e:
             print(f"Warning: Failed to remove {args.save_dir}: {e}")
-    dist.barrier(device_ids=[local_rank])
+    dist.barrier(device_ids=[runtime.local_rank])
 
 
-def inc_dump(args):
+def inc_dump(args, runtime: RuntimeContext):
     os.makedirs(args.save_dir, exist_ok=True)
     train_dataset = MovieLensDataset(args.data_path, split="train")
     # Use global rank for proper data distribution across all processes
     train_sampler = DistributedSampler(
-        train_dataset, num_replicas=world_size, rank=dist.get_rank(), shuffle=True
+        train_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=True
     )
 
-    train_loader = DataLoader(
-        train_dataset,
-        batch_size=args.batch_size,
-        shuffle=False,
-        collate_fn=collate_fn,
-        num_workers=0,
-        sampler=train_sampler,
-    )
+    train_loader = build_dataloader(train_dataset, train_sampler, args)
 
-    model = create_model(args)
-    model.to(device)
+    model = create_model(args, runtime)
+    model.to(runtime.device)
 
     optimizer = Adam(model.parameters(), lr=args.lr)
     criterion = nn.MSELoss()
@@ -874,8 +886,8 @@ def inc_dump(args):
         total_loss = 0
 
         for batch_idx, (features, labels) in enumerate(train_loader):
-            features = features.to(device)
-            labels = labels.to(device)
+            features = features.to(runtime.device)
+            labels = labels.to(runtime.device)
 
             outputs = model(features)
             loss = criterion(outputs, labels)
@@ -908,22 +920,25 @@ def inc_dump(args):
 
 def main():
     args = parse_args()
-    torch.cuda.manual_seed(args.seed)
-    np.random.seed(args.seed)
-    if dist.get_rank() == 0:  # Use global rank for multi-node consistency
-        download_movielens(args.data_path)
-    dist.barrier(device_ids=[local_rank])
-    if args.train:
-        train(args)
-    if args.dump:
-        dump(args)
-    if args.load:
-        load(args)
-    if args.incremental_dump:
-        inc_dump(args)
+    runtime: Optional[RuntimeContext] = None
+    try:
+        runtime = init_runtime()
+        torch.cuda.manual_seed(args.seed)
+        np.random.seed(args.seed)
+        if runtime.rank == 0:  # Use global rank for multi-node consistency
+            download_movielens(runtime, args.data_path)
+        dist.barrier(device_ids=[runtime.local_rank])
+        if args.train:
+            train(args, runtime)
+        if args.dump:
+            dump(args, runtime)
+        if args.load:
+            load(args, runtime)
+        if args.incremental_dump:
+            inc_dump(args, runtime)
+    finally:
+        cleanup_runtime(runtime)
 
 
 if __name__ == "__main__":
     main()
-
-dist.destroy_process_group()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
## Summary

This PR fixes the `RuntimeError: initialization error` seen on Torch 2.11 when running the DynamicEmb MovieLens example with `DataLoader(num_workers > 0)`.

The root cause was that `corelib/dynamicemb/example/example.py` initialized distributed/CUDA state at module import time. Under multi-worker DataLoader execution, worker processes would inherit or re-import that state, which Torch 2.11 now checks more strictly.

## Changes

- move distributed/CUDA runtime initialization out of module scope and into `main()`
- add explicit runtime context instead of relying on module-level `rank/device/world_size`
- make module import side-effect free
- add `--num_workers` argument to the example
- centralize DataLoader creation in a helper
- use spawn-based DataLoader workers when `num_workers > 0`
- move process-group cleanup into safe runtime shutdown logic

## Why

Before this change, importing `example.py` could trigger:

- `dist.init_process_group(...)`
- `torch.cuda.set_device(...)`
- global rank/device setup
- process-group destruction at module teardown

That is unsafe for DataLoader worker processes and caused the Torch 2.11 failure.

## Validation

Validated on the target Ubuntu Docker environment.

- `python3 -c "import example"`
  - no output, no import-time NCCL/CUDA side effects

- `torchrun --standalone --nproc_per_node=2 example.py --load --dump --num_workers 4`
  - passed, no `initialization error`

- `torchrun --standalone --nproc_per_node=2 example.py --train --num_workers 4`
  - passed

- `torchrun --standalone --nproc_per_node=2 example.py --train --num_workers 0`
  - passed

- `torchrun --standalone --nproc_per_node=2 example.py --train`
  - passed with the default worker configuration

## Notes

This PR is scoped to fixing the DynamicEmb example worker initialization issue on newer Torch. It does not change DynamicEmb core behavior outside the example path.
