### PR TITLE
feat(hstu/kvcache): integrate real FlexKV lifecycle for recsys-example KV cache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,53 +8,21 @@ ARG TRITONSERVER_BUILD
 
 WORKDIR /workspace/deps
 
+# -- Layer 1: system setup, arch symlinks, tritonserver deps ---
 RUN if [ "${TRITONSERVER_BUILD}" = "1" ]; then \
       ln /bin/python3 /bin/python && \
-      apt-get update -y --fix-missing && apt-get install -y cmake && apt-get install -y patchelf; \
-    fi
-
-RUN if [ "${TRITONSERVER_BUILD}" = "1" ]; then \
+      apt-get update -y --fix-missing && apt-get install -y cmake patchelf && \
       pip3 install pandas rich cloudpickle psutil && \
       pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130; \
-    fi
-
-RUN ARCH=$([ "${TARGETPLATFORM}" = "linux/arm64" ] && echo "aarch64" || echo "x86_64") && \
+    fi && \
+    ARCH=$([ "${TARGETPLATFORM}" = "linux/arm64" ] && echo "aarch64" || echo "x86_64") && \
     rm -rf /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1 && \
     if [ ${ARCH} = "aarch64" ]; then \
       ln -s /usr/local/cuda-13/targets/sbsa-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
     else \
       ln -s /usr/local/cuda-13/targets/${ARCH}-linux/lib/stubs/libnvidia-ml.so  /usr/lib/${ARCH}-linux-gnu/libnvidia-ml.so.1; \
-    fi
-
-RUN git clone -b core_v0.12.1 https://github.com/NVIDIA/Megatron-LM.git megatron-lm && \
-    pip install --no-deps -e ./megatron-lm
-
-RUN pip install torchx gin-config torchmetrics==1.0.3 typing-extensions iopath pyvers
-RUN pip install cloudpickle
-RUN pip install triton==3.6.0
-RUN pip install nvidia-cutlass-dsl==4.3.0
-
-RUN pip install --no-cache-dir setuptools-git-versioning scikit-build && \
-  git clone --recursive -b v1.5.0 https://github.com/pytorch/FBGEMM.git fbgemm && \
-  cd fbgemm/fbgemm_gpu && \
-  python setup.py install --build-target=default --build-variant=cuda -DTORCH_CUDA_ARCH_LIST="7.5 8.0 9.0"
-
-RUN pip install --no-deps tensordict orjson && \
-  git clone --recursive -b release/V1.5.0 https://github.com/pytorch/torchrec.git torchrec && \
-  cd torchrec && \
-  pip install --no-deps .
-
-
-# for dev
-RUN apt update -y --fix-missing && \
-    apt install -y gdb && \
-    apt autoremove -y && \
-    apt clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN pip install --no-cache pre-commit
-
-RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+    fi && \
+    if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
       CUDA_TARGET_ARCH=sbsa; \
     elif [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
       CUDA_TARGET_ARCH=x86_64; \
@@ -62,7 +30,28 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
       CUDA_TARGET_ARCH=$(uname -m); \
     fi && \
     ln -sf /usr/local/cuda-13/targets/${CUDA_TARGET_ARCH}-linux/include/cccl/cuda \
-    /usr/local/cuda/include/cuda
+    /usr/local/cuda/include/cuda && \
+    apt update -y --fix-missing && \
+    apt install -y gdb && \
+    apt autoremove -y && apt clean && rm -rf /var/lib/apt/lists/*
+
+# -- Layer 2: pip dependencies + Megatron-LM ---
+RUN git clone -b core_v0.12.1 https://github.com/NVIDIA/Megatron-LM.git megatron-lm && \
+    pip install --no-deps -e ./megatron-lm && \
+    pip install torchx gin-config torchmetrics==1.0.3 typing-extensions iopath pyvers \
+    cloudpickle triton==3.6.0 nvidia-cutlass-dsl==4.3.0 --no-cache pre-commit
+
+# -- Layer 3: FBGEMM (long build, own layer for caching) ---
+RUN pip install --no-cache-dir setuptools-git-versioning scikit-build && \
+    git clone --recursive -b v1.5.0 https://github.com/pytorch/FBGEMM.git fbgemm && \
+    cd fbgemm/fbgemm_gpu && \
+    python setup.py install --build-target=default --build-variant=cuda -DTORCH_CUDA_ARCH_LIST="7.5 8.0 9.0"
+
+# -- Layer 4: TorchRec ---
+RUN pip install --no-deps tensordict orjson && \
+    git clone --recursive -b release/V1.5.0 https://github.com/pytorch/torchrec.git torchrec && \
+    cd torchrec && \
+    pip install --no-deps .
 
 # Install fbgemm_gpu_hstu (package: fbgemm_gpu_hstu, import: hstu) from submodule
 COPY third_party/FBGEMM /workspace/deps/fbgemm_hstu
@@ -84,23 +73,17 @@ WORKDIR /workspace/recsys-examples
 COPY . .
 
 RUN cd /workspace/recsys-examples/corelib/dynamicemb && \
-    python setup.py install
-    
-RUN cd /workspace/deps && rm -rf nvcomp && \
+    python setup.py install && \
+    cd /workspace/deps && rm -rf nvcomp && \
     wget https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-5.1.0.21_cuda12-archive.tar.xz && \
     tar -xf nvcomp-linux-x86_64-5.1.0.21_cuda12-archive.tar.xz && \
     mv nvcomp-linux-x86_64-5.1.0.21_cuda12-archive nvcomp && \
-    rm  nvcomp-linux-x86_64-5.1.0.21_cuda12-archive.tar.xz 
-  
-RUN cd /workspace/recsys-examples/examples/commons && \
-    TORCH_CUDA_ARCH_LIST="7.5 8.0 8.6 9.0" python3 setup.py install
-
-RUN if [ "${TRITONSERVER_BUILD}" != "1" ]; then \
+    rm nvcomp-linux-x86_64-5.1.0.21_cuda12-archive.tar.xz && \
+    cd /workspace/recsys-examples/examples/commons && \
+    TORCH_CUDA_ARCH_LIST="7.5 8.0 8.6 9.0" python3 setup.py install && \
+    if [ "${TRITONSERVER_BUILD}" != "1" ]; then \
       rm -f /usr/lib/$(uname -m)-linux-gnu/libcuda.so.1 && \
-      ln -s /usr/local/cuda-13.1/compat/lib.real/libcuda.so.1  /usr/lib/$(uname -m)-linux-gnu/libcuda.so.1; \
-    fi
-
-RUN if [ "${TRITONSERVER_BUILD}" != "1" ]; then \
+      ln -s /usr/local/cuda-13.1/compat/lib.real/libcuda.so.1  /usr/lib/$(uname -m)-linux-gnu/libcuda.so.1 && \
       cd /workspace/recsys-examples/corelib/dynamicemb && \
       mkdir -p torch_binding_build && cd torch_binding_build && \
       cmake .. && make -j; \

--- a/docker/Dockerfile.flexkv-addon
+++ b/docker/Dockerfile.flexkv-addon
@@ -1,0 +1,22 @@
+ARG BASE_IMAGE=recsys-examples:inference
+FROM ${BASE_IMAGE}
+WORKDIR /workspace/deps
+ARG FLEXKV_REF=main
+ARG FLEXKV_MAX_JOBS=1
+ARG FLEXKV_CMAKE_JOBS=1
+RUN apt-get update -y --fix-missing && \
+    apt-get install -y --no-install-recommends git cmake patchelf liburing-dev libxxhash-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN git clone --recursive https://github.com/taco-project/FlexKV.git /workspace/deps/FlexKV && \
+    cd /workspace/deps/FlexKV && \
+    git checkout ${FLEXKV_REF} && \
+    git submodule update --init --recursive && \
+    mkdir -p build && cd build && cmake .. && cmake --build . -j"${FLEXKV_CMAKE_JOBS}" && \
+    cd .. && mkdir -p flexkv/lib && cp -P build/lib/*.so* flexkv/lib/ && \
+    if ! MAX_JOBS=${FLEXKV_MAX_JOBS} FLEXKV_DEBUG=1 python3 setup.py install -v > /tmp/flexkv_setup.log 2>&1; then \
+      echo "FlexKV build failed:" && \
+      python3 -c "import pathlib,re; p=re.compile(r'(fatal error:|error:|ninja: build stopped|killed|undefined reference)', re.I); t=pathlib.Path('/tmp/flexkv_setup.log').read_text(errors='ignore').splitlines(); h=[f'{i+1}: {x}' for i,x in enumerate(t) if p.search(x)]; print('\n'.join(h[:160])); print(f'Total matched error lines: {len(h)}')" && \
+      exit 1; \
+    fi && \
+    cd /tmp && python3 -c "from flexkv.kvmanager import KVManager; print('flexkv import ok')" && \
+    rm -rf /workspace/deps/FlexKV

--- a/examples/hstu/configs/inference_config.py
+++ b/examples/hstu/configs/inference_config.py
@@ -116,6 +116,16 @@ class KVCacheConfig:
     num_offload_buffer_chunks: int = 8
     num_memcpy_workers: int = 4
     enable_nvcomp: bool = False
+    secondary_backend: str = "nop"
+    namespace_mode: str = "uid"
+    namespace_base: str = "recsys_hstu"
+
+    flexkv_mode: str = "direct"
+    secondary_wait_timeout_ms: int = 0
+    secondary_fail_policy: str = "fail_open"
+    offload_mode: str = "lazy"
+    flexkv_server_addr: str = ""
+    flexkv_server_port: int = 0
 
 
 def get_kvcache_config(
@@ -123,6 +133,15 @@ def get_kvcache_config(
     page_size: int,
     offload_chunksize: int,
     max_attention_window: Optional[int] = None,
+    secondary_backend: str = "nop",
+    namespace_mode: str = "uid",
+    namespace_base: str = "recsys_hstu",
+    flexkv_mode: str = "direct",
+    secondary_wait_timeout_ms: int = 0,
+    secondary_fail_policy: str = "fail_open",
+    offload_mode: str = "lazy",
+    flexkv_server_addr: str = "",
+    flexkv_server_port: int = 0,
 ) -> KVCacheConfig:
     """
     Create the HSTU KV cache configuration.
@@ -142,6 +161,15 @@ def get_kvcache_config(
         page_size=page_size,
         offload_chunksize=offload_chunksize,
         max_attention_window=max_attention_window,
+        secondary_backend=secondary_backend,
+        namespace_mode=namespace_mode,
+        namespace_base=namespace_base,
+        flexkv_mode=flexkv_mode,
+        secondary_wait_timeout_ms=secondary_wait_timeout_ms,
+        secondary_fail_policy=secondary_fail_policy,
+        offload_mode=offload_mode,
+        flexkv_server_addr=flexkv_server_addr,
+        flexkv_server_port=flexkv_server_port,
     )
 
 

--- a/examples/hstu/configs/inference_config.py
+++ b/examples/hstu/configs/inference_config.py
@@ -117,8 +117,6 @@ class KVCacheConfig:
     num_memcpy_workers: int = 4
     enable_nvcomp: bool = False
     secondary_backend: str = "nop"
-    namespace_mode: str = "uid"
-    namespace_base: str = "recsys_hstu"
 
     flexkv_mode: str = "direct"
     secondary_wait_timeout_ms: int = 0
@@ -134,8 +132,6 @@ def get_kvcache_config(
     offload_chunksize: int,
     max_attention_window: Optional[int] = None,
     secondary_backend: str = "nop",
-    namespace_mode: str = "uid",
-    namespace_base: str = "recsys_hstu",
     flexkv_mode: str = "direct",
     secondary_wait_timeout_ms: int = 0,
     secondary_fail_policy: str = "fail_open",
@@ -162,8 +158,6 @@ def get_kvcache_config(
         offload_chunksize=offload_chunksize,
         max_attention_window=max_attention_window,
         secondary_backend=secondary_backend,
-        namespace_mode=namespace_mode,
-        namespace_base=namespace_base,
         flexkv_mode=flexkv_mode,
         secondary_wait_timeout_ms=secondary_wait_timeout_ms,
         secondary_fail_policy=secondary_fail_policy,

--- a/examples/hstu/model/inference_ranking_gr.py
+++ b/examples/hstu/model/inference_ranking_gr.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from typing import Dict, List, Tuple
 
 import torch
 from commons.datasets.hstu_batch import HSTUBatch
@@ -80,6 +81,128 @@ class InferenceRankingGR(torch.nn.Module):
         self.sparse_module.load_checkpoint(checkpoint_dir, model_state_dict)
         self.dense_module.load_state_dict(model_state_dict, strict=False)
 
+    def _build_lookup_tokens_from_batch(
+        self,
+        batch: HSTUBatch,
+        total_history_lengths: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Build per-user history token_ids/token_mask for FlexKV get_match.
+        Token order is aligned with HSTU inference preprocessor:
+        [contextual..., interleaved(item, action) history...], excluding candidates.
+        """
+        batch_size = int(batch.batch_size)
+        history_lengths_cpu = total_history_lengths.detach().cpu().to(torch.int64)
+        max_history_len = int(history_lengths_cpu.max().item()) if batch_size > 0 else 0
+        token_ids = torch.zeros((batch_size, max_history_len), dtype=torch.int64)
+        token_mask = torch.zeros((batch_size, max_history_len), dtype=torch.bool)
+
+        feature_order: List[str] = list(batch.contextual_feature_names)
+        feature_order.append(batch.item_feature_name)
+        if batch.action_feature_name is not None:
+            feature_order.append(batch.action_feature_name)
+        feature_tag = {name: idx + 1 for idx, name in enumerate(feature_order)}
+        tag_shift = 48
+        tag_mask = (1 << tag_shift) - 1
+
+        def _encode_feature_tokens(values: torch.Tensor, feat_name: str) -> torch.Tensor:
+            if values.numel() == 0:
+                return values.to(torch.int64)
+            tag = int(feature_tag.get(feat_name, 0))
+            encoded = values.to(torch.int64) & tag_mask
+            if tag > 0:
+                encoded = encoded | (tag << tag_shift)
+            return encoded
+
+        # Contextual features (if any)
+        contextual_cpu: Dict[str, Tuple[torch.Tensor, torch.Tensor]] = {}
+        for feat_name in batch.contextual_feature_names:
+            feat_jt = batch.features[feat_name]
+            contextual_cpu[feat_name] = (
+                feat_jt.values().detach().cpu(),
+                feat_jt.offsets().detach().cpu().to(torch.int64),
+            )
+
+        item_jt = batch.features[batch.item_feature_name]
+        item_values = item_jt.values().detach().cpu()
+        item_offsets = item_jt.offsets().detach().cpu().to(torch.int64)
+
+        action_values = None
+        action_offsets = None
+        if batch.action_feature_name is not None:
+            action_jt = batch.features[batch.action_feature_name]
+            action_values = action_jt.values().detach().cpu()
+            action_offsets = action_jt.offsets().detach().cpu().to(torch.int64)
+
+        if batch.num_candidates is None:
+            num_candidates = torch.zeros((batch_size,), dtype=torch.int64)
+        else:
+            num_candidates = batch.num_candidates.detach().cpu().to(torch.int64)
+            if num_candidates.numel() < batch_size:
+                num_candidates = torch.nn.functional.pad(
+                    num_candidates, (0, batch_size - num_candidates.numel())
+                )
+
+        for idx in range(batch_size):
+            target_len = int(history_lengths_cpu[idx].item())
+            if target_len <= 0:
+                continue
+
+            seq_chunks: List[torch.Tensor] = []
+
+            for feat_name in batch.contextual_feature_names:
+                feat_values, feat_offsets = contextual_cpu[feat_name]
+                left = int(feat_offsets[idx].item())
+                right = int(feat_offsets[idx + 1].item())
+                seq_chunks.append(
+                    _encode_feature_tokens(feat_values[left:right], feat_name)
+                )
+
+            item_l = int(item_offsets[idx].item())
+            item_r = int(item_offsets[idx + 1].item())
+            item_seq = item_values[item_l:item_r]
+            cand_cnt = int(num_candidates[idx].item())
+            cand_cnt = max(0, min(cand_cnt, item_seq.numel()))
+            item_hist = item_seq[: item_seq.numel() - cand_cnt]
+            item_hist = _encode_feature_tokens(item_hist, batch.item_feature_name)
+
+            if (
+                batch.action_feature_name is not None
+                and action_values is not None
+                and action_offsets is not None
+            ):
+                action_l = int(action_offsets[idx].item())
+                action_r = int(action_offsets[idx + 1].item())
+                action_seq = _encode_feature_tokens(
+                    action_values[action_l:action_r], batch.action_feature_name
+                )
+                interleave_len = min(item_hist.numel(), action_seq.numel())
+                if interleave_len > 0:
+                    interleaved = torch.empty(
+                        (interleave_len * 2,), dtype=torch.int64
+                    )
+                    interleaved[0::2] = item_hist[:interleave_len]
+                    interleaved[1::2] = action_seq[:interleave_len]
+                    seq_chunks.append(interleaved)
+                if item_hist.numel() > interleave_len:
+                    seq_chunks.append(item_hist[interleave_len:])
+                if action_seq.numel() > interleave_len:
+                    seq_chunks.append(action_seq[interleave_len:])
+            else:
+                seq_chunks.append(item_hist)
+
+            if len(seq_chunks) == 0:
+                continue
+            seq_tokens = torch.cat(seq_chunks, dim=0)
+            if seq_tokens.numel() == 0:
+                continue
+            clipped = seq_tokens[:target_len]
+            valid_len = clipped.numel()
+            token_ids[idx, :valid_len] = clipped
+            token_mask[idx, :valid_len] = True
+
+        return token_ids, token_mask
+
     def forward_with_kvcache(
         self,
         batch: HSTUBatch,
@@ -87,20 +210,25 @@ class InferenceRankingGR(torch.nn.Module):
         total_history_lengths: torch.Tensor,
     ):
         with torch.inference_mode():
-            prepare_kvcache_result = (
-                self.dense_module.async_kvcache.prepare_kvcache_async(
-                    batch.batch_size,
-                    user_ids.tolist(),
-                    total_history_lengths.tolist(),
-                    self.dense_module.async_kvcache.static_page_ids_gpu_buffer,
-                    self.dense_module.async_kvcache.static_offload_page_ids_gpu_buffer,
-                    self.dense_module.async_kvcache.static_metadata_gpu_buffer,
-                    self.dense_module.async_kvcache.static_onload_handle,
+            lookup_token_ids, lookup_token_mask = self._build_lookup_tokens_from_batch(
+                batch=batch,
+                total_history_lengths=total_history_lengths,
+            )
+            lookup_result = self.dense_module.async_kvcache.lookup_kvcache(
+                user_ids,
+                total_history_lengths,
+                token_ids=lookup_token_ids,
+                token_mask=lookup_token_mask,
+            )
+            self.dense_module.async_kvcache.finish_or_cancel_kvcache_ops()
+            kv_index_meta, prepare_result = (
+                self.dense_module.async_kvcache.allocate_kvcache(
+                    lookup_result,
                 )
             )
 
             old_cached_lengths = torch.tensor(
-                prepare_kvcache_result[0], dtype=torch.int32
+                lookup_result.old_cached_lengths, dtype=torch.int32
             )
             striped_batch = self.dense_module.async_kvcache.strip_cached_tokens(
                 batch,
@@ -111,13 +239,17 @@ class InferenceRankingGR(torch.nn.Module):
             embeddings = self.sparse_module(striped_batch.features)
             torch.cuda.nvtx.range_pop()
 
-            prepare_kvcache_result = [old_cached_lengths] + prepare_kvcache_result[1:]
             logits = self.dense_module.forward_with_kvcache(
                 striped_batch,
                 embeddings,
                 user_ids,
                 total_history_lengths,
-                prepare_kvcache_result,
+                prepare_result,
+                kv_index_meta,
+                lookup_result,
+            )
+            self.dense_module.async_kvcache.lazy_offload_kvcache(
+                kv_index_meta
             )
 
         return logits

--- a/examples/hstu/modules/async_kvcache_manager.py
+++ b/examples/hstu/modules/async_kvcache_manager.py
@@ -5,9 +5,156 @@ import paged_kvcache_ops
 import torch
 from configs import KVCacheMetadata
 from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
+from typing import Any, List, Dict, Optional, Tuple, Union
+from uuid import uuid4
+from dataclasses import dataclass
+from abc import ABC, abstractmethod
+from enum import Enum
+
+class KVCacheOffloadMode(Enum):
+    LAZY = "lazy"
+    EAGER = "eager"
+
+class SecondaryTaskStatus(Enum):
+    SKIPPED = "skipped"
+    LAUNCHED = "launched"
+    READY = "ready"
+    TIMEOUT = "timeout"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+@dataclass
+class KVLookupResult:
+    request_id: str
+    batch_size: int
+    user_ids: List[int]
+    total_history_lengths: List[int]
+    old_cached_lengths: List[int]
+    new_tokens_upper_bound: int
+    secondary_lookup: Optional[Dict[str, Any]] = None
+
+@dataclass
+class KVPrepareResult:
+    old_cached_lengths: List[int]
+    new_tokens: int
+    offload_uids_buffer: torch.Tensor
+    metadata_host_buffer: torch.Tensor
+    metadata_gpu_buffer: torch.Tensor
+    kvcache_metadata_fut: Any
+    onload_fut: Any
+
+    def to_legacy_list(self):
+        return [
+            self.old_cached_lengths,
+            self.new_tokens,
+            self.offload_uids_buffer,
+            self.metadata_host_buffer,
+            self.metadata_gpu_buffer,
+            self.kvcache_metadata_fut,
+            self.onload_fut,
+        ]
+
+@dataclass
+class KVIndexMeta:
+    request_id: str
+    batch_size: int
+    user_ids: List[int]
+    namespaces: List[str]
+    total_history_lengths: List[int]
+    old_cached_lengths: List[int]
+    seq_start_indices: List[int]
+    seq_lengths: List[int]
+    new_tokens: int
+    restore_slot_mapping: Optional[torch.Tensor] = None
+    append_slot_mapping: Optional[torch.Tensor] = None
+    secondary_hit_mask: Optional[torch.Tensor] = None
+
+@dataclass
+class SecondaryTaskHandle:
+    backend: str
+    handle: Optional[Any]
+    status: SecondaryTaskStatus = SecondaryTaskStatus.SKIPPED
+    metadata: Optional[Dict[str, Any]] = None
+
+@dataclass
+class SecondaryWaitResult:
+    status: SecondaryTaskStatus
+    ready: bool
+    error_code: Optional[str] = None
+    message: str = ""
+
+class SecondaryKVCacheManagerBase(ABC):
+    def __init__(self):
+        #self.offload_mode = KVCacheOffloadMode.LAZY
+        pass
+
+    @abstractmethod
+    def lookup_kvcache(self, index_meta: KVIndexMeta) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    def onboard_launch_kvcache(
+        self, index_meta: KVIndexMeta, restore_slot_mapping: Optional[torch.Tensor]
+    ) -> SecondaryTaskHandle:
+        pass
+
+    @abstractmethod
+    def onboard_wait_kvcache(self, task_handle: SecondaryTaskHandle) -> SecondaryWaitResult:
+        pass
+
+    @abstractmethod
+    def offload_launch_kvcache(
+        self, index_meta: KVIndexMeta, append_slot_mapping: Optional[torch.Tensor]
+    ) -> SecondaryTaskHandle:
+        pass
+
+    @abstractmethod
+    def offload_wait_kvcache(self, task_handle: SecondaryTaskHandle) -> SecondaryWaitResult:
+        pass
+
+    @abstractmethod
+    def cancel_task(self, task_handle: SecondaryTaskHandle) -> None:
+        pass
+
+class NopSecondaryKVCacheManager(SecondaryKVCacheManagerBase):
+    def lookup_kvcache(self, index_meta: KVIndexMeta):
+        return {"backend": "nop", "hit_mask": None}
+
+    def onboard_launch_kvcache(self, index_meta, restore_slot_mapping):
+        return SecondaryTaskHandle(
+            backend="nop",
+            handle=None,
+            status=SecondaryTaskStatus.SKIPPED,
+            metadata={"reason": "nop backend"},
+        )
+
+    def onboard_wait_kvcache(self, task_handle):
+        return SecondaryWaitResult(
+            status=SecondaryTaskStatus.READY,
+            ready=True,
+            message="nop onboard wait ready",
+        )
+
+    def offload_launch_kvcache(self, index_meta, append_slot_mapping):
+        return SecondaryTaskHandle(
+            backend="nop",
+            handle=None,
+            status=SecondaryTaskStatus.SKIPPED,
+            metadata={"reason": "nop backend"},
+        )
+
+    def offload_wait_kvcache(self, task_handle):
+        return SecondaryWaitResult(
+            status=SecondaryTaskStatus.READY,
+            ready=True,
+            message="nop offload wait ready",
+        )
+
+    def cancel_task(self, task_handle):
+        return None
 
 
-class AsyncHSTUKVCacheManager:
+class KVCacheManager:
     def __init__(
         self,
         num_layers,
@@ -26,6 +173,13 @@ class AsyncHSTUKVCacheManager:
         num_offload_buffer_chunks=8,
         num_memcpy_workers=8,
         enable_nvcomp=False,
+        secondary_kvcache_manager: Optional[SecondaryKVCacheManagerBase] = None,
+        namespace_mode: str = "uid",
+        namespace_base: str = "recsys_hstu",
+        offload_mode: str = "lazy",
+        secondary_wait_timeout_ms: int = 0,
+        secondary_fail_policy: str = "fail_open",
+
     ):
         self.executor = ThreadPoolExecutor(max_workers=1)
         self.onload_worker = ThreadPoolExecutor(max_workers=1)
@@ -112,67 +266,268 @@ class AsyncHSTUKVCacheManager:
         self.cache_table_list = [
             self.cache_table[idx] for idx in range(self.num_layers)
         ]
+        self.secondary_kvcache_manager = secondary_kvcache_manager if secondary_kvcache_manager is not None else NopSecondaryKVCacheManager()
+        self.namespace_mode = namespace_mode
+        self.namespace_base = namespace_base
 
-    def prepare_kvcache_async(
+        self.offload_mode = (
+            KVCacheOffloadMode(offload_mode)
+            if offload_mode in {m.value for m in KVCacheOffloadMode}
+            else KVCacheOffloadMode.LAZY
+        )
+        self.secondary_wait_timeout_ms = int(secondary_wait_timeout_ms)
+        self.secondary_fail_policy = secondary_fail_policy
+        self.ongoing_onboard_tasks: Dict[str, SecondaryTaskHandle] = {}
+        self.ongoing_offload_tasks: Dict[str, SecondaryTaskHandle] = {}
+        self.request_to_task_handles: Dict[str, Dict[str, Optional[SecondaryTaskHandle]]] = {}
+
+    @staticmethod
+    def _build_secondary_manager_from_config(
+        secondary_backend: str,
+        flexkv_mode: str,
+        flexkv_server_addr: str,
+        flexkv_server_port: int,
+    ) -> SecondaryKVCacheManagerBase:
+        if secondary_backend == "flexkv":
+            return FlexKVSecondaryKVCacheManager(
+                mode=flexkv_mode,
+                server_addr=flexkv_server_addr,
+                server_port=flexkv_server_port,
+            )
+        return NopSecondaryKVCacheManager()
+
+    def _build_namespace(self, uid: int) -> List[str]:
+        """
+        Phase 1 namespace helper.
+        - uid mode:       uid:<uid>
+        - default/fallback: <base>:uid=<uid>
+        """
+        if self.namespace_mode == "uid":
+            return [f"uid:{uid}"]
+        return [f"{self.namespace_base}:uid={uid}"]    
+
+    def _normalize_uid_and_sequence(
         self,
-        batch_size,
-        user_ids,
-        total_history_lengths,
-        static_page_ids_gpu_buffer,
-        static_offload_page_ids_gpu_buffer,
-        static_metadata_gpu_buffer,
-        static_onload_handle,
-    ):
-        origin_cached_lengths = self.gpu_kvcache_mgr.get_total_cache_length(user_ids)
-        new_tokens = sum(
-            [
-                total_history_lengths[idx] - origin_cached_lengths[idx]
-                for idx in range(batch_size)
-            ]
+        uid: Union[int, List[int], torch.Tensor],
+        sequence_or_lengths: Union[int, List[int], torch.Tensor],
+    ) -> Tuple[List[int], List[int]]:
+        if isinstance(uid, torch.Tensor):
+            user_ids = uid.detach().cpu().tolist()
+        elif isinstance(uid, list):
+            user_ids = uid
+        else:
+            user_ids = [uid]
+        user_ids = [int(x) for x in user_ids]
+        if isinstance(sequence_or_lengths, torch.Tensor):
+            total_history_lengths = sequence_or_lengths.detach().cpu().tolist()
+        elif isinstance(sequence_or_lengths, list):
+            total_history_lengths = sequence_or_lengths
+        else:
+            total_history_lengths = [sequence_or_lengths]
+        total_history_lengths = [int(x) for x in total_history_lengths]
+        if len(total_history_lengths) == 1 and len(user_ids) > 1:
+            total_history_lengths = total_history_lengths * len(user_ids)
+        if len(user_ids) != len(total_history_lengths):
+            raise ValueError(
+                f"user_ids and sequence lengths size mismatch: {len(user_ids)} vs {len(total_history_lengths)}"
+            )
+        return user_ids, total_history_lengths
+    def _build_index_meta_from_lookup(self, lookup: KVLookupResult) -> KVIndexMeta:
+        seq_start_indices = [
+            min(lookup.old_cached_lengths[i], lookup.total_history_lengths[i])
+            for i in range(lookup.batch_size)
+        ]
+        seq_lengths = [
+            max(lookup.total_history_lengths[i] - seq_start_indices[i], 0)
+            for i in range(lookup.batch_size)
+        ]
+        namespaces = [self._build_namespace(uid)[0] for uid in lookup.user_ids]
+        return KVIndexMeta(
+            request_id=lookup.request_id,
+            batch_size=lookup.batch_size,
+            user_ids=list(lookup.user_ids),
+            namespaces=namespaces,
+            total_history_lengths=list(lookup.total_history_lengths),
+            old_cached_lengths=list(lookup.old_cached_lengths),
+            seq_start_indices=seq_start_indices,
+            seq_lengths=seq_lengths,
+            new_tokens=lookup.new_tokens_upper_bound,
         )
 
-        offload_uids_buffer = torch.empty(
-            [
-                batch_size,
-            ],
-            dtype=torch.int64,
+    def lookup_kvcache(
+        self,
+        uid_or_uids: Union[int, List[int], torch.Tensor],
+        sequence_or_lengths: Union[int, List[int], torch.Tensor],
+    ) -> KVLookupResult:
+        user_ids, total_history_lengths = self._normalize_uid_and_sequence(
+            uid_or_uids, sequence_or_lengths
         )
+        batch_size = len(user_ids)
+        old_cached_lengths = list(self.gpu_kvcache_mgr.get_total_cache_length(user_ids))
+        new_tokens = max(
+            sum(
+                max(total_history_lengths[i] - old_cached_lengths[i], 0)
+                for i in range(batch_size)
+            ),
+            0,
+        )
+        request_id = str(uuid4())
+        lookup = KVLookupResult(
+            request_id=request_id,
+            batch_size=batch_size,
+            user_ids=user_ids,
+            total_history_lengths=total_history_lengths,
+            old_cached_lengths=old_cached_lengths,
+            new_tokens_upper_bound=int(new_tokens),
+        )
+        index_meta = self._build_index_meta_from_lookup(lookup)
+        lookup.secondary_lookup = self.secondary_kvcache_manager.lookup_kvcache(index_meta)
+        return lookup
+
+    def allocate_kvcache(
+        self,
+        uid_or_uids: Union[int, List[int], torch.Tensor],
+        lookup_results: KVLookupResult,
+        static_page_ids_gpu_buffer: Optional[torch.Tensor] = None,
+        static_offload_page_ids_gpu_buffer: Optional[torch.Tensor] = None,
+        static_metadata_gpu_buffer: Optional[torch.Tensor] = None,
+        static_onload_handle: Optional[Any] = None,
+    ) -> Tuple[KVIndexMeta, KVPrepareResult]:
+        index_meta = self._build_index_meta_from_lookup(lookup_results)
+        secondary = lookup_results.secondary_lookup or {}
+        index_meta.secondary_hit_mask = secondary.get("hit_mask", None)
+        index_meta.restore_slot_mapping = secondary.get("restore_slot_mapping", None)
+        # TODO: append_slot_mapping 后续按真实 page_id/block_id 规则生成
+        index_meta.append_slot_mapping = secondary.get("append_slot_mapping", None)
+        page_ids_gpu_buffer = (
+            static_page_ids_gpu_buffer
+            if static_page_ids_gpu_buffer is not None
+            else self.static_page_ids_gpu_buffer
+        )
+        offload_page_ids_gpu_buffer = (
+            static_offload_page_ids_gpu_buffer
+            if static_offload_page_ids_gpu_buffer is not None
+            else self.static_offload_page_ids_gpu_buffer
+        )
+        metadata_gpu_buffer = (
+            static_metadata_gpu_buffer
+            if static_metadata_gpu_buffer is not None
+            else self.static_metadata_gpu_buffer
+        )
+        onload_handle = (
+            static_onload_handle
+            if static_onload_handle is not None
+            else self.static_onload_handle
+        )
+        offload_uids_buffer = torch.empty([lookup_results.batch_size], dtype=torch.int64)
         metadata_host_buffer = torch.empty(
-            [
-                batch_size * 7 + 7,
-            ],
-            dtype=torch.int,
-            pin_memory=True,
+            [lookup_results.batch_size * 7 + 7], dtype=torch.int, pin_memory=True
         )
-        # metadata_gpu_buffer = torch.empty([batch_size * 5 + 4 + new_tokens * 2,], dtype=torch.int, device = torch.cuda.current_device())
-
         kvcache_metadata_fut = self.executor.submit(
             paged_kvcache_ops.prepare_kvcache,
             self.gpu_kvcache_mgr,
             self.host_kv_mgr,
-            user_ids,
-            total_history_lengths,
-            static_page_ids_gpu_buffer,
-            static_offload_page_ids_gpu_buffer,
+            lookup_results.user_ids,
+            lookup_results.total_history_lengths,
+            page_ids_gpu_buffer,
+            offload_page_ids_gpu_buffer,
             offload_uids_buffer,
             metadata_host_buffer,
-            static_metadata_gpu_buffer,
+            metadata_gpu_buffer,
         )
-
-        static_onload_handle.reset()
+        onload_handle.reset()
         onload_fut = self.onload_worker.submit(
-            self.gpu_kvcache_mgr.onload_kvcache, user_ids, static_onload_handle
+            self.gpu_kvcache_mgr.onload_kvcache,
+            lookup_results.user_ids,
+            onload_handle,
         )
-
-        return [
-            origin_cached_lengths,
-            new_tokens,
-            offload_uids_buffer,
-            metadata_host_buffer,
-            static_metadata_gpu_buffer,
-            kvcache_metadata_fut,
-            onload_fut,
-        ]
+        prepare = KVPrepareResult(
+            old_cached_lengths=lookup_results.old_cached_lengths,
+            new_tokens=lookup_results.new_tokens_upper_bound,
+            offload_uids_buffer=offload_uids_buffer,
+            metadata_host_buffer=metadata_host_buffer,
+            metadata_gpu_buffer=metadata_gpu_buffer,
+            kvcache_metadata_fut=kvcache_metadata_fut,
+            onload_fut=onload_fut,
+        )
+        return index_meta, prepare
+    
+    def onboard_launch_kvcache(
+        self,
+        uid_or_uids,
+        kv_index_meta: KVIndexMeta,
+        lookup_results: KVLookupResult,
+    ) -> SecondaryTaskHandle:
+        task = self.secondary_kvcache_manager.onboard_launch_kvcache(
+            kv_index_meta, kv_index_meta.restore_slot_mapping
+        )
+        rid = kv_index_meta.request_id
+        self.ongoing_onboard_tasks[rid] = task
+        self.request_to_task_handles.setdefault(rid, {})["onboard"] = task
+        return task
+    
+    def onboard_try_wait_kvcache_or_fail(
+        self,
+        uid_or_uids,
+        kv_index_meta: KVIndexMeta,
+        lookup_results: KVLookupResult,
+        task_handle: Optional[SecondaryTaskHandle],
+    ) -> Optional[SecondaryWaitResult]:
+        if task_handle is None:
+            return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
+        wait_result = self.secondary_kvcache_manager.onboard_wait_kvcache(task_handle)
+        if wait_result.status in (
+            SecondaryTaskStatus.FAILED,
+            SecondaryTaskStatus.TIMEOUT,
+            SecondaryTaskStatus.CANCELLED,
+        ):
+            self.secondary_kvcache_manager.cancel_task(task_handle)
+            self.ongoing_onboard_tasks.pop(kv_index_meta.request_id, None)
+            if self.secondary_fail_policy == "fail_close":
+                raise RuntimeError(
+                    f"onboard wait failed: status={wait_result.status.value}, msg={wait_result.message}"
+                )
+        elif wait_result.ready:
+            self.ongoing_onboard_tasks.pop(kv_index_meta.request_id, None)
+        return wait_result
+    def lazy_offload_kvcache(
+        self,
+        uid_or_uids,
+        kv_index_meta: KVIndexMeta,
+        lookup_results: KVLookupResult,
+    ) -> Optional[SecondaryTaskHandle]:
+        if self.offload_mode != KVCacheOffloadMode.LAZY:
+            return None
+        task = self.secondary_kvcache_manager.offload_launch_kvcache(
+            kv_index_meta, kv_index_meta.append_slot_mapping
+        )
+        rid = kv_index_meta.request_id
+        self.ongoing_offload_tasks[rid] = task
+        self.request_to_task_handles.setdefault(rid, {})["offload"] = task
+        return task
+    def finish_or_cancel_kvcache_ops(self, uid_or_uids=None, kv_index_meta=None) -> None:
+        target_request_id = kv_index_meta.request_id if kv_index_meta is not None else None
+        request_ids = (
+            [target_request_id]
+            if target_request_id is not None
+            else list(self.ongoing_offload_tasks.keys())
+        )
+        for rid in request_ids:
+            task = self.ongoing_offload_tasks.get(rid)
+            if task is None:
+                continue
+            wait_result = self.secondary_kvcache_manager.offload_wait_kvcache(task)
+            if wait_result.status in (
+                SecondaryTaskStatus.FAILED,
+                SecondaryTaskStatus.TIMEOUT,
+                SecondaryTaskStatus.CANCELLED,
+            ):
+                self.secondary_kvcache_manager.cancel_task(task)
+            self.ongoing_offload_tasks.pop(rid, None)
+            if rid in self.request_to_task_handles:
+                self.request_to_task_handles[rid].pop("offload", None)
+                if not self.request_to_task_handles[rid]:
+                    self.request_to_task_handles.pop(rid, None)
 
     def prepare_kvcache_wait(
         self,
@@ -286,7 +641,7 @@ class AsyncHSTUKVCacheManager:
         old_lengths = batch.features.lengths().cpu()
 
         item_offset = num_context * batch.batch_size
-        item_offset + batch.batch_size
+        #item_offset + batch.batch_size （Todo：junyi check this）
 
         new_lengths = torch.zeros_like(old_lengths)
         new_lengths[:item_offset] = torch.where(
@@ -323,3 +678,272 @@ class AsyncHSTUKVCacheManager:
 
         torch.cuda.nvtx.range_pop()
         return batch
+
+    @classmethod
+    def from_config(cls, hstu_config, kvcache_config):
+        if kvcache_config.max_queued_offload_tokens is None:
+            kvcache_config.max_queued_offload_tokens = (
+                4 * hstu_config.max_batch_size * hstu_config.max_seq_len
+            )
+
+        secondary_mgr = cls._build_secondary_manager_from_config(
+            secondary_backend=getattr(kvcache_config, "secondary_backend", "nop"),
+            flexkv_mode=getattr(kvcache_config, "flexkv_mode", "direct"),
+            flexkv_server_addr=getattr(kvcache_config, "flexkv_server_addr", ""),
+            flexkv_server_port=getattr(kvcache_config, "flexkv_server_port", 0),
+        )
+        return cls(
+            hstu_config.num_layers,
+            hstu_config.num_heads,
+            hstu_config.head_dim,
+            kvcache_config.page_size,
+            kvcache_config.blocks_in_primary_pool,
+            math.ceil(
+                hstu_config.max_batch_size
+                * hstu_config.max_seq_len
+                / kvcache_config.page_size
+        ),
+        0,
+        kvcache_config.offload_chunksize,
+        -1,
+        hstu_config.max_seq_len,
+        hstu_config.max_batch_size,
+        kvcache_config.max_queued_offload_tokens,
+        kvcache_config.num_onload_buffer_chunks,
+        kvcache_config.num_offload_buffer_chunks,
+        kvcache_config.num_memcpy_workers,
+        kvcache_config.enable_nvcomp,
+        secondary_mgr,
+        kvcache_config.namespace_mode,
+        kvcache_config.namespace_base,
+        getattr(kvcache_config, "offload_mode", "lazy"),
+        getattr(kvcache_config, "secondary_wait_timeout_ms", 0),
+        getattr(kvcache_config, "secondary_fail_policy", "fail_open"),
+    )
+
+
+class FlexKVSecondaryKVCacheManager(SecondaryKVCacheManagerBase):
+    def __init__(self, mode: str = "direct", server_addr: str = "", server_port: int = 0):
+        self.mode = mode
+        self.server_addr = server_addr
+        self.server_port = server_port
+        self._tasks: Dict[str, Dict[str, Any]] = {}
+        self._adapter = FlexKVClientAdapter(mode, server_addr, server_port)
+
+    def _failed_wait_result(self, msg: str, error_code: str = "flexkv_error") -> SecondaryWaitResult:
+        return SecondaryWaitResult(
+            status=SecondaryTaskStatus.FAILED,
+            ready=False,
+            error_code=error_code,
+            message=msg,
+        )
+
+    def lookup_kvcache(self, index_meta: KVIndexMeta) -> Dict[str, Any]:
+        try:
+            match = self._adapter.get_match(index_meta)
+            return {
+                "backend": "flexkv",
+                "hit_mask": match.get("hit_mask"),
+                "restore_slot_mapping": match.get("restore_slot_mapping"),
+                "append_slot_mapping": match.get("append_slot_mapping"),
+            }
+        except Exception as e:
+            return {
+                "backend": "flexkv",
+                "error": str(e),
+                "hit_mask": None,
+                "restore_slot_mapping": None,
+                "append_slot_mapping": None,
+            }
+
+    def onboard_launch_kvcache(self, index_meta: KVIndexMeta, restore_slot_mapping: Optional[torch.Tensor]) -> SecondaryTaskHandle:
+        endpoint = (
+            f"{self.server_addr}:{self.server_port}"
+            if self.mode == "server_client"
+            else "local"
+        )
+        try:
+            raw_handle = self._adapter.launch("onboard", index_meta, restore_slot_mapping)
+            task_key = f"onboard:{index_meta.request_id}"
+            self._tasks[task_key] = {
+                "raw_handle": raw_handle,
+                "ready": False,
+                "error": None,
+                "kind": "onboard",
+                "mode": self.mode,
+                "endpoint": endpoint,
+            }
+            return SecondaryTaskHandle(
+                backend="flexkv",
+                handle={
+                    "task_key": task_key,
+                    "raw_handle": raw_handle,
+                    "kind": "onboard",
+                    "mode": self.mode,
+                    "endpoint": endpoint,
+                },
+                status=SecondaryTaskStatus.LAUNCHED,
+            )
+        except Exception as e:
+            return SecondaryTaskHandle(
+                backend="flexkv",
+                handle=None,
+                status=SecondaryTaskStatus.FAILED,
+                metadata={
+                    "error": str(e),
+                    "kind": "onboard",
+                    "mode": self.mode,
+                    "endpoint": endpoint,
+                },
+            )
+        
+    def onboard_wait_kvcache(self, task_handle: SecondaryTaskHandle) -> SecondaryWaitResult:
+        if task_handle is None or task_handle.handle is None:
+            return SecondaryWaitResult(status=SecondaryTaskStatus.SKIPPED, ready=True)
+        try:
+            task_key = task_handle.handle.get("task_key")
+            state = self._tasks.get(task_key, None) if task_key is not None else None
+            if state is not None and state.get("error"):
+                return SecondaryWaitResult(
+                    status=SecondaryTaskStatus.FAILED,
+                    ready=False,
+                    message=str(state["error"]),
+                )
+            raw = task_handle.handle.get("raw_handle")
+            if raw is None and state is not None:
+                raw = state.get("raw_handle")
+            if raw is None:
+                return self._failed_wait_result("onboard_wait missing raw_handle")
+            result = self._adapter.try_wait(raw)
+            if result.get("ready", False):
+                if state is not None:
+                    state["ready"] = True
+                return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
+            return SecondaryWaitResult(status=SecondaryTaskStatus.TIMEOUT, ready=False)
+        except Exception as e:
+            return self._failed_wait_result(f"onboard_wait exception: {e}")
+    
+    def offload_launch_kvcache(
+        self, index_meta: KVIndexMeta, append_slot_mapping: Optional[torch.Tensor]
+    ) -> SecondaryTaskHandle:
+        endpoint = (
+            f"{self.server_addr}:{self.server_port}"
+            if self.mode == "server_client"
+            else "local"
+        )
+       
+        if self.mode == "server_client" and (not self.server_addr or self.server_port <= 0):
+            return SecondaryTaskHandle(
+                backend="flexkv",
+                handle=None,
+                status=SecondaryTaskStatus.FAILED,
+                metadata={
+                    "error": "missing_server_endpoint",
+                    "kind": "offload",
+                    "mode": self.mode,
+                    "endpoint": endpoint,
+                },
+            )
+        try:
+            raw_handle = self._adapter.launch("offload", index_meta, append_slot_mapping)
+            task_key = f"offload:{index_meta.request_id}"
+            self._tasks[task_key] = {
+                "raw_handle": raw_handle,
+                "ready": False,
+                "error": None,
+                "kind": "offload",
+                "mode": self.mode,
+                "endpoint": endpoint,
+                "request_id": index_meta.request_id,
+            }
+            return SecondaryTaskHandle(
+                backend="flexkv",
+                handle={
+                    "task_key": task_key,
+                    "raw_handle": raw_handle,
+                    "kind": "offload",
+                    "mode": self.mode,
+                    "endpoint": endpoint,
+                },
+                status=SecondaryTaskStatus.LAUNCHED,
+                metadata={"request_id": index_meta.request_id},
+            )
+        except Exception as e:
+            return SecondaryTaskHandle(
+                backend="flexkv",
+                handle=None,
+                status=SecondaryTaskStatus.FAILED,
+                metadata={
+                    "error": str(e),
+                    "kind": "offload",
+                    "mode": self.mode,
+                    "endpoint": endpoint,
+                },
+            )
+    def offload_wait_kvcache(self, task_handle: SecondaryTaskHandle) -> SecondaryWaitResult:
+        if task_handle is None or task_handle.handle is None:
+            return SecondaryWaitResult(status=SecondaryTaskStatus.SKIPPED, ready=True)
+        try:
+            task_key = task_handle.handle.get("task_key")
+            state = self._tasks.get(task_key, None) if task_key is not None else None
+          
+            if state is not None and state.get("error"):
+                return SecondaryWaitResult(
+                    status=SecondaryTaskStatus.FAILED,
+                    ready=False,
+                    message=str(state["error"]),
+                )
+            raw_handle = task_handle.handle.get("raw_handle")
+            if raw_handle is None and state is not None:
+                raw_handle = state.get("raw_handle")
+            if raw_handle is None:
+                return self._failed_wait_result("offload_wait missing raw_handle")
+           
+            result = self._adapter.try_wait(raw_handle)
+            if result.get("ready", False):
+                if state is not None:
+                    state["ready"] = True
+                return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
+            return SecondaryWaitResult(status=SecondaryTaskStatus.TIMEOUT, ready=False)
+        except Exception as e:
+            return self._failed_wait_result(f"offload_wait exception: {e}")
+    
+    def cancel_task(self, task_handle: SecondaryTaskHandle) -> None:
+        if task_handle is None or task_handle.handle is None:
+            return
+        task_key = task_handle.handle.get("task_key")
+        if task_key in self._tasks:
+            del self._tasks[task_key]
+
+    
+
+class FlexKVClientAdapter:
+    def __init__(self, mode: str, server_addr: str = "", server_port: int = 0):
+        self.mode = mode
+        self.server_addr = server_addr
+        self.server_port = server_port
+        self.client = self._build_client()
+
+    def _build_client(self):
+        # TODO: 替换为真实 FlexKV SDK 初始化
+        # direct: local engine/client
+        # server_client: remote client(addr, port)
+        return None
+
+    def get_match(self, index_meta: KVIndexMeta) -> Dict[str, Any]:
+        # TODO: 对接真实 get_match
+        return {"hit_mask": None, "restore_slot_mapping": None, "append_slot_mapping": None}
+
+    def launch(self, op: str, index_meta: KVIndexMeta, slot_mapping: Optional[torch.Tensor]) -> Any:
+        # TODO: 对接真实 launch，返回原生 handle
+        return {"op": op, "request_id": index_meta.request_id}
+
+    def wait(self, handle: Any, timeout_ms: int = 0) -> Dict[str, Any]:
+        # TODO: 对接真实 wait
+        return {"ready": True}
+
+    def try_wait(self, handle: Any, timeout_ms: int = 0) -> Dict[str, Any]:
+        # TODO: 对接真实 try_wait
+        return {"ready": True}
+
+AsyncHSTUKVCacheManager = KVCacheManager

--- a/examples/hstu/modules/async_kvcache_manager.py
+++ b/examples/hstu/modules/async_kvcache_manager.py
@@ -67,6 +67,7 @@ class KVIndexMeta:
     new_tokens: int
     restore_slot_mapping: Optional[torch.Tensor] = None
     append_slot_mapping: Optional[torch.Tensor] = None
+    append_slot_indptr: Optional[torch.Tensor] = None
     secondary_hit_mask: Optional[torch.Tensor] = None
 
 @dataclass
@@ -82,6 +83,8 @@ class SecondaryWaitResult:
     ready: bool
     error_code: Optional[str] = None
     message: str = ""
+    failed_mask: Optional[torch.Tensor] = None
+    failed_user_ids: Optional[List[int]] = None
 
 class SecondaryKVCacheManagerBase(ABC):
     def __init__(self):
@@ -104,7 +107,10 @@ class SecondaryKVCacheManagerBase(ABC):
 
     @abstractmethod
     def offload_launch_kvcache(
-        self, index_meta: KVIndexMeta, append_slot_mapping: Optional[torch.Tensor]
+        self,
+        index_meta: KVIndexMeta,
+        append_slot_mapping: Optional[torch.Tensor],
+        append_slot_indptr: Optional[torch.Tensor] = None,
     ) -> SecondaryTaskHandle:
         pass
 
@@ -135,7 +141,12 @@ class NopSecondaryKVCacheManager(SecondaryKVCacheManagerBase):
             message="nop onboard wait ready",
         )
 
-    def offload_launch_kvcache(self, index_meta, append_slot_mapping):
+    def offload_launch_kvcache(
+        self,
+        index_meta,
+        append_slot_mapping,
+        append_slot_indptr=None,
+    ):
         return SecondaryTaskHandle(
             backend="nop",
             handle=None,
@@ -289,7 +300,7 @@ class KVCacheManager:
         flexkv_server_port: int,
     ) -> SecondaryKVCacheManagerBase:
         if secondary_backend == "flexkv":
-            return FlexKVSecondaryKVCacheManager(
+            return FlexKVStorageManager(
                 mode=flexkv_mode,
                 server_addr=flexkv_server_addr,
                 server_port=flexkv_server_port,
@@ -305,6 +316,44 @@ class KVCacheManager:
         if self.namespace_mode == "uid":
             return [f"uid:{uid}"]
         return [f"{self.namespace_base}:uid={uid}"]    
+
+    def _build_append_page_mapping_from_metadata(
+        self,
+        batch_size: int,
+        offload_page_ids: torch.Tensor,
+        new_offload_lengths: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        page_ids = offload_page_ids.to(torch.int32).detach().cpu()
+        lengths = new_offload_lengths.to(torch.int64).detach().cpu()
+        pages_per_req = torch.div(
+            lengths + (self.page_size - 1),
+            self.page_size,
+            rounding_mode="floor",
+        ).to(torch.int32)
+        indptr = torch.empty(batch_size + 1, dtype=torch.int32)
+        indptr[0] = 0
+        indptr[1:] = torch.cumsum(pages_per_req, dim=0)
+        if int(indptr[-1].item()) != int(page_ids.numel()):
+            raise RuntimeError(
+                f"append mapping mismatch: indptr[-1]={int(indptr[-1].item())}, "
+                f"num_page_ids={int(page_ids.numel())}"
+            )
+        return page_ids, indptr
+    
+    def materialize_append_mapping_from_metadata(
+        self,
+        kv_index_meta: Optional[KVIndexMeta],
+        kvcache_metadata: KVCacheMetadata,
+    ) -> None:
+        if kv_index_meta is None:
+            return
+        page_ids, indptr = self._build_append_page_mapping_from_metadata(
+            batch_size=kv_index_meta.batch_size,
+            offload_page_ids=kvcache_metadata.offload_page_ids,
+            new_offload_lengths=kvcache_metadata.new_offload_lengths,
+        )
+        kv_index_meta.append_slot_mapping = page_ids
+        kv_index_meta.append_slot_indptr = indptr
 
     def _normalize_uid_and_sequence(
         self,
@@ -499,7 +548,7 @@ class KVCacheManager:
         if self.offload_mode != KVCacheOffloadMode.LAZY:
             return None
         task = self.secondary_kvcache_manager.offload_launch_kvcache(
-            kv_index_meta, kv_index_meta.append_slot_mapping
+            kv_index_meta, kv_index_meta.append_slot_mapping, kv_index_meta.append_slot_indptr,
         )
         rid = kv_index_meta.request_id
         self.ongoing_offload_tasks[rid] = task
@@ -722,31 +771,42 @@ class KVCacheManager:
     )
 
 
-class FlexKVSecondaryKVCacheManager(SecondaryKVCacheManagerBase):
+class FlexKVStorageManager(SecondaryKVCacheManagerBase):
     def __init__(self, mode: str = "direct", server_addr: str = "", server_port: int = 0):
         self.mode = mode
         self.server_addr = server_addr
         self.server_port = server_port
         self._tasks: Dict[str, Dict[str, Any]] = {}
         self._adapter = FlexKVClientAdapter(mode, server_addr, server_port)
-
-    def _failed_wait_result(self, msg: str, error_code: str = "flexkv_error") -> SecondaryWaitResult:
+        self._client = self._build_client()
+    def _build_client(self):
+        # TODO: 接真实 FlexKV SDK
+        # if self.mode == "direct":
+        #     return FlexKVDirectClient(...)
+        # return FlexKVServerClient(addr=self.server_addr, port=self.server_port)
+        return _MockFlexKVClient()
+    def _failed_wait_result(
+        self,
+        msg: str,
+        error_code: str = "flexkv_error",
+        failed_user_ids: Optional[List[int]] = None,
+    ) -> SecondaryWaitResult:
+        failed_mask = None
+        if failed_user_ids:
+            failed_mask = torch.ones((len(failed_user_ids),), dtype=torch.bool)
         return SecondaryWaitResult(
             status=SecondaryTaskStatus.FAILED,
             ready=False,
             error_code=error_code,
             message=msg,
+            failed_mask=failed_mask,
+            failed_user_ids=failed_user_ids,
         )
-
     def lookup_kvcache(self, index_meta: KVIndexMeta) -> Dict[str, Any]:
         try:
-            match = self._adapter.get_match(index_meta)
-            return {
-                "backend": "flexkv",
-                "hit_mask": match.get("hit_mask"),
-                "restore_slot_mapping": match.get("restore_slot_mapping"),
-                "append_slot_mapping": match.get("append_slot_mapping"),
-            }
+            req = self._adapter.to_get_match_request(index_meta)
+            resp = self._client.get_match(req)
+            return self._adapter.from_get_match_response(resp)
         except Exception as e:
             return {
                 "backend": "flexkv",
@@ -755,15 +815,20 @@ class FlexKVSecondaryKVCacheManager(SecondaryKVCacheManagerBase):
                 "restore_slot_mapping": None,
                 "append_slot_mapping": None,
             }
-
-    def onboard_launch_kvcache(self, index_meta: KVIndexMeta, restore_slot_mapping: Optional[torch.Tensor]) -> SecondaryTaskHandle:
+    def onboard_launch_kvcache(
+        self,
+        index_meta: KVIndexMeta,
+        restore_slot_mapping: Optional[torch.Tensor],
+    ) -> SecondaryTaskHandle:
         endpoint = (
             f"{self.server_addr}:{self.server_port}"
             if self.mode == "server_client"
             else "local"
         )
         try:
-            raw_handle = self._adapter.launch("onboard", index_meta, restore_slot_mapping)
+            req = self._adapter.to_launch_request("onboard", index_meta, restore_slot_mapping)
+            raw_handle = self._client.launch(req)
+            raw_handle = self._adapter.from_launch_response(raw_handle)
             task_key = f"onboard:{index_meta.request_id}"
             self._tasks[task_key] = {
                 "raw_handle": raw_handle,
@@ -772,6 +837,7 @@ class FlexKVSecondaryKVCacheManager(SecondaryKVCacheManagerBase):
                 "kind": "onboard",
                 "mode": self.mode,
                 "endpoint": endpoint,
+                "user_ids": list(index_meta.user_ids),
             }
             return SecondaryTaskHandle(
                 backend="flexkv",
@@ -796,42 +862,61 @@ class FlexKVSecondaryKVCacheManager(SecondaryKVCacheManagerBase):
                     "endpoint": endpoint,
                 },
             )
-        
     def onboard_wait_kvcache(self, task_handle: SecondaryTaskHandle) -> SecondaryWaitResult:
         if task_handle is None or task_handle.handle is None:
             return SecondaryWaitResult(status=SecondaryTaskStatus.SKIPPED, ready=True)
         try:
             task_key = task_handle.handle.get("task_key")
             state = self._tasks.get(task_key, None) if task_key is not None else None
-            if state is not None and state.get("error"):
-                return SecondaryWaitResult(
-                    status=SecondaryTaskStatus.FAILED,
-                    ready=False,
-                    message=str(state["error"]),
+            if state is None:
+                return self._failed_wait_result(
+                    msg="task not found",
+                    error_code="onboard_task_not_found",
                 )
-            raw = task_handle.handle.get("raw_handle")
-            if raw is None and state is not None:
-                raw = state.get("raw_handle")
-            if raw is None:
-                return self._failed_wait_result("onboard_wait missing raw_handle")
-            result = self._adapter.try_wait(raw)
-            if result.get("ready", False):
-                if state is not None:
-                    state["ready"] = True
+            if state.get("error"):
+                failed_user_ids = list(state.get("user_ids", []))
+                return self._failed_wait_result(
+                    msg=str(state["error"]),
+                    error_code="onboard_wait_failed",
+                    failed_user_ids=failed_user_ids if failed_user_ids else None,
+                )
+            if state.get("ready", False):
+                return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
+            raw_handle = task_handle.handle.get("raw_handle")
+            if raw_handle is None:
+                raw_handle = state.get("raw_handle")
+            if raw_handle is None:
+                return self._failed_wait_result(
+                    msg="onboard_wait missing raw_handle",
+                    error_code="onboard_missing_handle",
+                )
+            wait_req = self._adapter.to_wait_request(raw_handle, timeout_ms=0, op="onboard")
+            wait_resp = self._client.try_wait(wait_req)
+            parsed = self._adapter.from_wait_response(wait_resp)
+            if parsed.get("error"):
+                failed_user_ids = list(state.get("user_ids", []))
+                return self._failed_wait_result(
+                    msg=str(parsed["error"]),
+                    error_code="onboard_wait_failed",
+                    failed_user_ids=failed_user_ids if failed_user_ids else None,
+                )
+            if parsed.get("ready", False):
+                state["ready"] = True
                 return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
             return SecondaryWaitResult(status=SecondaryTaskStatus.TIMEOUT, ready=False)
         except Exception as e:
             return self._failed_wait_result(f"onboard_wait exception: {e}")
-    
     def offload_launch_kvcache(
-        self, index_meta: KVIndexMeta, append_slot_mapping: Optional[torch.Tensor]
+        self,
+        index_meta: KVIndexMeta,
+        append_slot_mapping: Optional[torch.Tensor],
+        append_slot_indptr: Optional[torch.Tensor] = None,
     ) -> SecondaryTaskHandle:
         endpoint = (
             f"{self.server_addr}:{self.server_port}"
             if self.mode == "server_client"
             else "local"
         )
-       
         if self.mode == "server_client" and (not self.server_addr or self.server_port <= 0):
             return SecondaryTaskHandle(
                 backend="flexkv",
@@ -845,7 +930,15 @@ class FlexKVSecondaryKVCacheManager(SecondaryKVCacheManagerBase):
                 },
             )
         try:
-            raw_handle = self._adapter.launch("offload", index_meta, append_slot_mapping)
+            if append_slot_indptr is None:
+                append_slot_indptr = index_meta.append_slot_indptr
+            payload = {
+                "page_ids": append_slot_mapping,
+                "indptr": append_slot_indptr,
+            }
+            req = self._adapter.to_launch_request("offload", index_meta, payload)
+            raw_handle = self._client.launch(req)
+            raw_handle = self._adapter.from_launch_response(raw_handle)
             task_key = f"offload:{index_meta.request_id}"
             self._tasks[task_key] = {
                 "raw_handle": raw_handle,
@@ -855,6 +948,8 @@ class FlexKVSecondaryKVCacheManager(SecondaryKVCacheManagerBase):
                 "mode": self.mode,
                 "endpoint": endpoint,
                 "request_id": index_meta.request_id,
+                "user_ids": list(index_meta.user_ids),
+                "append_slot_indptr": append_slot_indptr,
             }
             return SecondaryTaskHandle(
                 backend="flexkv",
@@ -886,64 +981,125 @@ class FlexKVSecondaryKVCacheManager(SecondaryKVCacheManagerBase):
         try:
             task_key = task_handle.handle.get("task_key")
             state = self._tasks.get(task_key, None) if task_key is not None else None
-          
-            if state is not None and state.get("error"):
-                return SecondaryWaitResult(
-                    status=SecondaryTaskStatus.FAILED,
-                    ready=False,
-                    message=str(state["error"]),
+            if state is None:
+                return self._failed_wait_result(
+                    msg="task not found",
+                    error_code="offload_task_not_found",
                 )
+            if state.get("error"):
+                failed_user_ids = list(state.get("user_ids", []))
+                return self._failed_wait_result(
+                    msg=str(state["error"]),
+                    error_code="offload_wait_failed",
+                    failed_user_ids=failed_user_ids if failed_user_ids else None,
+                )
+            if state.get("ready", False):
+                return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
             raw_handle = task_handle.handle.get("raw_handle")
-            if raw_handle is None and state is not None:
+            if raw_handle is None:
                 raw_handle = state.get("raw_handle")
             if raw_handle is None:
-                return self._failed_wait_result("offload_wait missing raw_handle")
-           
-            result = self._adapter.try_wait(raw_handle)
-            if result.get("ready", False):
-                if state is not None:
-                    state["ready"] = True
+                return self._failed_wait_result(
+                    msg="offload_wait missing raw_handle",
+                    error_code="offload_missing_handle",
+                )
+            wait_req = self._adapter.to_wait_request(raw_handle, timeout_ms=0, op="offload")
+            wait_resp = self._client.try_wait(wait_req)
+            parsed = self._adapter.from_wait_response(wait_resp)
+            if parsed.get("error"):
+                failed_user_ids = list(state.get("user_ids", []))
+                return self._failed_wait_result(
+                    msg=str(parsed["error"]),
+                    error_code="offload_wait_failed",
+                    failed_user_ids=failed_user_ids if failed_user_ids else None,
+                )
+            if parsed.get("ready", False):
+                state["ready"] = True
                 return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
             return SecondaryWaitResult(status=SecondaryTaskStatus.TIMEOUT, ready=False)
         except Exception as e:
             return self._failed_wait_result(f"offload_wait exception: {e}")
-    
     def cancel_task(self, task_handle: SecondaryTaskHandle) -> None:
         if task_handle is None or task_handle.handle is None:
             return
         task_key = task_handle.handle.get("task_key")
         if task_key in self._tasks:
-            del self._tasks[task_key]
+            del self._tasks[task_key]    
 
-    
+class _MockFlexKVClient:
+    def get_match(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "hit_mask": None,
+            "restore_slot_mapping": None,
+            "append_slot_mapping": None,
+        }
+    def launch(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        return {"request": request, "handle": "mock_handle"}
+    def wait(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        return {"ready": True}
+    def try_wait(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        return {"ready": True}
 
 class FlexKVClientAdapter:
     def __init__(self, mode: str, server_addr: str = "", server_port: int = 0):
         self.mode = mode
         self.server_addr = server_addr
         self.server_port = server_port
-        self.client = self._build_client()
-
-    def _build_client(self):
-        # TODO: 替换为真实 FlexKV SDK 初始化
-        # direct: local engine/client
-        # server_client: remote client(addr, port)
-        return None
-
-    def get_match(self, index_meta: KVIndexMeta) -> Dict[str, Any]:
-        # TODO: 对接真实 get_match
-        return {"hit_mask": None, "restore_slot_mapping": None, "append_slot_mapping": None}
-
-    def launch(self, op: str, index_meta: KVIndexMeta, slot_mapping: Optional[torch.Tensor]) -> Any:
-        # TODO: 对接真实 launch，返回原生 handle
-        return {"op": op, "request_id": index_meta.request_id}
-
-    def wait(self, handle: Any, timeout_ms: int = 0) -> Dict[str, Any]:
-        # TODO: 对接真实 wait
-        return {"ready": True}
-
-    def try_wait(self, handle: Any, timeout_ms: int = 0) -> Dict[str, Any]:
-        # TODO: 对接真实 try_wait
-        return {"ready": True}
+    def to_get_match_request(self, index_meta: KVIndexMeta) -> Dict[str, Any]:
+        return {
+            "request_id": index_meta.request_id,
+            "mode": self.mode,
+            "user_ids": list(index_meta.user_ids),
+            "namespaces": list(index_meta.namespaces),
+            "total_history_lengths": list(index_meta.total_history_lengths),
+            "old_cached_lengths": list(index_meta.old_cached_lengths),
+            "seq_start_indices": list(index_meta.seq_start_indices),
+            "seq_lengths": list(index_meta.seq_lengths),
+        }
+    def from_get_match_response(self, resp: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "backend": "flexkv",
+            "hit_mask": resp.get("hit_mask"),
+            "restore_slot_mapping": resp.get("restore_slot_mapping"),
+            "append_slot_mapping": resp.get("append_slot_mapping"),
+        }
+    def to_launch_request(self, op: str, index_meta: KVIndexMeta, payload: Any) -> Dict[str, Any]:
+        if op == "offload":
+            page_ids = None
+            indptr = None
+            if isinstance(payload, dict):
+                page_ids = payload.get("page_ids")
+                indptr = payload.get("indptr")
+            return {
+                "op": op,
+                "request_id": index_meta.request_id,
+                "mode": self.mode,
+                "user_ids": list(index_meta.user_ids),
+                "namespaces": list(index_meta.namespaces),
+                "page_ids": page_ids,
+                "indptr": indptr,
+            }
+        return {
+            "op": op,
+            "request_id": index_meta.request_id,
+            "mode": self.mode,
+            "user_ids": list(index_meta.user_ids),
+            "namespaces": list(index_meta.namespaces),
+            "payload": payload,
+        }
+    def from_launch_response(self, resp: Any) -> Any:
+        return resp
+    def to_wait_request(self, raw_handle: Any, timeout_ms: int = 0, op: str = "") -> Dict[str, Any]:
+        return {
+            "op": op,
+            "mode": self.mode,
+            "raw_handle": raw_handle,
+            "timeout_ms": int(timeout_ms),
+        }
+    def from_wait_response(self, resp: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "ready": bool(resp.get("ready", False)),
+            "error": resp.get("error"),
+        }
 
 AsyncHSTUKVCacheManager = KVCacheManager

--- a/examples/hstu/modules/async_kvcache_manager.py
+++ b/examples/hstu/modules/async_kvcache_manager.py
@@ -1,6 +1,9 @@
 import math
+import os
+import time
 from concurrent.futures import ThreadPoolExecutor
 
+import numpy as np
 import paged_kvcache_ops
 import torch
 from configs import KVCacheMetadata
@@ -10,6 +13,7 @@ from uuid import uuid4
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
 from enum import Enum
+
 
 class KVCacheOffloadMode(Enum):
     LAZY = "lazy"
@@ -23,6 +27,19 @@ class SecondaryTaskStatus(Enum):
     FAILED = "failed"
     CANCELLED = "cancelled"
 
+class SecondaryErrorCode(str, Enum):
+    SDK_IMPORT_FAILED = "sdk_import_failed"
+    SDK_INIT_FAILED = "sdk_init_failed"
+    LOOKUP_FAILED = "lookup_failed"
+    LOOKUP_MISSING_TOKENS = "lookup_missing_tokens"
+    ONBOARD_TASK_NOT_FOUND = "onboard_task_not_found"
+    ONBOARD_WAIT_FAILED = "onboard_wait_failed"
+    ONBOARD_TIMEOUT = "onboard_timeout"
+    OFFLOAD_TASK_NOT_FOUND = "offload_task_not_found"
+    OFFLOAD_WAIT_FAILED = "offload_wait_failed"
+    OFFLOAD_TIMEOUT = "offload_timeout"
+    CANCEL_FAILED = "cancel_failed"
+
 @dataclass
 class KVLookupResult:
     request_id: str
@@ -31,6 +48,8 @@ class KVLookupResult:
     total_history_lengths: List[int]
     old_cached_lengths: List[int]
     new_tokens_upper_bound: int
+    token_ids: Optional[torch.Tensor] = None
+    token_mask: Optional[torch.Tensor] = None
     secondary_lookup: Optional[Dict[str, Any]] = None
 
 @dataclass
@@ -65,10 +84,14 @@ class KVIndexMeta:
     seq_start_indices: List[int]
     seq_lengths: List[int]
     new_tokens: int
+    token_ids: Optional[torch.Tensor] = None
+    token_mask: Optional[torch.Tensor] = None
     restore_slot_mapping: Optional[torch.Tensor] = None
     append_slot_mapping: Optional[torch.Tensor] = None
     append_slot_indptr: Optional[torch.Tensor] = None
     secondary_hit_mask: Optional[torch.Tensor] = None
+    secondary_get_task_ids: Optional[List[int]] = None
+    secondary_matched_lengths: Optional[List[int]] = None
 
 @dataclass
 class SecondaryTaskHandle:
@@ -87,23 +110,19 @@ class SecondaryWaitResult:
     failed_user_ids: Optional[List[int]] = None
 
 class SecondaryKVCacheManagerBase(ABC):
-    def __init__(self):
-        #self.offload_mode = KVCacheOffloadMode.LAZY
-        pass
-
     @abstractmethod
     def lookup_kvcache(self, index_meta: KVIndexMeta) -> Dict[str, Any]:
-        pass
+        ...
 
     @abstractmethod
     def onboard_launch_kvcache(
         self, index_meta: KVIndexMeta, restore_slot_mapping: Optional[torch.Tensor]
     ) -> SecondaryTaskHandle:
-        pass
+        ...
 
     @abstractmethod
     def onboard_wait_kvcache(self, task_handle: SecondaryTaskHandle) -> SecondaryWaitResult:
-        pass
+        ...
 
     @abstractmethod
     def offload_launch_kvcache(
@@ -112,15 +131,19 @@ class SecondaryKVCacheManagerBase(ABC):
         append_slot_mapping: Optional[torch.Tensor],
         append_slot_indptr: Optional[torch.Tensor] = None,
     ) -> SecondaryTaskHandle:
-        pass
+        ...
 
     @abstractmethod
     def offload_wait_kvcache(self, task_handle: SecondaryTaskHandle) -> SecondaryWaitResult:
-        pass
+        ...
 
     @abstractmethod
     def cancel_task(self, task_handle: SecondaryTaskHandle) -> None:
-        pass
+        ...
+
+    def register_gpu_cache_tensors(self, cache_table_list: List[torch.Tensor]) -> None:
+        # Optional hook for backends that require GPU KV cache registration.
+        return None
 
 class NopSecondaryKVCacheManager(SecondaryKVCacheManagerBase):
     def lookup_kvcache(self, index_meta: KVIndexMeta):
@@ -185,8 +208,6 @@ class KVCacheManager:
         num_memcpy_workers=8,
         enable_nvcomp=False,
         secondary_kvcache_manager: Optional[SecondaryKVCacheManagerBase] = None,
-        namespace_mode: str = "uid",
-        namespace_base: str = "recsys_hstu",
         offload_mode: str = "lazy",
         secondary_wait_timeout_ms: int = 0,
         secondary_fail_policy: str = "fail_open",
@@ -278,8 +299,8 @@ class KVCacheManager:
             self.cache_table[idx] for idx in range(self.num_layers)
         ]
         self.secondary_kvcache_manager = secondary_kvcache_manager if secondary_kvcache_manager is not None else NopSecondaryKVCacheManager()
-        self.namespace_mode = namespace_mode
-        self.namespace_base = namespace_base
+        # Real FlexKV backend requires explicit GPU KV cache registration before ready.
+        self.secondary_kvcache_manager.register_gpu_cache_tensors(self.cache_table_list)
 
         self.offload_mode = (
             KVCacheOffloadMode(offload_mode)
@@ -292,30 +313,85 @@ class KVCacheManager:
         self.ongoing_offload_tasks: Dict[str, SecondaryTaskHandle] = {}
         self.request_to_task_handles: Dict[str, Dict[str, Optional[SecondaryTaskHandle]]] = {}
 
+    def _page_ids_to_slot_mapping(self, page_ids: torch.Tensor) -> np.ndarray:
+        page_ids_np = page_ids.to(torch.int64).detach().cpu().numpy()
+        return np.repeat(page_ids_np * self.page_size, self.page_size).astype(np.int64)
+
+    def materialize_restore_mapping_from_metadata(
+        self,
+        kv_index_meta: Optional[KVIndexMeta],
+        kvcache_metadata: KVCacheMetadata,
+    ) -> None:
+        if kv_index_meta is None:
+            return
+        task_ids = kv_index_meta.secondary_get_task_ids or []
+        matched_lengths = kv_index_meta.secondary_matched_lengths or []
+        if len(task_ids) == 0 or len(matched_lengths) == 0:
+            kv_index_meta.restore_slot_mapping = None
+            return
+
+        kv_indices = kvcache_metadata.kv_indices.to(torch.int64).detach().cpu()
+        kv_indptr = kvcache_metadata.kv_indptr.to(torch.int64).detach().cpu()
+
+        launch_task_ids: List[int] = []
+        launch_slot_mappings: List[np.ndarray] = []
+
+        for i in range(kv_index_meta.batch_size):
+            if i >= len(task_ids):
+                continue
+            task_id = int(task_ids[i])
+            matched_len = int(matched_lengths[i]) if i < len(matched_lengths) else 0
+            old_cached_len = int(kv_index_meta.old_cached_lengths[i])
+
+            start_block = old_cached_len // self.page_size
+            end_block = matched_len // self.page_size
+            if end_block <= start_block:
+                continue
+
+            seq_page_start = int(kv_indptr[i].item())
+            seq_page_end = int(kv_indptr[i + 1].item())
+            seq_pages = kv_indices[seq_page_start:seq_page_end]
+            restore_pages = seq_pages[start_block:end_block]
+            if restore_pages.numel() == 0:
+                continue
+
+            launch_task_ids.append(task_id)
+            launch_slot_mappings.append(self._page_ids_to_slot_mapping(restore_pages))
+
+        kv_index_meta.restore_slot_mapping = {
+            "task_ids": launch_task_ids,
+            "slot_mappings": launch_slot_mappings,
+        }
+
     @staticmethod
     def _build_secondary_manager_from_config(
         secondary_backend: str,
         flexkv_mode: str,
         flexkv_server_addr: str,
         flexkv_server_port: int,
+        num_layers: int,
+        num_heads: int,
+        head_dim: int,
+        page_size: int,
+        secondary_wait_timeout_ms: int,
+        secondary_fail_policy: str,
     ) -> SecondaryKVCacheManagerBase:
         if secondary_backend == "flexkv":
             return FlexKVStorageManager(
                 mode=flexkv_mode,
                 server_addr=flexkv_server_addr,
                 server_port=flexkv_server_port,
+                num_layers=num_layers,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                page_size=page_size,
+                secondary_wait_timeout_ms=secondary_wait_timeout_ms,
+                secondary_fail_policy=secondary_fail_policy,
             )
         return NopSecondaryKVCacheManager()
 
     def _build_namespace(self, uid: int) -> List[str]:
-        """
-        Phase 1 namespace helper.
-        - uid mode:       uid:<uid>
-        - default/fallback: <base>:uid=<uid>
-        """
-        if self.namespace_mode == "uid":
-            return [f"uid:{uid}"]
-        return [f"{self.namespace_base}:uid={uid}"]    
+        return [f"uid:{uid}"]
 
     def _build_append_page_mapping_from_metadata(
         self,
@@ -355,10 +431,10 @@ class KVCacheManager:
         kv_index_meta.append_slot_mapping = page_ids
         kv_index_meta.append_slot_indptr = indptr
 
-    def _normalize_uid_and_sequence(
+    def _normalize_user_ids_and_lengths(
         self,
         uid: Union[int, List[int], torch.Tensor],
-        sequence_or_lengths: Union[int, List[int], torch.Tensor],
+        history_lengths_input: Union[int, List[int], torch.Tensor],
     ) -> Tuple[List[int], List[int]]:
         if isinstance(uid, torch.Tensor):
             user_ids = uid.detach().cpu().tolist()
@@ -367,12 +443,12 @@ class KVCacheManager:
         else:
             user_ids = [uid]
         user_ids = [int(x) for x in user_ids]
-        if isinstance(sequence_or_lengths, torch.Tensor):
-            total_history_lengths = sequence_or_lengths.detach().cpu().tolist()
-        elif isinstance(sequence_or_lengths, list):
-            total_history_lengths = sequence_or_lengths
+        if isinstance(history_lengths_input, torch.Tensor):
+            total_history_lengths = history_lengths_input.detach().cpu().tolist()
+        elif isinstance(history_lengths_input, list):
+            total_history_lengths = history_lengths_input
         else:
-            total_history_lengths = [sequence_or_lengths]
+            total_history_lengths = [history_lengths_input]
         total_history_lengths = [int(x) for x in total_history_lengths]
         if len(total_history_lengths) == 1 and len(user_ids) > 1:
             total_history_lengths = total_history_lengths * len(user_ids)
@@ -401,17 +477,131 @@ class KVCacheManager:
             seq_start_indices=seq_start_indices,
             seq_lengths=seq_lengths,
             new_tokens=lookup.new_tokens_upper_bound,
+            token_ids=lookup.token_ids,
+            token_mask=lookup.token_mask,
         )
+
+    def _normalize_lookup_token_inputs(
+        self,
+        token_ids: Optional[Union[torch.Tensor, List[List[int]], List[int]]],
+        token_mask: Optional[Union[torch.Tensor, List[List[bool]], List[bool]]],
+        batch_size: int,
+    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+        if token_ids is None:
+            return None, None
+        row_lengths: Optional[List[int]] = None
+
+        if isinstance(token_ids, torch.Tensor):
+            token_ids_cpu = token_ids.detach().cpu()
+            if token_ids_cpu.ndim == 1:
+                token_ids_cpu = token_ids_cpu.unsqueeze(0)
+            if token_ids_cpu.ndim != 2:
+                raise ValueError(
+                    f"token_ids tensor must be 1D/2D, got shape={tuple(token_ids_cpu.shape)}"
+                )
+            token_ids_2d = token_ids_cpu.to(torch.int64)
+        elif isinstance(token_ids, list):
+            if len(token_ids) == 0:
+                token_ids_2d = torch.zeros((batch_size, 0), dtype=torch.int64)
+                row_lengths = []
+            elif isinstance(token_ids[0], list):
+                row_count = len(token_ids)
+                max_len = max(len(row) for row in token_ids) if row_count > 0 else 0
+                token_ids_2d = torch.zeros((row_count, max_len), dtype=torch.int64)
+                row_lengths = [len(row) for row in token_ids]
+                for idx, row in enumerate(token_ids):
+                    if len(row) == 0:
+                        continue
+                    token_ids_2d[idx, : len(row)] = torch.tensor(
+                        row, dtype=torch.int64
+                    )
+            else:
+                token_ids_2d = torch.tensor(token_ids, dtype=torch.int64).view(1, -1)
+        else:
+            raise ValueError(
+                f"Unsupported token_ids type: {type(token_ids)}. "
+                "Expected torch.Tensor or List[List[int]]."
+            )
+
+        if token_ids_2d.size(0) == 1 and batch_size > 1:
+            token_ids_2d = token_ids_2d.repeat(batch_size, 1)
+            if row_lengths is not None and len(row_lengths) == 1:
+                row_lengths = row_lengths * batch_size
+        if token_ids_2d.size(0) != batch_size:
+            raise ValueError(
+                f"token_ids batch dimension mismatch: token_ids_batch={token_ids_2d.size(0)}, "
+                f"batch_size={batch_size}"
+            )
+
+        if token_mask is None:
+            token_mask_2d = torch.ones_like(token_ids_2d, dtype=torch.bool)
+            if row_lengths is not None and len(row_lengths) == batch_size:
+                for idx, row_len in enumerate(row_lengths):
+                    if row_len < token_ids_2d.size(1):
+                        token_mask_2d[idx, row_len:] = False
+            return token_ids_2d, token_mask_2d
+
+        if isinstance(token_mask, torch.Tensor):
+            token_mask_cpu = token_mask.detach().cpu()
+            if token_mask_cpu.ndim == 1:
+                token_mask_cpu = token_mask_cpu.unsqueeze(0)
+            if token_mask_cpu.ndim != 2:
+                raise ValueError(
+                    f"token_mask tensor must be 1D/2D, got shape={tuple(token_mask_cpu.shape)}"
+                )
+            token_mask_2d = token_mask_cpu.to(torch.bool)
+        elif isinstance(token_mask, list):
+            if len(token_mask) == 0:
+                token_mask_2d = torch.zeros_like(token_ids_2d, dtype=torch.bool)
+            elif isinstance(token_mask[0], list):
+                row_count = len(token_mask)
+                max_len = max(len(row) for row in token_mask) if row_count > 0 else 0
+                token_mask_2d = torch.zeros((row_count, max_len), dtype=torch.bool)
+                for idx, row in enumerate(token_mask):
+                    if len(row) == 0:
+                        continue
+                    token_mask_2d[idx, : len(row)] = torch.tensor(
+                        row, dtype=torch.bool
+                    )
+            else:
+                token_mask_2d = torch.tensor(token_mask, dtype=torch.bool).view(1, -1)
+        else:
+            raise ValueError(
+                f"Unsupported token_mask type: {type(token_mask)}. "
+                "Expected torch.Tensor or List[List[bool]]."
+            )
+
+        if token_mask_2d.size(0) == 1 and batch_size > 1:
+            token_mask_2d = token_mask_2d.repeat(batch_size, 1)
+        if token_mask_2d.size(0) != batch_size:
+            raise ValueError(
+                f"token_mask batch dimension mismatch: token_mask_batch={token_mask_2d.size(0)}, "
+                f"batch_size={batch_size}"
+            )
+        if token_mask_2d.size(1) != token_ids_2d.size(1):
+            raise ValueError(
+                f"token_mask length mismatch: token_mask_width={token_mask_2d.size(1)}, "
+                f"token_ids_width={token_ids_2d.size(1)}"
+            )
+
+        return token_ids_2d, token_mask_2d
 
     def lookup_kvcache(
         self,
-        uid_or_uids: Union[int, List[int], torch.Tensor],
-        sequence_or_lengths: Union[int, List[int], torch.Tensor],
+        user_ids_input: Union[int, List[int], torch.Tensor],
+        history_lengths_input: Union[int, List[int], torch.Tensor],
+        token_ids: Optional[Union[torch.Tensor, List[List[int]], List[int]]] = None,
+        token_mask: Optional[Union[torch.Tensor, List[List[bool]], List[bool]]] = None,
     ) -> KVLookupResult:
-        user_ids, total_history_lengths = self._normalize_uid_and_sequence(
-            uid_or_uids, sequence_or_lengths
+        user_ids, total_history_lengths = self._normalize_user_ids_and_lengths(
+            user_ids_input, history_lengths_input
         )
         batch_size = len(user_ids)
+        lookup_token_ids, lookup_token_mask = self._normalize_lookup_token_inputs(
+            token_ids=token_ids,
+            token_mask=token_mask,
+            batch_size=batch_size,
+        )
         old_cached_lengths = list(self.gpu_kvcache_mgr.get_total_cache_length(user_ids))
         new_tokens = max(
             sum(
@@ -428,6 +618,8 @@ class KVCacheManager:
             total_history_lengths=total_history_lengths,
             old_cached_lengths=old_cached_lengths,
             new_tokens_upper_bound=int(new_tokens),
+            token_ids=lookup_token_ids,
+            token_mask=lookup_token_mask,
         )
         index_meta = self._build_index_meta_from_lookup(lookup)
         lookup.secondary_lookup = self.secondary_kvcache_manager.lookup_kvcache(index_meta)
@@ -435,7 +627,6 @@ class KVCacheManager:
 
     def allocate_kvcache(
         self,
-        uid_or_uids: Union[int, List[int], torch.Tensor],
         lookup_results: KVLookupResult,
         static_page_ids_gpu_buffer: Optional[torch.Tensor] = None,
         static_offload_page_ids_gpu_buffer: Optional[torch.Tensor] = None,
@@ -445,8 +636,9 @@ class KVCacheManager:
         index_meta = self._build_index_meta_from_lookup(lookup_results)
         secondary = lookup_results.secondary_lookup or {}
         index_meta.secondary_hit_mask = secondary.get("hit_mask", None)
+        index_meta.secondary_get_task_ids = secondary.get("task_ids")
+        index_meta.secondary_matched_lengths = secondary.get("matched_lengths")
         index_meta.restore_slot_mapping = secondary.get("restore_slot_mapping", None)
-        # TODO: append_slot_mapping 后续按真实 page_id/block_id 规则生成
         index_meta.append_slot_mapping = secondary.get("append_slot_mapping", None)
         page_ids_gpu_buffer = (
             static_page_ids_gpu_buffer
@@ -503,9 +695,7 @@ class KVCacheManager:
     
     def onboard_launch_kvcache(
         self,
-        uid_or_uids,
         kv_index_meta: KVIndexMeta,
-        lookup_results: KVLookupResult,
     ) -> SecondaryTaskHandle:
         task = self.secondary_kvcache_manager.onboard_launch_kvcache(
             kv_index_meta, kv_index_meta.restore_slot_mapping
@@ -517,9 +707,7 @@ class KVCacheManager:
     
     def onboard_try_wait_kvcache_or_fail(
         self,
-        uid_or_uids,
         kv_index_meta: KVIndexMeta,
-        lookup_results: KVLookupResult,
         task_handle: Optional[SecondaryTaskHandle],
     ) -> Optional[SecondaryWaitResult]:
         if task_handle is None:
@@ -541,9 +729,7 @@ class KVCacheManager:
         return wait_result
     def lazy_offload_kvcache(
         self,
-        uid_or_uids,
         kv_index_meta: KVIndexMeta,
-        lookup_results: KVLookupResult,
     ) -> Optional[SecondaryTaskHandle]:
         if self.offload_mode != KVCacheOffloadMode.LAZY:
             return None
@@ -554,7 +740,8 @@ class KVCacheManager:
         self.ongoing_offload_tasks[rid] = task
         self.request_to_task_handles.setdefault(rid, {})["offload"] = task
         return task
-    def finish_or_cancel_kvcache_ops(self, uid_or_uids=None, kv_index_meta=None) -> None:
+
+    def finish_or_cancel_kvcache_ops(self, kv_index_meta=None) -> None:
         target_request_id = kv_index_meta.request_id if kv_index_meta is not None else None
         request_ids = (
             [target_request_id]
@@ -566,17 +753,25 @@ class KVCacheManager:
             if task is None:
                 continue
             wait_result = self.secondary_kvcache_manager.offload_wait_kvcache(task)
-            if wait_result.status in (
+            failed = wait_result.status in (
                 SecondaryTaskStatus.FAILED,
                 SecondaryTaskStatus.TIMEOUT,
                 SecondaryTaskStatus.CANCELLED,
-            ):
+            )
+
+            should_raise = failed and self.secondary_fail_policy == "fail_close"
+            if failed:
                 self.secondary_kvcache_manager.cancel_task(task)
             self.ongoing_offload_tasks.pop(rid, None)
             if rid in self.request_to_task_handles:
                 self.request_to_task_handles[rid].pop("offload", None)
                 if not self.request_to_task_handles[rid]:
                     self.request_to_task_handles.pop(rid, None)
+            if should_raise:
+                raise RuntimeError(
+                    f"offload wait failed: status={wait_result.status.value}, "
+                    f"error_code={wait_result.error_code}, msg={wait_result.message}"
+                )
 
     def prepare_kvcache_wait(
         self,
@@ -588,7 +783,7 @@ class KVCacheManager:
         static_offload_page_ids_gpu_buffer,
         offload_uids_buffer,
         metadata_host_buffer,
-        metadata_gpu_buffer,  # input static
+        metadata_gpu_buffer,
         static_onload_handle,
     ):
         kvcache_metadata_fut.result()
@@ -625,10 +820,9 @@ class KVCacheManager:
         static_offload_page_ids_gpu_buffer,
         offload_uids_buffer,
         metadata_host_buffer,
-        metadata_gpu_buffer,  # input static
+        metadata_gpu_buffer,
         static_onload_handle,
     ):
-        # assert int(metadata_host_buffer[batch_size * 4 + 2]) == new_tokens
         offload_handle = self.static_empty_offload_handle
         if int(metadata_host_buffer[batch_size * 7 + 5]) > 0:
             offload_handle = paged_kvcache_ops.KVOffloadHandle(
@@ -690,7 +884,6 @@ class KVCacheManager:
         old_lengths = batch.features.lengths().cpu()
 
         item_offset = num_context * batch.batch_size
-        #item_offset + batch.batch_size （Todo：junyi check this）
 
         new_lengths = torch.zeros_like(old_lengths)
         new_lengths[:item_offset] = torch.where(
@@ -740,6 +933,12 @@ class KVCacheManager:
             flexkv_mode=getattr(kvcache_config, "flexkv_mode", "direct"),
             flexkv_server_addr=getattr(kvcache_config, "flexkv_server_addr", ""),
             flexkv_server_port=getattr(kvcache_config, "flexkv_server_port", 0),
+            num_layers=hstu_config.num_layers,
+            num_heads=hstu_config.num_heads,
+            head_dim=hstu_config.head_dim,
+            page_size=kvcache_config.page_size,
+            secondary_wait_timeout_ms=getattr(kvcache_config, "secondary_wait_timeout_ms", 0),
+            secondary_fail_policy=getattr(kvcache_config, "secondary_fail_policy", "fail_open"),
         )
         return cls(
             hstu_config.num_layers,
@@ -763,8 +962,6 @@ class KVCacheManager:
         kvcache_config.num_memcpy_workers,
         kvcache_config.enable_nvcomp,
         secondary_mgr,
-        kvcache_config.namespace_mode,
-        kvcache_config.namespace_base,
         getattr(kvcache_config, "offload_mode", "lazy"),
         getattr(kvcache_config, "secondary_wait_timeout_ms", 0),
         getattr(kvcache_config, "secondary_fail_policy", "fail_open"),
@@ -772,23 +969,184 @@ class KVCacheManager:
 
 
 class FlexKVStorageManager(SecondaryKVCacheManagerBase):
-    def __init__(self, mode: str = "direct", server_addr: str = "", server_port: int = 0):
+    def __init__(
+        self,
+        mode: str = "direct",
+        server_addr: str = "",
+        server_port: int = 0,
+        num_layers: int = 1,
+        num_heads: int = 1,
+        head_dim: int = 1,
+        page_size: int = 16,
+        secondary_wait_timeout_ms: int = 0,
+        secondary_fail_policy: str = "fail_open",
+    ):
         self.mode = mode
         self.server_addr = server_addr
         self.server_port = server_port
+        self.num_layers = int(num_layers)
+        self.num_heads = int(num_heads)
+        self.head_dim = int(head_dim)
+        self.page_size = int(page_size)
+        self.secondary_wait_timeout_ms = int(secondary_wait_timeout_ms)
+        self.secondary_fail_policy = secondary_fail_policy
+        self._gpu_register_port: str = ""
+        self._ready: bool = False
+        self._registered: bool = False
         self._tasks: Dict[str, Dict[str, Any]] = {}
         self._adapter = FlexKVClientAdapter(mode, server_addr, server_port)
         self._client = self._build_client()
+
+    def _import_flexkv_sdk(self):
+        try:
+            from flexkv.kvmanager import KVManager
+            from flexkv.common.config import ModelConfig, CacheConfig
+            from flexkv.common.request import KVResponseStatus
+            return KVManager, ModelConfig, CacheConfig, KVResponseStatus
+        except Exception as e:
+            raise RuntimeError(
+                "FlexKV SDK import failed. "
+                "Please install FlexKV in the runtime image/environment "
+                "(for example via Dockerfile build step), and ensure ABI compatibility "
+                f"(python/cuda/glibc). Original error: {e}"
+            ) from e
+
+
+    def _build_server_recv_port(self) -> str:
+        if self.mode != "server_client":
+            return ""
+        if not self.server_addr:
+            raise RuntimeError("server_client mode requires flexkv_server_addr")
+        if str(self.server_addr).startswith(("ipc://", "inproc://")):
+            return self.server_addr
+        if str(self.server_addr).startswith("tcp://"):
+            if self.server_port > 0 and self.server_addr.count(":") == 1:
+                return f"{self.server_addr}:{self.server_port}"
+            return self.server_addr
+        if self.server_port <= 0:
+            raise RuntimeError("server_client mode requires flexkv_server_port > 0")
+        return f"tcp://{self.server_addr}:{self.server_port}"
+
     def _build_client(self):
-        # TODO: 接真实 FlexKV SDK
-        # if self.mode == "direct":
-        #     return FlexKVDirectClient(...)
-        # return FlexKVServerClient(addr=self.server_addr, port=self.server_port)
-        return _MockFlexKVClient()
+        server_recv_port = self._build_server_recv_port()
+        # NOTE: FlexKV's GLOBAL_CONFIG_FROM_ENV is initialized at import time.
+        # Set env vars before importing SDK modules so runtime config is honored.
+        if "FLEXKV_ENABLE_MPS" not in os.environ:
+            # In many containers, MPS directories are unavailable for non-root users.
+            # Defaulting to disabled avoids init timeout caused by MPS startup failure.
+            os.environ["FLEXKV_ENABLE_MPS"] = "0"
+        if self.mode == "server_client":
+            os.environ["FLEXKV_SERVER_CLIENT_MODE"] = "1"
+            os.environ["FLEXKV_SERVER_RECV_PORT"] = server_recv_port
+        else:
+            os.environ["FLEXKV_SERVER_CLIENT_MODE"] = "0"
+            # Use per-instance endpoint in direct mode to avoid cross-test/process leakage.
+            server_recv_port = f"ipc:///tmp/flexkv_server_{os.getpid()}_{id(self)}"
+            os.environ["FLEXKV_SERVER_RECV_PORT"] = server_recv_port
+        self._gpu_register_port = f"{server_recv_port}_gpu_register"
+
+        KVManager, ModelConfig, CacheConfig, _ = self._import_flexkv_sdk()
+        # Keep GLOBAL_CONFIG_FROM_ENV consistent even when module was imported earlier.
+        try:
+            from flexkv.common.config import GLOBAL_CONFIG_FROM_ENV
+
+            GLOBAL_CONFIG_FROM_ENV.server_client_mode = (self.mode == "server_client")
+            GLOBAL_CONFIG_FROM_ENV.server_recv_port = server_recv_port
+            GLOBAL_CONFIG_FROM_ENV.enable_mps = bool(
+                int(os.environ.get("FLEXKV_ENABLE_MPS", "0"))
+            )
+        except Exception:
+            pass
+
+        model_cfg = ModelConfig(
+            num_layers=self.num_layers,
+            num_kv_heads=self.num_heads,
+            head_size=self.head_dim,
+            tp_size=1,
+            dp_size=1,
+            dtype=torch.bfloat16,
+        )
+        cache_cfg = CacheConfig(tokens_per_block=self.page_size)
+
+        client = KVManager(
+            model_config=model_cfg,
+            cache_config=cache_cfg,
+            dp_client_id=0,
+            server_recv_port=server_recv_port,
+        )
+        client.start()
+        # IMPORTANT:
+        # FlexKV transfer manager becomes ready only after KVTPClient registers GPU blocks.
+        # Real registration is triggered by register_gpu_cache_tensors(), so do not block here.
+        return client
+
+    def _ensure_client_ready(self) -> None:
+        if self._ready:
+            return
+        init_timeout_s = float(os.environ.get("FLEXKV_CLIENT_INIT_TIMEOUT_S", "45"))
+        ready_grace_s = float(os.environ.get("FLEXKV_CLIENT_INIT_READY_GRACE_S", "30"))
+        deadline = time.time() + init_timeout_s
+        while not self._client.is_ready():
+            if time.time() > deadline:
+                # GPU blocks are already registered, but TransferEngine worker startup can
+                # still take extra time (e.g., large CPU pinning). Give a short grace window
+                # before treating it as hard timeout.
+                if self._registered and ready_grace_s > 0:
+                    grace_deadline = time.time() + ready_grace_s
+                    while not self._client.is_ready() and time.time() <= grace_deadline:
+                        time.sleep(0.05)
+                    if self._client.is_ready():
+                        self._ready = True
+                        return
+                raise RuntimeError(
+                    "FlexKV client init timeout: is_ready=False, "
+                    f"mode={self.mode}, timeout_s={init_timeout_s}, "
+                    f"ready_grace_s={ready_grace_s}, "
+                    f"enable_mps={os.environ.get('FLEXKV_ENABLE_MPS')}, "
+                    f"server_recv_port={os.environ.get('FLEXKV_SERVER_RECV_PORT', 'ipc:///tmp/flexkv_server')}, "
+                    f"gpu_registered={self._registered}, gpu_register_port={self._gpu_register_port}"
+                )
+            time.sleep(0.05)
+        self._ready = True
+
+    def register_gpu_cache_tensors(self, cache_table_list: List[torch.Tensor]) -> None:
+        if self._registered:
+            return
+        if cache_table_list is None or len(cache_table_list) == 0:
+            return
+        try:
+            from flexkv.server.client import KVTPClient
+            from flexkv.common.storage import KVCacheLayout, KVCacheLayoutType
+
+            # cache_table per-layer shape: [num_blocks, 2, tokens_per_block, num_heads, head_dim]
+            # FlexKV worker registration expects [2, num_blocks, tokens_per_block, num_heads, head_dim].
+            kv_caches = [layer.permute(1, 0, 2, 3, 4) for layer in cache_table_list]
+            first = kv_caches[0]
+            device_id = int(first.device.index if first.device.index is not None else 0)
+            gpu_layout = KVCacheLayout(
+                type=KVCacheLayoutType.LAYERFIRST,
+                num_layer=len(kv_caches),
+                num_block=int(first.shape[1]),
+                tokens_per_block=int(first.shape[2]),
+                num_head=int(first.shape[3]),
+                head_size=int(first.shape[4]),
+                is_mla=False,
+            )
+            tp_client = KVTPClient(
+                gpu_register_port=self._gpu_register_port,
+                dp_client_id=0,
+                device_id=device_id,
+            )
+            tp_client.register_to_server(kv_caches=kv_caches, kv_layout=gpu_layout)
+            self._registered = True
+            self._ensure_client_ready()
+        except Exception as e:
+            raise RuntimeError(f"FlexKV GPU cache registration failed: {e}") from e
+
     def _failed_wait_result(
         self,
         msg: str,
-        error_code: str = "flexkv_error",
+        error_code: str,
         failed_user_ids: Optional[List[int]] = None,
     ) -> SecondaryWaitResult:
         failed_mask = None
@@ -802,38 +1160,158 @@ class FlexKVStorageManager(SecondaryKVCacheManagerBase):
             failed_mask=failed_mask,
             failed_user_ids=failed_user_ids,
         )
+
+    def _wait_task_ids(self, task_ids: List[int]) -> Dict[int, Any]:
+        if len(task_ids) == 0:
+            return {}
+        if self.secondary_wait_timeout_ms > 0:
+            timeout_s = float(self.secondary_wait_timeout_ms) / 1000.0
+            return self._client.wait(task_ids, timeout=timeout_s, completely=True)
+        return self._client.try_wait(task_ids)
+
+    def _convert_wait_result(
+        self,
+        responses: Dict[int, Any],
+        user_ids: List[int],
+        timeout_code: str,
+        failed_code: str,
+    ) -> SecondaryWaitResult:
+        if responses is None:
+            return self._failed_wait_result(
+                msg="wait returned None",
+                error_code=failed_code,
+                failed_user_ids=user_ids,
+            )
+        if len(responses) == 0:
+            return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
+
+        has_timeout = False
+        has_cancelled = False
+        has_failed = False
+        status_msgs: List[str] = []
+        for task_id, resp in responses.items():
+            status_name = str(getattr(getattr(resp, "status", None), "name", "UNKNOWN"))
+            status_msgs.append(f"{task_id}:{status_name}")
+            if status_name == "SUCCESS":
+                continue
+            if status_name == "TIMEOUT":
+                has_timeout = True
+            elif status_name == "CANCELLED":
+                has_cancelled = True
+            else:
+                has_failed = True
+
+        if has_timeout:
+            return SecondaryWaitResult(
+                status=SecondaryTaskStatus.TIMEOUT,
+                ready=False,
+                error_code=timeout_code,
+                message=";".join(status_msgs),
+                failed_mask=torch.ones((len(user_ids),), dtype=torch.bool) if user_ids else None,
+                failed_user_ids=user_ids if user_ids else None,
+            )
+        if has_failed or has_cancelled:
+            status = SecondaryTaskStatus.CANCELLED if has_cancelled and not has_failed else SecondaryTaskStatus.FAILED
+            return SecondaryWaitResult(
+                status=status,
+                ready=False,
+                error_code=failed_code,
+                message=";".join(status_msgs),
+                failed_mask=torch.ones((len(user_ids),), dtype=torch.bool) if user_ids else None,
+                failed_user_ids=user_ids if user_ids else None,
+            )
+        return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
+
     def lookup_kvcache(self, index_meta: KVIndexMeta) -> Dict[str, Any]:
-        try:
-            req = self._adapter.to_get_match_request(index_meta)
-            resp = self._client.get_match(req)
-            return self._adapter.from_get_match_response(resp)
-        except Exception as e:
+        self._ensure_client_ready()
+        if index_meta.token_ids is None or index_meta.token_mask is None:
             return {
                 "backend": "flexkv",
-                "error": str(e),
+                "error_code": SecondaryErrorCode.LOOKUP_MISSING_TOKENS.value,
+                "task_ids": [],
+                "matched_lengths": [0] * index_meta.batch_size,
                 "hit_mask": None,
                 "restore_slot_mapping": None,
                 "append_slot_mapping": None,
             }
+        try:
+            requests = self._adapter.to_get_match_requests(index_meta)
+            task_ids: List[int] = []
+            matched_lengths: List[int] = []
+            hit_masks: List[np.ndarray] = []
+            for req in requests:
+                if req["token_ids"].size == 0:
+                    task_ids.append(-1)
+                    matched_lengths.append(0)
+                    hit_masks.append(np.zeros_like(req["token_mask"], dtype=np.bool_))
+                    continue
+                task_id, matched_mask = self._client.get_match(
+                    token_ids=req["token_ids"],
+                    token_mask=req["token_mask"],
+                    namespace=req["namespace"],
+                )
+                matched_mask = np.asarray(matched_mask, dtype=np.bool_)
+                task_ids.append(int(task_id))
+                matched_lengths.append(int(matched_mask.sum()))
+                hit_masks.append(matched_mask)
+            return self._adapter.from_get_match_responses(
+                index_meta=index_meta,
+                task_ids=task_ids,
+                matched_lengths=matched_lengths,
+                hit_masks=hit_masks,
+            )
+        except Exception as e:
+            return {
+                "backend": "flexkv",
+                "error": str(e),
+                "error_code": SecondaryErrorCode.LOOKUP_FAILED.value,
+                "task_ids": [],
+                "matched_lengths": [0] * index_meta.batch_size,
+                "hit_mask": None,
+                "restore_slot_mapping": None,
+                "append_slot_mapping": None,
+            }
+
     def onboard_launch_kvcache(
         self,
         index_meta: KVIndexMeta,
         restore_slot_mapping: Optional[torch.Tensor],
     ) -> SecondaryTaskHandle:
+        self._ensure_client_ready()
         endpoint = (
             f"{self.server_addr}:{self.server_port}"
             if self.mode == "server_client"
             else "local"
         )
         try:
-            req = self._adapter.to_launch_request("onboard", index_meta, restore_slot_mapping)
-            raw_handle = self._client.launch(req)
-            raw_handle = self._adapter.from_launch_response(raw_handle)
+            payload = self._adapter.to_onboard_launch_payload(index_meta, restore_slot_mapping)
+            task_ids: List[int] = payload["task_ids"]
+            slot_mappings: List[np.ndarray] = payload["slot_mappings"]
+            all_get_task_ids = [int(x) for x in (index_meta.secondary_get_task_ids or []) if int(x) >= 0]
+
+            if len(task_ids) == 0:
+                if len(all_get_task_ids) > 0:
+                    self._client.cancel(task_ids=all_get_task_ids)
+                return SecondaryTaskHandle(
+                    backend="flexkv",
+                    handle=None,
+                    status=SecondaryTaskStatus.SKIPPED,
+                    metadata={"reason": "no onboard restore blocks"},
+                )
+
+            launched = self._client.launch(
+                task_ids=task_ids,
+                slot_mappings=slot_mappings,
+                as_batch=True,
+            )
+            launched_ids = [int(x) for x in launched]
+            to_cancel = [tid for tid in all_get_task_ids if tid not in task_ids]
+            if len(to_cancel) > 0:
+                self._client.cancel(task_ids=to_cancel)
+
             task_key = f"onboard:{index_meta.request_id}"
             self._tasks[task_key] = {
-                "raw_handle": raw_handle,
-                "ready": False,
-                "error": None,
+                "task_ids": launched_ids,
                 "kind": "onboard",
                 "mode": self.mode,
                 "endpoint": endpoint,
@@ -843,7 +1321,7 @@ class FlexKVStorageManager(SecondaryKVCacheManagerBase):
                 backend="flexkv",
                 handle={
                     "task_key": task_key,
-                    "raw_handle": raw_handle,
+                    "task_ids": launched_ids,
                     "kind": "onboard",
                     "mode": self.mode,
                     "endpoint": endpoint,
@@ -857,105 +1335,90 @@ class FlexKVStorageManager(SecondaryKVCacheManagerBase):
                 status=SecondaryTaskStatus.FAILED,
                 metadata={
                     "error": str(e),
+                    "error_code": SecondaryErrorCode.ONBOARD_WAIT_FAILED.value,
                     "kind": "onboard",
                     "mode": self.mode,
                     "endpoint": endpoint,
                 },
             )
+
     def onboard_wait_kvcache(self, task_handle: SecondaryTaskHandle) -> SecondaryWaitResult:
         if task_handle is None or task_handle.handle is None:
             return SecondaryWaitResult(status=SecondaryTaskStatus.SKIPPED, ready=True)
         try:
             task_key = task_handle.handle.get("task_key")
-            state = self._tasks.get(task_key, None) if task_key is not None else None
+            state = self._tasks.get(task_key)
             if state is None:
                 return self._failed_wait_result(
-                    msg="task not found",
-                    error_code="onboard_task_not_found",
+                    msg="onboard task not found",
+                    error_code=SecondaryErrorCode.ONBOARD_TASK_NOT_FOUND.value,
                 )
-            if state.get("error"):
-                failed_user_ids = list(state.get("user_ids", []))
-                return self._failed_wait_result(
-                    msg=str(state["error"]),
-                    error_code="onboard_wait_failed",
-                    failed_user_ids=failed_user_ids if failed_user_ids else None,
-                )
-            if state.get("ready", False):
-                return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
-            raw_handle = task_handle.handle.get("raw_handle")
-            if raw_handle is None:
-                raw_handle = state.get("raw_handle")
-            if raw_handle is None:
-                return self._failed_wait_result(
-                    msg="onboard_wait missing raw_handle",
-                    error_code="onboard_missing_handle",
-                )
-            wait_req = self._adapter.to_wait_request(raw_handle, timeout_ms=0, op="onboard")
-            wait_resp = self._client.try_wait(wait_req)
-            parsed = self._adapter.from_wait_response(wait_resp)
-            if parsed.get("error"):
-                failed_user_ids = list(state.get("user_ids", []))
-                return self._failed_wait_result(
-                    msg=str(parsed["error"]),
-                    error_code="onboard_wait_failed",
-                    failed_user_ids=failed_user_ids if failed_user_ids else None,
-                )
-            if parsed.get("ready", False):
-                state["ready"] = True
-                return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
-            return SecondaryWaitResult(status=SecondaryTaskStatus.TIMEOUT, ready=False)
+            task_ids = list(state.get("task_ids", []))
+            responses = self._wait_task_ids(task_ids)
+            return self._convert_wait_result(
+                responses=responses,
+                user_ids=list(state.get("user_ids", [])),
+                timeout_code=SecondaryErrorCode.ONBOARD_TIMEOUT.value,
+                failed_code=SecondaryErrorCode.ONBOARD_WAIT_FAILED.value,
+            )
         except Exception as e:
-            return self._failed_wait_result(f"onboard_wait exception: {e}")
+            return self._failed_wait_result(
+                msg=f"onboard_wait exception: {e}",
+                error_code=SecondaryErrorCode.ONBOARD_WAIT_FAILED.value,
+            )
+
     def offload_launch_kvcache(
         self,
         index_meta: KVIndexMeta,
         append_slot_mapping: Optional[torch.Tensor],
         append_slot_indptr: Optional[torch.Tensor] = None,
     ) -> SecondaryTaskHandle:
+        self._ensure_client_ready()
         endpoint = (
             f"{self.server_addr}:{self.server_port}"
             if self.mode == "server_client"
             else "local"
         )
-        if self.mode == "server_client" and (not self.server_addr or self.server_port <= 0):
-            return SecondaryTaskHandle(
-                backend="flexkv",
-                handle=None,
-                status=SecondaryTaskStatus.FAILED,
-                metadata={
-                    "error": "missing_server_endpoint",
-                    "kind": "offload",
-                    "mode": self.mode,
-                    "endpoint": endpoint,
-                },
-            )
         try:
-            if append_slot_indptr is None:
-                append_slot_indptr = index_meta.append_slot_indptr
-            payload = {
-                "page_ids": append_slot_mapping,
-                "indptr": append_slot_indptr,
-            }
-            req = self._adapter.to_launch_request("offload", index_meta, payload)
-            raw_handle = self._client.launch(req)
-            raw_handle = self._adapter.from_launch_response(raw_handle)
+            reqs = self._adapter.to_offload_requests(
+                index_meta=index_meta,
+                append_slot_mapping=append_slot_mapping,
+                append_slot_indptr=append_slot_indptr,
+                tokens_per_block=self.page_size,
+            )
+            if len(reqs) == 0:
+                return SecondaryTaskHandle(
+                    backend="flexkv",
+                    handle=None,
+                    status=SecondaryTaskStatus.SKIPPED,
+                    metadata={"reason": "no offload blocks"},
+                )
+
+            task_ids: List[int] = []
+            req_user_ids: List[int] = []
+            for req in reqs:
+                task_id = self._client.put_async(
+                    token_ids=req["token_ids"],
+                    slot_mapping=req["slot_mapping"],
+                    token_mask=req["token_mask"],
+                    namespace=req["namespace"],
+                )
+                task_ids.append(int(task_id))
+                req_user_ids.append(int(req["user_id"]))
+
             task_key = f"offload:{index_meta.request_id}"
             self._tasks[task_key] = {
-                "raw_handle": raw_handle,
-                "ready": False,
-                "error": None,
+                "task_ids": task_ids,
                 "kind": "offload",
                 "mode": self.mode,
                 "endpoint": endpoint,
-                "request_id": index_meta.request_id,
-                "user_ids": list(index_meta.user_ids),
-                "append_slot_indptr": append_slot_indptr,
+                "user_ids": req_user_ids,
             }
             return SecondaryTaskHandle(
                 backend="flexkv",
                 handle={
                     "task_key": task_key,
-                    "raw_handle": raw_handle,
+                    "task_ids": task_ids,
                     "kind": "offload",
                     "mode": self.mode,
                     "endpoint": endpoint,
@@ -970,136 +1433,196 @@ class FlexKVStorageManager(SecondaryKVCacheManagerBase):
                 status=SecondaryTaskStatus.FAILED,
                 metadata={
                     "error": str(e),
+                    "error_code": SecondaryErrorCode.OFFLOAD_WAIT_FAILED.value,
                     "kind": "offload",
                     "mode": self.mode,
                     "endpoint": endpoint,
                 },
             )
+
     def offload_wait_kvcache(self, task_handle: SecondaryTaskHandle) -> SecondaryWaitResult:
         if task_handle is None or task_handle.handle is None:
             return SecondaryWaitResult(status=SecondaryTaskStatus.SKIPPED, ready=True)
         try:
             task_key = task_handle.handle.get("task_key")
-            state = self._tasks.get(task_key, None) if task_key is not None else None
+            state = self._tasks.get(task_key)
             if state is None:
                 return self._failed_wait_result(
-                    msg="task not found",
-                    error_code="offload_task_not_found",
+                    msg="offload task not found",
+                    error_code=SecondaryErrorCode.OFFLOAD_TASK_NOT_FOUND.value,
                 )
-            if state.get("error"):
-                failed_user_ids = list(state.get("user_ids", []))
-                return self._failed_wait_result(
-                    msg=str(state["error"]),
-                    error_code="offload_wait_failed",
-                    failed_user_ids=failed_user_ids if failed_user_ids else None,
-                )
-            if state.get("ready", False):
-                return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
-            raw_handle = task_handle.handle.get("raw_handle")
-            if raw_handle is None:
-                raw_handle = state.get("raw_handle")
-            if raw_handle is None:
-                return self._failed_wait_result(
-                    msg="offload_wait missing raw_handle",
-                    error_code="offload_missing_handle",
-                )
-            wait_req = self._adapter.to_wait_request(raw_handle, timeout_ms=0, op="offload")
-            wait_resp = self._client.try_wait(wait_req)
-            parsed = self._adapter.from_wait_response(wait_resp)
-            if parsed.get("error"):
-                failed_user_ids = list(state.get("user_ids", []))
-                return self._failed_wait_result(
-                    msg=str(parsed["error"]),
-                    error_code="offload_wait_failed",
-                    failed_user_ids=failed_user_ids if failed_user_ids else None,
-                )
-            if parsed.get("ready", False):
-                state["ready"] = True
-                return SecondaryWaitResult(status=SecondaryTaskStatus.READY, ready=True)
-            return SecondaryWaitResult(status=SecondaryTaskStatus.TIMEOUT, ready=False)
+            task_ids = list(state.get("task_ids", []))
+            responses = self._wait_task_ids(task_ids)
+            return self._convert_wait_result(
+                responses=responses,
+                user_ids=list(state.get("user_ids", [])),
+                timeout_code=SecondaryErrorCode.OFFLOAD_TIMEOUT.value,
+                failed_code=SecondaryErrorCode.OFFLOAD_WAIT_FAILED.value,
+            )
         except Exception as e:
-            return self._failed_wait_result(f"offload_wait exception: {e}")
+            return self._failed_wait_result(
+                msg=f"offload_wait exception: {e}",
+                error_code=SecondaryErrorCode.OFFLOAD_WAIT_FAILED.value,
+            )
+
     def cancel_task(self, task_handle: SecondaryTaskHandle) -> None:
         if task_handle is None or task_handle.handle is None:
             return
         task_key = task_handle.handle.get("task_key")
-        if task_key in self._tasks:
-            del self._tasks[task_key]    
-
-class _MockFlexKVClient:
-    def get_match(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        return {
-            "hit_mask": None,
-            "restore_slot_mapping": None,
-            "append_slot_mapping": None,
-        }
-    def launch(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        return {"request": request, "handle": "mock_handle"}
-    def wait(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        return {"ready": True}
-    def try_wait(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        return {"ready": True}
+        state = self._tasks.get(task_key)
+        if state is None:
+            return
+        task_ids = list(state.get("task_ids", []))
+        if len(task_ids) > 0:
+            try:
+                self._client.cancel(task_ids=task_ids)
+            except Exception:
+                pass
+        self._tasks.pop(task_key, None)
 
 class FlexKVClientAdapter:
     def __init__(self, mode: str, server_addr: str = "", server_port: int = 0):
         self.mode = mode
         self.server_addr = server_addr
         self.server_port = server_port
-    def to_get_match_request(self, index_meta: KVIndexMeta) -> Dict[str, Any]:
-        return {
-            "request_id": index_meta.request_id,
-            "mode": self.mode,
-            "user_ids": list(index_meta.user_ids),
-            "namespaces": list(index_meta.namespaces),
-            "total_history_lengths": list(index_meta.total_history_lengths),
-            "old_cached_lengths": list(index_meta.old_cached_lengths),
-            "seq_start_indices": list(index_meta.seq_start_indices),
-            "seq_lengths": list(index_meta.seq_lengths),
-        }
-    def from_get_match_response(self, resp: Dict[str, Any]) -> Dict[str, Any]:
+
+    def _to_numpy_2d(self, x: Optional[torch.Tensor], dtype) -> Optional[np.ndarray]:
+        if x is None:
+            return None
+        arr = x.detach().cpu().numpy()
+        return arr.astype(dtype)
+
+    def to_get_match_requests(self, index_meta: KVIndexMeta) -> List[Dict[str, Any]]:
+        token_ids_2d = self._to_numpy_2d(index_meta.token_ids, np.int64)
+        token_mask_2d = self._to_numpy_2d(index_meta.token_mask, np.bool_)
+        if token_ids_2d is None or token_mask_2d is None:
+            return []
+        reqs: List[Dict[str, Any]] = []
+        for i in range(index_meta.batch_size):
+            row_ids = token_ids_2d[i]
+            row_mask = token_mask_2d[i]
+            true_idx = np.where(row_mask)[0]
+            if true_idx.size == 0:
+                reqs.append(
+                    {
+                        "user_id": int(index_meta.user_ids[i]),
+                        "namespace": [index_meta.namespaces[i]],
+                        "token_ids": np.zeros((0,), dtype=np.int64),
+                        "token_mask": np.zeros((0,), dtype=np.bool_),
+                    }
+                )
+                continue
+            end = int(true_idx[-1]) + 1
+            reqs.append(
+                {
+                    "user_id": int(index_meta.user_ids[i]),
+                    "namespace": [index_meta.namespaces[i]],
+                    "token_ids": row_ids[:end].astype(np.int64),
+                    "token_mask": row_mask[:end].astype(np.bool_),
+                }
+            )
+        return reqs
+
+    def from_get_match_responses(
+        self,
+        index_meta: KVIndexMeta,
+        task_ids: List[int],
+        matched_lengths: List[int],
+        hit_masks: List[np.ndarray],
+    ) -> Dict[str, Any]:
+        batch_size = index_meta.batch_size
+        max_len = 0
+        if index_meta.token_mask is not None:
+            max_len = int(index_meta.token_mask.shape[1])
+        elif len(hit_masks) > 0:
+            max_len = max(int(m.shape[0]) for m in hit_masks)
+        hit_mask_2d = np.zeros((batch_size, max_len), dtype=np.bool_)
+        for i, m in enumerate(hit_masks):
+            if i >= batch_size:
+                break
+            upto = min(max_len, int(m.shape[0]))
+            hit_mask_2d[i, :upto] = m[:upto]
         return {
             "backend": "flexkv",
-            "hit_mask": resp.get("hit_mask"),
-            "restore_slot_mapping": resp.get("restore_slot_mapping"),
-            "append_slot_mapping": resp.get("append_slot_mapping"),
+            "task_ids": task_ids,
+            "matched_lengths": matched_lengths,
+            "hit_mask": torch.from_numpy(hit_mask_2d).to(torch.bool) if max_len > 0 else None,
+            "restore_slot_mapping": None,
+            "append_slot_mapping": None,
         }
-    def to_launch_request(self, op: str, index_meta: KVIndexMeta, payload: Any) -> Dict[str, Any]:
-        if op == "offload":
-            page_ids = None
-            indptr = None
-            if isinstance(payload, dict):
-                page_ids = payload.get("page_ids")
-                indptr = payload.get("indptr")
-            return {
-                "op": op,
-                "request_id": index_meta.request_id,
-                "mode": self.mode,
-                "user_ids": list(index_meta.user_ids),
-                "namespaces": list(index_meta.namespaces),
-                "page_ids": page_ids,
-                "indptr": indptr,
-            }
-        return {
-            "op": op,
-            "request_id": index_meta.request_id,
-            "mode": self.mode,
-            "user_ids": list(index_meta.user_ids),
-            "namespaces": list(index_meta.namespaces),
-            "payload": payload,
-        }
-    def from_launch_response(self, resp: Any) -> Any:
-        return resp
-    def to_wait_request(self, raw_handle: Any, timeout_ms: int = 0, op: str = "") -> Dict[str, Any]:
-        return {
-            "op": op,
-            "mode": self.mode,
-            "raw_handle": raw_handle,
-            "timeout_ms": int(timeout_ms),
-        }
-    def from_wait_response(self, resp: Dict[str, Any]) -> Dict[str, Any]:
-        return {
-            "ready": bool(resp.get("ready", False)),
-            "error": resp.get("error"),
-        }
+
+    def to_onboard_launch_payload(
+        self,
+        index_meta: KVIndexMeta,
+        restore_slot_mapping: Any,
+    ) -> Dict[str, Any]:
+        if not isinstance(restore_slot_mapping, dict):
+            return {"task_ids": [], "slot_mappings": []}
+        task_ids = [int(x) for x in restore_slot_mapping.get("task_ids", [])]
+        slot_mappings = [
+            np.asarray(x, dtype=np.int64) for x in restore_slot_mapping.get("slot_mappings", [])
+        ]
+        valid_task_ids: List[int] = []
+        valid_slot_mappings: List[np.ndarray] = []
+        for t, s in zip(task_ids, slot_mappings):
+            if s.ndim != 1 or s.size == 0:
+                continue
+            valid_task_ids.append(t)
+            valid_slot_mappings.append(s)
+        return {"task_ids": valid_task_ids, "slot_mappings": valid_slot_mappings}
+
+    def to_offload_requests(
+        self,
+        index_meta: KVIndexMeta,
+        append_slot_mapping: Optional[torch.Tensor],
+        append_slot_indptr: Optional[torch.Tensor],
+        tokens_per_block: int,
+    ) -> List[Dict[str, Any]]:
+        if append_slot_mapping is None or append_slot_indptr is None:
+            return []
+        if index_meta.token_ids is None or index_meta.token_mask is None:
+            return []
+
+        page_ids = append_slot_mapping.to(torch.int64).detach().cpu().numpy()
+        indptr = append_slot_indptr.to(torch.int64).detach().cpu().numpy()
+        token_ids_2d = index_meta.token_ids.to(torch.int64).detach().cpu().numpy()
+        token_mask_2d = index_meta.token_mask.to(torch.bool).detach().cpu().numpy()
+        matched_lengths = index_meta.secondary_matched_lengths or []
+
+        reqs: List[Dict[str, Any]] = []
+        for i in range(index_meta.batch_size):
+            p0 = int(indptr[i])
+            p1 = int(indptr[i + 1])
+            if p1 <= p0:
+                continue
+            req_pages = page_ids[p0:p1]
+            slot_mapping_full = np.repeat(req_pages * tokens_per_block, tokens_per_block).astype(np.int64)
+
+            row_ids = token_ids_2d[i]
+            row_mask = token_mask_2d[i]
+            valid_token_ids = row_ids[row_mask]
+
+            old_cached = int(index_meta.old_cached_lengths[i])
+            if i < len(matched_lengths):
+                old_cached = max(old_cached, int(matched_lengths[i]))
+
+            append_token_ids = valid_token_ids[old_cached:]
+        
+            aligned = (append_token_ids.size // tokens_per_block) * tokens_per_block
+            aligned = min(aligned, slot_mapping_full.size)
+            if aligned <= 0:
+                continue
+
+            reqs.append(
+                {
+                    "user_id": int(index_meta.user_ids[i]),
+                    "namespace": [index_meta.namespaces[i]],
+                    "token_ids": append_token_ids[:aligned].astype(np.int64),
+                    "token_mask": np.ones((aligned,), dtype=np.bool_),
+                    "slot_mapping": slot_mapping_full[:aligned].astype(np.int64),
+                }
+            )
+        return reqs
+
 
 AsyncHSTUKVCacheManager = KVCacheManager

--- a/examples/hstu/modules/inference_dense_module.py
+++ b/examples/hstu/modules/inference_dense_module.py
@@ -377,6 +377,12 @@ class InferenceDenseModule(torch.nn.Module):
                 metadata_gpu_buffer,  # returned static
                 self.async_kvcache.static_onload_handle,
             )
+            
+            self.async_kvcache.materialize_append_mapping_from_metadata(
+                kv_index_meta,
+                kvcache_metadata,
+            )
+
             self.async_kvcache.offload_kvcache(kvcache_metadata)
             kvcache_metadata.total_history_offsets += jagged_data.num_candidates_offsets
             kvcache_metadata.total_history_lengths += jagged_data.num_candidates

--- a/examples/hstu/modules/inference_dense_module.py
+++ b/examples/hstu/modules/inference_dense_module.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import math
 import os
 from typing import Any, Dict, List, Optional, Union
 
@@ -203,34 +202,9 @@ class InferenceDenseModule(torch.nn.Module):
         self._use_kvcache = False
         if kvcache_config is not None:
             self._use_kvcache = True
-            from modules.async_kvcache_manager import AsyncHSTUKVCacheManager
+            from modules.async_kvcache_manager import KVCacheManager
 
-            if kvcache_config.max_queued_offload_tokens is None:
-                kvcache_config.max_queued_offload_tokens = (
-                    4 * hstu_config.max_batch_size * hstu_config.max_seq_len
-                )
-            self.async_kvcache = AsyncHSTUKVCacheManager(
-                hstu_config.num_layers,
-                hstu_config.num_heads,
-                hstu_config.head_dim,
-                kvcache_config.page_size,
-                kvcache_config.blocks_in_primary_pool,
-                math.ceil(
-                    hstu_config.max_batch_size
-                    * hstu_config.max_seq_len
-                    / kvcache_config.page_size
-                ),
-                0,
-                kvcache_config.offload_chunksize,
-                -1,
-                hstu_config.max_seq_len,
-                hstu_config.max_batch_size,
-                kvcache_config.max_queued_offload_tokens,
-                kvcache_config.num_onload_buffer_chunks,
-                kvcache_config.num_offload_buffer_chunks,
-                kvcache_config.num_memcpy_workers,
-                kvcache_config.enable_nvcomp,
-            )
+            self.async_kvcache = KVCacheManager.from_config(hstu_config, kvcache_config)
 
     def setup_for_cudagraph(
         self, hstu_config, kvcache_config, use_cudagraph, cudagraph_configs
@@ -345,18 +319,20 @@ class InferenceDenseModule(torch.nn.Module):
         embeddings: Dict[str, JaggedTensor],
         user_ids: torch.Tensor,
         total_history_lengths: torch.Tensor,
-        prepare_kvcache_result: List,
+        prepare_kvcache_result: Any,
+        kv_index_meta: Optional[Any] = None,
+        lookup_result: Optional[Any] = None,
     ):
         with torch.inference_mode():
-            (
-                old_cached_lengths,
-                num_history_tokens,
-                offload_uids_buffer,
-                metadata_host_buffer,
-                metadata_gpu_buffer,  # returned static
-                kvcache_metadata_fut,
-                onload_fut,
-            ) = prepare_kvcache_result
+            old_cached_lengths = torch.tensor(
+                prepare_kvcache_result.old_cached_lengths, dtype=torch.int32
+            )
+            num_history_tokens = prepare_kvcache_result.new_tokens
+            offload_uids_buffer = prepare_kvcache_result.offload_uids_buffer
+            metadata_host_buffer = prepare_kvcache_result.metadata_host_buffer
+            metadata_gpu_buffer = prepare_kvcache_result.metadata_gpu_buffer
+            kvcache_metadata_fut = prepare_kvcache_result.kvcache_metadata_fut
+            onload_fut = prepare_kvcache_result.onload_fut
 
             jagged_data = self._hstu_block._preprocessor(
                 embeddings=embeddings,
@@ -377,13 +353,27 @@ class InferenceDenseModule(torch.nn.Module):
                 metadata_gpu_buffer,  # returned static
                 self.async_kvcache.static_onload_handle,
             )
-            
+            # 1) 先基于 prepare 后的真实 kv metadata 生成 restore 映射
+            self.async_kvcache.materialize_restore_mapping_from_metadata(
+                kv_index_meta,
+                kvcache_metadata,
+            )
+            # 2) 再 launch + wait onboard（把命中的 prefix 拉回 GPU）
+            if kv_index_meta is not None and lookup_result is not None:
+                onboard_task_handle_local = self.async_kvcache.onboard_launch_kvcache(
+                    kv_index_meta
+                )
+                self.async_kvcache.onboard_try_wait_kvcache_or_fail(
+                    kv_index_meta,
+                    onboard_task_handle_local,
+                )
+            # 3) onboard 完成后，再做 append 映射和 offload
             self.async_kvcache.materialize_append_mapping_from_metadata(
                 kv_index_meta,
                 kvcache_metadata,
             )
-
             self.async_kvcache.offload_kvcache(kvcache_metadata)
+            
             kvcache_metadata.total_history_offsets += jagged_data.num_candidates_offsets
             kvcache_metadata.total_history_lengths += jagged_data.num_candidates
             kvcache_metadata.max_seqlen += jagged_data.max_num_candidates

--- a/examples/hstu/test/test_flexkv_integration.py
+++ b/examples/hstu/test/test_flexkv_integration.py
@@ -1,0 +1,82 @@
+import pytest
+import torch
+from configs import get_inference_hstu_config, get_kvcache_config
+from modules.async_kvcache_manager import AsyncHSTUKVCacheManager, SecondaryTaskStatus
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def _build_mgr(mode="direct", fail_policy="fail_open"):
+    hstu = get_inference_hstu_config(
+        hidden_size=128, num_layers=2, num_attention_heads=2, head_dim=64,
+        max_batch_size=4, max_seq_len=256, dtype=torch.bfloat16
+    )
+    kv = get_kvcache_config(
+        blocks_in_primary_pool=512, page_size=32, offload_chunksize=128,
+        secondary_backend="flexkv", flexkv_mode=mode, secondary_fail_policy=fail_policy
+    )
+    mgr = AsyncHSTUKVCacheManager.from_config(hstu, kv)
+    return mgr
+def _shutdown(mgr):
+    if hasattr(mgr, "executor"):
+        mgr.executor.shutdown(wait=False)
+    if hasattr(mgr, "onload_worker"):
+        mgr.onload_worker.shutdown(wait=False)
+def test_flexkv_lookup_onboard_offload_smoke():
+    mgr = _build_mgr(mode="direct")
+    try:
+        user_ids = [11, 22]
+        lengths = [64, 96]
+        lookup = mgr.lookup_kvcache(user_ids, lengths)
+        index_meta, _ = mgr.allocate_kvcache(user_ids, lookup)
+        onboard = mgr.onboard_launch_kvcache(user_ids, index_meta, lookup)
+        wait = mgr.onboard_try_wait_kvcache_or_fail(user_ids, index_meta, lookup, onboard)
+        assert wait is None or wait.ready
+        offload = mgr.lazy_offload_kvcache(user_ids, index_meta, lookup)
+        assert offload is not None
+        mgr.finish_or_cancel_kvcache_ops(uid_or_uids=user_ids, kv_index_meta=index_meta)
+    finally:
+        _shutdown(mgr)
+def test_flexkv_task_handle_contract():
+    mgr = _build_mgr(mode="direct")
+    try:
+        lookup = mgr.lookup_kvcache([1], [32])
+        idx, _ = mgr.allocate_kvcache([1], lookup)
+        task = mgr.onboard_launch_kvcache([1], idx, lookup)
+        assert task.backend == "flexkv"
+        assert task.handle is not None
+        assert "task_key" in task.handle
+    finally:
+        _shutdown(mgr)
+def test_flexkv_server_client_mode_smoke():
+    mgr = _build_mgr(mode="server_client")
+    try:
+        lookup = mgr.lookup_kvcache([1], [32])
+        idx, _ = mgr.allocate_kvcache([1], lookup)
+        task = mgr.onboard_launch_kvcache([1], idx, lookup)
+        assert task.handle["mode"] == "server_client"
+    finally:
+        _shutdown(mgr)
+
+@pytest.mark.parametrize("fail_policy,should_raise", [
+    ("fail_open", False),
+    ("fail_close", True),
+])
+def test_flexkv_fail_policy_behavior(fail_policy, should_raise):
+    mgr = _build_mgr(mode="direct", fail_policy=fail_policy)
+    try:
+        lookup = mgr.lookup_kvcache([1], [32])
+        idx, _ = mgr.allocate_kvcache([1], lookup)
+        handle = mgr.onboard_launch_kvcache([1], idx, lookup)
+
+        # 注入失败：模拟 wait 路径异常
+        if handle and handle.handle and "task_key" in handle.handle:
+            task_key = handle.handle["task_key"]
+            mgr.secondary_kvcache_manager._tasks[task_key]["error"] = "mock_wait_failed"
+
+        if should_raise:
+            with pytest.raises(RuntimeError):
+                mgr.onboard_try_wait_kvcache_or_fail([1], idx, lookup, handle)
+        else:
+            result = mgr.onboard_try_wait_kvcache_or_fail([1], idx, lookup, handle)
+            assert result is not None
+            assert result.status == SecondaryTaskStatus.FAILED
+    finally:
+        _shutdown(mgr)

--- a/examples/hstu/test/test_flexkv_integration.py
+++ b/examples/hstu/test/test_flexkv_integration.py
@@ -1,56 +1,224 @@
+import gc
+import os
+import time
+from uuid import uuid4
+
 import pytest
 import torch
+import numpy as np
+from types import SimpleNamespace
 from configs import get_inference_hstu_config, get_kvcache_config
-from modules.async_kvcache_manager import AsyncHSTUKVCacheManager, SecondaryTaskStatus
+from modules.async_kvcache_manager import (
+    AsyncHSTUKVCacheManager,
+    FlexKVClientAdapter,
+    FlexKVStorageManager,
+    KVIndexMeta,
+    SecondaryErrorCode,
+    SecondaryTaskHandle,
+    SecondaryTaskStatus,
+    SecondaryWaitResult,
+)
+
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+def _new_ipc_endpoint(prefix: str) -> str:
+    return f"ipc:///tmp/{prefix}_{os.getpid()}_{uuid4().hex}"
+
+
+def _cleanup_cuda_and_gc() -> None:
+    if torch.cuda.is_available():
+        try:
+            torch.cuda.synchronize()
+        except Exception:
+            pass
+        try:
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+    gc.collect()
+
+
+def _cancel_secondary_tasks(secondary_mgr) -> None:
+    tasks = getattr(secondary_mgr, "_tasks", None)
+    client = getattr(secondary_mgr, "_client", None)
+    if not isinstance(tasks, dict) or client is None:
+        return
+    for state in list(tasks.values()):
+        task_ids = [int(x) for x in state.get("task_ids", []) if int(x) >= 0]
+        if len(task_ids) == 0:
+            continue
+        try:
+            client.cancel(task_ids=task_ids)
+        except Exception:
+            pass
+    tasks.clear()
+
+
+def _build_lookup_tokens(lengths):
+    max_len = max(int(x) for x in lengths) if len(lengths) > 0 else 0
+    token_ids = torch.zeros((len(lengths), max_len), dtype=torch.int64)
+    token_mask = torch.zeros((len(lengths), max_len), dtype=torch.bool)
+    for i, ln in enumerate(lengths):
+        ln = int(ln)
+        if ln <= 0:
+            continue
+        token_ids[i, :ln] = torch.arange(1, ln + 1, dtype=torch.int64) + i * 1000
+        token_mask[i, :ln] = True
+    return token_ids, token_mask
+
+
 def _build_mgr(mode="direct", fail_policy="fail_open"):
     hstu = get_inference_hstu_config(
         hidden_size=128, num_layers=2, num_attention_heads=2, head_dim=64,
         max_batch_size=4, max_seq_len=256, dtype=torch.bfloat16
     )
+    extra_kv_args = {}
+    if mode == "server_client":
+        # server_client mode requires an explicit endpoint in current manager contract.
+        extra_kv_args.update(
+            flexkv_server_addr=_new_ipc_endpoint("flexkv_server_pytest"),
+            flexkv_server_port=0,
+        )
     kv = get_kvcache_config(
         blocks_in_primary_pool=512, page_size=32, offload_chunksize=128,
-        secondary_backend="flexkv", flexkv_mode=mode, secondary_fail_policy=fail_policy
+        secondary_backend="flexkv", flexkv_mode=mode, secondary_fail_policy=fail_policy,
+        **extra_kv_args,
     )
     mgr = AsyncHSTUKVCacheManager.from_config(hstu, kv)
     return mgr
+
+
 def _shutdown(mgr):
+    secondary = getattr(mgr, "secondary_kvcache_manager", None)
+    try:
+        mgr.finish_or_cancel_kvcache_ops()
+    except Exception:
+        pass
+    if secondary is not None:
+        _cancel_secondary_tasks(secondary)
+    client = getattr(secondary, "_client", None) if secondary is not None else None
+    if client is not None:
+        try:
+            client.shutdown()
+        except Exception:
+            pass
     if hasattr(mgr, "executor"):
-        mgr.executor.shutdown(wait=False)
+        try:
+            mgr.executor.shutdown(wait=True, cancel_futures=True)
+        except TypeError:
+            mgr.executor.shutdown(wait=True)
     if hasattr(mgr, "onload_worker"):
-        mgr.onload_worker.shutdown(wait=False)
+        try:
+            mgr.onload_worker.shutdown(wait=True, cancel_futures=True)
+        except TypeError:
+            mgr.onload_worker.shutdown(wait=True)
+    time.sleep(0.05)
+    _cleanup_cuda_and_gc()
+
+
+def _shutdown_storage_mgr(storage_mgr):
+    _cancel_secondary_tasks(storage_mgr)
+    client = getattr(storage_mgr, "_client", None)
+    if client is not None:
+        try:
+            client.shutdown()
+        except Exception:
+            pass
+    time.sleep(0.05)
+    _cleanup_cuda_and_gc()
+
 def test_flexkv_lookup_onboard_offload_smoke():
     mgr = _build_mgr(mode="direct")
     try:
         user_ids = [11, 22]
         lengths = [64, 96]
-        lookup = mgr.lookup_kvcache(user_ids, lengths)
-        index_meta, _ = mgr.allocate_kvcache(user_ids, lookup)
-        onboard = mgr.onboard_launch_kvcache(user_ids, index_meta, lookup)
-        wait = mgr.onboard_try_wait_kvcache_or_fail(user_ids, index_meta, lookup, onboard)
+        token_ids, token_mask = _build_lookup_tokens(lengths)
+        lookup = mgr.lookup_kvcache(
+            user_ids,
+            lengths,
+            token_ids=token_ids,
+            token_mask=token_mask,
+        )
+        index_meta, _ = mgr.allocate_kvcache(lookup)
+        onboard = mgr.onboard_launch_kvcache(index_meta)
+        wait = mgr.onboard_try_wait_kvcache_or_fail(index_meta, onboard)
         assert wait is None or wait.ready
-        offload = mgr.lazy_offload_kvcache(user_ids, index_meta, lookup)
+        offload = mgr.lazy_offload_kvcache(index_meta)
         assert offload is not None
-        mgr.finish_or_cancel_kvcache_ops(uid_or_uids=user_ids, kv_index_meta=index_meta)
+        mgr.finish_or_cancel_kvcache_ops(kv_index_meta=index_meta)
     finally:
         _shutdown(mgr)
+
+def test_flexkv_lookup_with_token_ids_and_mask():
+    mgr = _build_mgr(mode="direct")
+    try:
+        user_ids = [101, 202]
+        lengths = [6, 4]
+        token_ids = torch.tensor(
+            [
+                [11, 12, 13, 14, 15, 16],
+                [21, 22, 23, 24, 0, 0],
+            ],
+            dtype=torch.int64,
+        )
+        token_mask = torch.tensor(
+            [
+                [1, 1, 1, 1, 1, 1],
+                [1, 1, 1, 1, 0, 0],
+            ],
+            dtype=torch.bool,
+        )
+        lookup = mgr.lookup_kvcache(
+            user_ids,
+            lengths,
+            token_ids=token_ids,
+            token_mask=token_mask,
+        )
+        assert lookup.token_ids is not None
+        assert lookup.token_mask is not None
+        assert lookup.token_ids.shape == token_ids.shape
+        assert lookup.token_mask.shape == token_mask.shape
+        assert isinstance(lookup.secondary_lookup, dict)
+        assert lookup.secondary_lookup.get("backend") == "flexkv"
+        hit_mask = lookup.secondary_lookup.get("hit_mask")
+        assert hit_mask is None or hit_mask.shape == token_mask.shape
+    finally:
+        _shutdown(mgr)
+
 def test_flexkv_task_handle_contract():
     mgr = _build_mgr(mode="direct")
     try:
-        lookup = mgr.lookup_kvcache([1], [32])
-        idx, _ = mgr.allocate_kvcache([1], lookup)
-        task = mgr.onboard_launch_kvcache([1], idx, lookup)
+        token_ids, token_mask = _build_lookup_tokens([32])
+        lookup = mgr.lookup_kvcache([1], [32], token_ids=token_ids, token_mask=token_mask)
+        idx, _ = mgr.allocate_kvcache(lookup)
+        real_task_ids = [int(x) for x in (idx.secondary_get_task_ids or []) if int(x) >= 0]
+        assert len(real_task_ids) > 0
+        idx.restore_slot_mapping = {
+            "task_ids": [real_task_ids[0]],
+            "slot_mappings": [np.array([0], dtype=np.int64)],
+        }
+        task = mgr.onboard_launch_kvcache(idx)
         assert task.backend == "flexkv"
         assert task.handle is not None
         assert "task_key" in task.handle
     finally:
         _shutdown(mgr)
+
+
 def test_flexkv_server_client_mode_smoke():
     mgr = _build_mgr(mode="server_client")
     try:
-        lookup = mgr.lookup_kvcache([1], [32])
-        idx, _ = mgr.allocate_kvcache([1], lookup)
-        task = mgr.onboard_launch_kvcache([1], idx, lookup)
+        token_ids, token_mask = _build_lookup_tokens([32])
+        lookup = mgr.lookup_kvcache([1], [32], token_ids=token_ids, token_mask=token_mask)
+        idx, _ = mgr.allocate_kvcache(lookup)
+        real_task_ids = [int(x) for x in (idx.secondary_get_task_ids or []) if int(x) >= 0]
+        assert len(real_task_ids) > 0
+        idx.restore_slot_mapping = {
+            "task_ids": [real_task_ids[0]],
+            "slot_mappings": [np.array([0], dtype=np.int64)],
+        }
+        task = mgr.onboard_launch_kvcache(idx)
         assert task.handle["mode"] == "server_client"
     finally:
         _shutdown(mgr)
@@ -62,21 +230,190 @@ def test_flexkv_server_client_mode_smoke():
 def test_flexkv_fail_policy_behavior(fail_policy, should_raise):
     mgr = _build_mgr(mode="direct", fail_policy=fail_policy)
     try:
-        lookup = mgr.lookup_kvcache([1], [32])
-        idx, _ = mgr.allocate_kvcache([1], lookup)
-        handle = mgr.onboard_launch_kvcache([1], idx, lookup)
-
-        # 注入失败：模拟 wait 路径异常
-        if handle and handle.handle and "task_key" in handle.handle:
-            task_key = handle.handle["task_key"]
-            mgr.secondary_kvcache_manager._tasks[task_key]["error"] = "mock_wait_failed"
+        token_ids, token_mask = _build_lookup_tokens([32])
+        lookup = mgr.lookup_kvcache([1], [32], token_ids=token_ids, token_mask=token_mask)
+        idx, _ = mgr.allocate_kvcache(lookup)
+        real_task_ids = [int(x) for x in (idx.secondary_get_task_ids or []) if int(x) >= 0]
+        assert len(real_task_ids) > 0
+        idx.restore_slot_mapping = {
+            "task_ids": [real_task_ids[0]],
+            "slot_mappings": [np.array([0], dtype=np.int64)],
+        }
+        handle = mgr.onboard_launch_kvcache(idx)
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(
+            mgr.secondary_kvcache_manager,
+            "onboard_wait_kvcache",
+            lambda _task_handle: SecondaryWaitResult(
+                status=SecondaryTaskStatus.FAILED,
+                ready=False,
+                error_code=SecondaryErrorCode.ONBOARD_WAIT_FAILED.value,
+                message="mock onboard failed",
+            ),
+        )
 
         if should_raise:
             with pytest.raises(RuntimeError):
-                mgr.onboard_try_wait_kvcache_or_fail([1], idx, lookup, handle)
+                mgr.onboard_try_wait_kvcache_or_fail(idx, handle)
         else:
-            result = mgr.onboard_try_wait_kvcache_or_fail([1], idx, lookup, handle)
+            result = mgr.onboard_try_wait_kvcache_or_fail(idx, handle)
             assert result is not None
             assert result.status == SecondaryTaskStatus.FAILED
     finally:
+        if 'monkeypatch' in locals():
+            monkeypatch.undo()
         _shutdown(mgr)
+
+
+def test_append_slot_mapping_indptr_to_slot_mapping_contract():
+    adapter = FlexKVClientAdapter(mode="direct")
+    page_size = 4
+    index_meta = KVIndexMeta(
+        request_id="req-append-contract",
+        batch_size=1,
+        user_ids=[7],
+        namespaces=["uid:7"],
+        total_history_lengths=[8],
+        old_cached_lengths=[0],
+        seq_start_indices=[0],
+        seq_lengths=[8],
+        new_tokens=8,
+        token_ids=torch.tensor([[11, 12, 13, 14, 15, 16, 17, 18]], dtype=torch.int64),
+        token_mask=torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1]], dtype=torch.bool),
+        secondary_matched_lengths=[0],
+    )
+    append_slot_mapping = torch.tensor([3, 4], dtype=torch.int64)   # 2 pages
+    append_slot_indptr = torch.tensor([0, 2], dtype=torch.int64)
+    reqs = adapter.to_offload_requests(
+        index_meta=index_meta,
+        append_slot_mapping=append_slot_mapping,
+        append_slot_indptr=append_slot_indptr,
+        tokens_per_block=page_size,
+    )
+    assert len(reqs) == 1
+    req = reqs[0]
+    assert req["token_ids"].dtype == np.int64
+    assert req["slot_mapping"].dtype == np.int64
+    assert req["token_mask"].dtype == np.bool_
+    assert req["slot_mapping"].size == int(req["token_mask"].sum())
+    # 核心契约：slot_mapping[::page_size] // page_size == page_ids
+    np.testing.assert_array_equal(
+        req["slot_mapping"][::page_size] // page_size,
+        np.array([3, 4], dtype=np.int64),
+    )
+def test_offload_fail_policy_close_raises(monkeypatch):
+    mgr = _build_mgr(mode="direct", fail_policy="fail_close")
+    try:
+        task_key = "offload:req-fail-close"
+        handle = SecondaryTaskHandle(
+            backend="flexkv",
+            handle={"task_key": task_key, "task_ids": [101]},
+            status=SecondaryTaskStatus.LAUNCHED,
+        )
+        mgr.ongoing_offload_tasks["req-fail-close"] = handle
+        mgr.request_to_task_handles["req-fail-close"] = {"offload": handle}
+        def _mock_offload_wait(_task_handle):
+            return SecondaryWaitResult(
+                status=SecondaryTaskStatus.FAILED,
+                ready=False,
+                error_code=SecondaryErrorCode.OFFLOAD_WAIT_FAILED.value,
+                message="mock offload failed",
+            )
+        monkeypatch.setattr(
+            mgr.secondary_kvcache_manager,
+            "offload_wait_kvcache",
+            _mock_offload_wait,
+        )
+        monkeypatch.setattr(
+            mgr.secondary_kvcache_manager,
+            "cancel_task",
+            lambda _task_handle: None,
+        )
+        with pytest.raises(RuntimeError):
+            mgr.finish_or_cancel_kvcache_ops(
+                kv_index_meta=SimpleNamespace(request_id="req-fail-close")
+            )
+    finally:
+        _shutdown(mgr)
+def test_server_client_timeout_surface(monkeypatch):
+    storage_mgr = FlexKVStorageManager(
+        mode="server_client",
+        server_addr=_new_ipc_endpoint("flexkv_test"),
+        server_port=0,
+        secondary_wait_timeout_ms=10,
+    )
+    try:
+        task_key = "offload:req-timeout"
+        storage_mgr._tasks[task_key] = {
+            "task_ids": [201],
+            "user_ids": [42],
+        }
+        handle = SecondaryTaskHandle(
+            backend="flexkv",
+            handle={"task_key": task_key, "task_ids": [201]},
+            status=SecondaryTaskStatus.LAUNCHED,
+        )
+        # 强制返回 TIMEOUT
+        monkeypatch.setattr(
+            storage_mgr,
+            "_wait_task_ids",
+            lambda task_ids: {
+                201: SimpleNamespace(status=SimpleNamespace(name="TIMEOUT"))
+            },
+        )
+        result = storage_mgr.offload_wait_kvcache(handle)
+        assert result.status == SecondaryTaskStatus.TIMEOUT
+        assert result.error_code == SecondaryErrorCode.OFFLOAD_TIMEOUT.value
+        assert result.failed_user_ids == [42]
+        assert result.failed_mask is not None
+        assert bool(result.failed_mask.all())
+    finally:
+        _shutdown_storage_mgr(storage_mgr)
+def test_lookup_returns_task_ids_and_matched_lengths():
+    storage_mgr = FlexKVStorageManager(mode="direct")
+    try:
+        # FlexKV now requires explicit GPU KV cache registration before lookup.
+        cache_tables = [
+            torch.zeros(
+                (8, 2, storage_mgr.page_size, storage_mgr.num_heads, storage_mgr.head_dim),
+                dtype=torch.bfloat16,
+                device="cuda",
+            )
+            for _ in range(storage_mgr.num_layers)
+        ]
+        storage_mgr.register_gpu_cache_tensors(cache_tables)
+
+        index_meta = KVIndexMeta(
+            request_id="req-lookup-fields",
+            batch_size=2,
+            user_ids=[1, 2],
+            namespaces=["uid:1", "uid:2"],
+            total_history_lengths=[4, 2],
+            old_cached_lengths=[0, 0],
+            seq_start_indices=[0, 0],
+            seq_lengths=[4, 2],
+            new_tokens=6,
+            token_ids=torch.tensor(
+                [
+                    [11, 12, 13, 14],
+                    [21, 22, 0, 0],
+                ],
+                dtype=torch.int64,
+            ),
+            token_mask=torch.tensor(
+                [
+                    [1, 1, 1, 1],
+                    [1, 1, 0, 0],
+                ],
+                dtype=torch.bool,
+            ),
+        )
+        out = storage_mgr.lookup_kvcache(index_meta)
+        assert out["backend"] == "flexkv"
+        assert "task_ids" in out and len(out["task_ids"]) == 2
+        assert "matched_lengths" in out and len(out["matched_lengths"]) == 2
+        assert all(int(x) >= 0 for x in out["matched_lengths"])
+        assert isinstance(out["hit_mask"], torch.Tensor)
+        assert out["hit_mask"].shape == (2, 4)
+    finally:
+        _shutdown_storage_mgr(storage_mgr)

--- a/examples/hstu/test/test_hstu_block_inference_with_kvcache.py
+++ b/examples/hstu/test/test_hstu_block_inference_with_kvcache.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# end-to-end test of HSTU block inference with KVcache and without KVcache
+import copy
+import itertools
+import os
+import sys
+from contextlib import contextmanager
+
+import pytest
+import torch
+from commons.datasets.hstu_batch import FeatureConfig
+from commons.datasets.random_inference_dataset import RandomInferenceDataset
+from configs import (
+    InferenceEmbeddingConfig,
+    RankingConfig,
+    get_inference_hstu_config,
+    get_kvcache_config,
+)
+
+os.environ.setdefault("HSTU_INFERENCE_ONLY", "1")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA is required for inference kvcache smoke test.",
+)
+_CUR_DIR = os.path.dirname(__file__)
+_HSTU_DIR = os.path.abspath(os.path.join(_CUR_DIR, ".."))
+sys.path.append(os.path.join(_HSTU_DIR, "model"))
+from inference_ranking_gr import get_inference_ranking_gr  # noqa: E402
+
+
+def _shutdown_model_kvcache_threads(model) -> None:
+    mgr = model.dense_module.async_kvcache
+    if hasattr(mgr, "executor"):
+        mgr.executor.shutdown(wait=False)
+    if hasattr(mgr, "onload_worker"):
+        mgr.onload_worker.shutdown(wait=False)
+
+
+@contextmanager
+def _capture_hstu_layer_outputs(model):
+    layers = model.dense_module._hstu_block._attention_layers
+    original_methods = []
+    outputs = {}
+
+    for layer_idx, layer in enumerate(layers):
+        original = layer.forward_naive
+        original_methods.append((layer, original))
+
+        def _wrap_forward_naive(batch_size, num_tokens, layer_input, jd, kv_cache_metadata, _orig=original, _idx=layer_idx):
+            layer_output = _orig(
+                batch_size, num_tokens, layer_input, jd, kv_cache_metadata
+            )
+            outputs[_idx] = layer_output.detach().float().cpu().clone()
+            return layer_output
+
+        layer.forward_naive = _wrap_forward_naive
+
+    try:
+        yield outputs
+    finally:
+        for layer, original in original_methods:
+            layer.forward_naive = original
+
+
+def _build_model_and_dataset(
+    secondary_backend: str = "nop",
+    flexkv_mode: str = "direct",
+):
+    max_batch_size = 4
+    max_history_length = 128
+    max_num_candidates = 16
+    max_incremental_seqlen = 16
+    max_seq_len = max_history_length * 2 + max_num_candidates
+    item_fea_name, item_vocab_size = "item_feat", 10000
+    action_fea_name, action_vocab_size = "act_feat", 128
+
+    feature_configs = [
+        FeatureConfig(
+            feature_names=[item_fea_name, action_fea_name],
+            max_item_ids=[item_vocab_size - 1, action_vocab_size - 1],
+            max_sequence_length=max_seq_len,
+            is_jagged=False,
+        ),
+    ]
+
+    hidden_dim_size = 128
+    num_heads = 2
+    head_dim = 64
+    num_layers = 2
+    hstu_config = get_inference_hstu_config(
+        hidden_size=hidden_dim_size,
+        num_layers=num_layers,
+        num_attention_heads=num_heads,
+        head_dim=head_dim,
+        max_batch_size=max_batch_size,
+        max_seq_len=max_seq_len,
+        dtype=torch.bfloat16,
+    )
+    kvcache_config = get_kvcache_config(
+        blocks_in_primary_pool=512,
+        page_size=32,
+        offload_chunksize=128,
+        secondary_backend=secondary_backend,
+        flexkv_mode=flexkv_mode,
+        namespace_mode="uid",
+        namespace_base="recsys_hstu_test",
+    )
+    emb_configs = [
+        InferenceEmbeddingConfig(
+            feature_names=[action_fea_name],
+            table_name="act",
+            vocab_size=action_vocab_size,
+            dim=hidden_dim_size,
+            use_dynamicemb=False,
+        ),
+        InferenceEmbeddingConfig(
+            feature_names=[item_fea_name],
+            table_name="item",
+            vocab_size=item_vocab_size,
+            dim=hidden_dim_size,
+            use_dynamicemb=True,
+        ),
+    ]
+    task_config = RankingConfig(
+        embedding_configs=emb_configs,
+        prediction_head_arch=[64, 16, 1],
+        num_tasks=1,
+    )
+    model = get_inference_ranking_gr(
+        hstu_config=hstu_config,
+        kvcache_config=kvcache_config,
+        task_config=task_config,
+        use_cudagraph=False,
+    )
+    model.sparse_module._dynamic_embedding_collection.set_feature_splits([1, 1], [0])
+    model.bfloat16()
+    model.eval()
+
+    dataset = RandomInferenceDataset(
+        feature_configs=feature_configs,
+        item_feature_name=item_fea_name,
+        contextual_feature_names=[],
+        action_feature_name=action_fea_name,
+        max_num_users=16,
+        max_batch_size=max_batch_size,
+        max_history_length=max_history_length,
+        max_num_candidates=max_num_candidates,
+        max_incremental_seqlen=max_incremental_seqlen,
+        max_num_cached_batches=2,
+        full_mode=True,
+    )
+    return model, dataset
+
+
+def test_inference_forward_with_kvcache_layerwise_compare():
+    model, dataset = _build_model_and_dataset()
+    try:
+        batches = list(itertools.islice(iter(dataset), 1))
+        assert len(batches) == 1
+        batch, user_ids, total_history_lengths = batches[0]
+
+        # Use identical input batch for both paths to compare per-layer outputs.
+        batch_nokv = copy.deepcopy(batch)
+        batch_kvcache = copy.deepcopy(batch)
+
+        with torch.inference_mode():
+            with _capture_hstu_layer_outputs(model) as nokv_layer_outputs:
+                logits_nokv = model.forward_nokvcache(batch_nokv)
+
+            with _capture_hstu_layer_outputs(model) as kvcache_layer_outputs:
+                logits_kvcache = model.forward_with_kvcache(
+                    batch_kvcache,
+                    user_ids,
+                    total_history_lengths,
+                )
+
+        assert torch.is_tensor(logits_kvcache)
+        assert logits_kvcache.is_cuda
+        assert logits_kvcache.numel() > 0
+        assert logits_kvcache.shape[-1] == 1
+
+        assert torch.is_tensor(logits_nokv)
+        assert logits_nokv.is_cuda
+        assert logits_nokv.numel() > 0
+        assert logits_nokv.shape[-1] == 1
+
+        num_layers = len(model.dense_module._hstu_block._attention_layers)
+        assert len(nokv_layer_outputs) == num_layers
+        assert len(kvcache_layer_outputs) == num_layers
+        a = kvcache_layer_outputs[0].float().cpu()
+        b = nokv_layer_outputs[0].float().cpu()
+        max_abs = (a - b).abs().max().item()
+        torch.testing.assert_close(
+                a, b, rtol=1e-2, atol=1e-2,
+                msg=f"layer={0}, max_abs={max_abs:.6f}",
+            )
+        # for layer_idx in range(num_layers):
+        #     a = kvcache_layer_outputs[layer_idx]
+        #     b = nokv_layer_outputs[layer_idx]
+        #     max_abs = (a - b).abs().max().item()
+        #     print(f"[layer {layer_idx}] max_abs={max_abs:.6f}")
+        #     torch.testing.assert_close(
+        #         a, b, rtol=1e-2, atol=1e-2,
+        #         msg=f"layer={layer_idx}, max_abs={max_abs:.6f}",
+        #     )
+
+        torch.testing.assert_close(
+            logits_kvcache.detach().float().cpu(),
+            logits_nokv.detach().float().cpu(),
+            rtol=1e-2,
+            atol=1e-2,
+        )
+    finally:
+        _shutdown_model_kvcache_threads(model)
+
+@pytest.mark.parametrize("secondary_backend,flexkv_mode", [
+    ("nop", "direct"),
+    ("flexkv", "direct"),
+])
+def test_inference_forward_with_kvcache_backend_smoke(secondary_backend, flexkv_mode):
+    model, dataset = _build_model_and_dataset(
+        secondary_backend=secondary_backend,
+        flexkv_mode=flexkv_mode,
+    )
+    try:
+        batch, user_ids, total_history_lengths = next(iter(dataset))
+        with torch.inference_mode():
+            logits = model.forward_with_kvcache(batch, user_ids, total_history_lengths)
+        assert torch.is_tensor(logits)
+        assert logits.is_cuda
+        assert logits.shape[-1] == 1
+        assert logits.numel() > 0
+    finally:
+        _shutdown_model_kvcache_threads(model)

--- a/examples/hstu/test/test_hstu_block_inference_with_kvcache.py
+++ b/examples/hstu/test/test_hstu_block_inference_with_kvcache.py
@@ -32,6 +32,13 @@ from inference_ranking_gr import get_inference_ranking_gr  # noqa: E402
 
 def _shutdown_model_kvcache_threads(model) -> None:
     mgr = model.dense_module.async_kvcache
+    secondary = getattr(mgr, "secondary_kvcache_manager", None)
+    client = getattr(secondary, "_client", None) if secondary is not None else None
+    if client is not None:
+        try:
+            client.shutdown()
+        except Exception:
+            pass
     if hasattr(mgr, "executor"):
         mgr.executor.shutdown(wait=False)
     if hasattr(mgr, "onload_worker"):
@@ -104,8 +111,6 @@ def _build_model_and_dataset(
         offload_chunksize=128,
         secondary_backend=secondary_backend,
         flexkv_mode=flexkv_mode,
-        namespace_mode="uid",
-        namespace_base="recsys_hstu_test",
     )
     emb_configs = [
         InferenceEmbeddingConfig(

--- a/examples/hstu/test/test_kvcache.py
+++ b/examples/hstu/test/test_kvcache.py
@@ -14,14 +14,24 @@
 # limitations under the License.
 import math
 import random
-
+from typing import Optional
 import paged_kvcache_ops
+import pytest
 import torch
 from commons.datasets.hstu_batch import FeatureConfig
 from configs import KVCacheMetadata, get_inference_hstu_config, get_kvcache_config
 from modules.async_kvcache_manager import AsyncHSTUKVCacheManager
-
-
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA is required for kvcache tests.",
+)
+def _shutdown_mgr(async_kvcache_mgr: AsyncHSTUKVCacheManager) -> None:
+    # Current manager has no explicit shutdown() in your branch.
+    # Explicitly close thread pools to avoid dangling threads in tests.
+    if hasattr(async_kvcache_mgr, "executor"):
+        async_kvcache_mgr.executor.shutdown(wait=False)
+    if hasattr(async_kvcache_mgr, "onload_worker"):
+        async_kvcache_mgr.onload_worker.shutdown(wait=False)
 def get_test_kvcache_mgr(
     num_layers,
     blocks_in_primary_pool,
@@ -29,13 +39,12 @@ def get_test_kvcache_mgr(
     offload_chunksize,
     enable_nvcomp=False,
 ):
-    # requires to test sequentientially
+    # Original stress config kept for offload/onload regression
     max_batch_size = 8
     max_seqlen = 10240
-
     item_fea_name, item_vocab_size = "item_feat", 100
     action_fea_name, action_vocab_size = "act_feat", 128
-    feature_configs = [
+    _ = [
         FeatureConfig(
             feature_names=[item_fea_name, action_fea_name],
             max_item_ids=[item_vocab_size - 1, action_vocab_size - 1],
@@ -43,12 +52,10 @@ def get_test_kvcache_mgr(
             is_jagged=False,
         ),
     ]
-
     hidden_dim_size = 512
     num_heads = 4
     head_dim = 128
     inference_dtype = torch.bfloat16
-
     hstu_config = get_inference_hstu_config(
         hidden_size=hidden_dim_size,
         num_layers=num_layers,
@@ -58,13 +65,11 @@ def get_test_kvcache_mgr(
         max_seq_len=max_seqlen,
         dtype=inference_dtype,
     )
-
     kv_cache_config = get_kvcache_config(
         blocks_in_primary_pool=blocks_in_primary_pool,
         page_size=page_size,
         offload_chunksize=offload_chunksize,
     )
-
     async_kvcache_mgr = AsyncHSTUKVCacheManager(
         hstu_config.num_layers,
         hstu_config.num_heads,
@@ -87,22 +92,61 @@ def get_test_kvcache_mgr(
         8,
         enable_nvcomp,
     )
-
-    # randomnize kvcache data
+    # randomize kvcache data
     for idx in range(num_layers):
         async_kvcache_mgr.cache_table[idx].uniform_(-0.5, 0.5)
-
     return async_kvcache_mgr
-
-
-def init_random_kvcache_status():
-    pass
-
-
-def reset_kvcache_status():
-    pass
-
-
+def get_small_test_kvcache_mgr(
+    secondary_kvcache_manager: Optional[object] = None,
+):
+    # Lightweight config for fast unit tests
+    max_batch_size = 4
+    max_seqlen = 256
+    num_layers = 2
+    num_heads = 2
+    head_dim = 64
+    page_size = 32
+    blocks_in_primary_pool = 512
+    offload_chunksize = 128
+    inference_dtype = torch.bfloat16
+    hstu_config = get_inference_hstu_config(
+        hidden_size=num_heads * head_dim,
+        num_layers=num_layers,
+        num_attention_heads=num_heads,
+        head_dim=head_dim,
+        max_batch_size=max_batch_size,
+        max_seq_len=max_seqlen,
+        dtype=inference_dtype,
+    )
+    kv_cache_config = get_kvcache_config(
+        blocks_in_primary_pool=blocks_in_primary_pool,
+        page_size=page_size,
+        offload_chunksize=offload_chunksize,
+    )
+    mgr = AsyncHSTUKVCacheManager(
+        hstu_config.num_layers,
+        hstu_config.num_heads,
+        hstu_config.head_dim,
+        kv_cache_config.page_size,
+        kv_cache_config.blocks_in_primary_pool,
+        math.ceil(
+            hstu_config.max_batch_size
+            * hstu_config.max_seq_len
+            / kv_cache_config.page_size
+        ),
+        0,
+        kv_cache_config.offload_chunksize,
+        -1,
+        hstu_config.max_seq_len,
+        hstu_config.max_batch_size,
+        4 * hstu_config.max_batch_size * hstu_config.max_seq_len,
+        kv_cache_config.num_onload_buffer_chunks,
+        kv_cache_config.num_offload_buffer_chunks,
+        kv_cache_config.num_memcpy_workers,
+        kv_cache_config.enable_nvcomp,
+        secondary_kvcache_manager,
+    )
+    return mgr, hstu_config, kv_cache_config
 def get_test_userids_and_metadata(
     min_user_id, seq_lengths, num_layers, gpu_kvcache_mgr
 ):
@@ -110,12 +154,10 @@ def get_test_userids_and_metadata(
     page_size = 32
     chunk_size = 1024
     blocks_in_primary_pool = 10240
-
     uids = list(range(min_user_id * 2, (min_user_id + batch_size) * 2))
     random.shuffle(uids)
     user_ids = torch.tensor(uids[:batch_size]).long().cuda()
     offload_user_ids = user_ids.clone().cpu()
-
     num_pages = torch.floor(seq_lengths / chunk_size).int() * int(
         chunk_size / page_size
     )
@@ -127,17 +169,14 @@ def get_test_userids_and_metadata(
         ],
         0,
     ).int()
-
     kv_offload_handle = paged_kvcache_ops.KVOffloadHandle(
         num_layers, gpu_kvcache_mgr, True
     )
-
     # zero start
     new_offload_startpos = torch.zeros((batch_size,)).int().cpu()
     new_offload_lengths = torch.floor(seq_lengths / chunk_size).int().cpu() * int(
         chunk_size
     )
-
     kvcache_metadata = KVCacheMetadata(
         offload_user_ids=offload_user_ids,
         offload_page_ids=offload_page_ids,
@@ -145,65 +184,144 @@ def get_test_userids_and_metadata(
         new_offload_startpos=new_offload_startpos,
         new_offload_lengths=new_offload_lengths,
     )
-
     return user_ids, kvcache_metadata
-
-
 def test_kvcache_offload_onload():
     num_layers = 4
     blocks_in_primary_pool = 10240
     page_size = 32
     offload_chunksize = 1024
-
     with torch.inference_mode():
         async_kvcache_mgr = get_test_kvcache_mgr(
             num_layers, blocks_in_primary_pool, page_size, offload_chunksize
         )
+        try:
+            uid_min_limit = 0
+            for batch_size, seq_len in [
+                (3, 5000),
+                (5, 10000),
+                (6, 8000),
+            ]:
+                uids, kv_metadata = get_test_userids_and_metadata(
+                    uid_min_limit,
+                    torch.tensor([seq_len] * batch_size).int().cuda(),
+                    num_layers,
+                    async_kvcache_mgr.gpu_kvcache_mgr,
+                )
+                async_kvcache_mgr.offload_kvcache(kv_metadata)
+                for layer_idx in range(num_layers):
+                    kv_metadata.kv_offload_handle.mark_ready(layer_idx)
+                while async_kvcache_mgr.gpu_kvcache_mgr.is_busy_offloading():
+                    pass
+                async_kvcache_mgr.static_onload_handle.reset()
+                async_kvcache_mgr.gpu_kvcache_mgr.onload_kvcache(
+                    uids.tolist(), async_kvcache_mgr.static_onload_handle
+                )
+                for layer_idx in range(num_layers):
+                    async_kvcache_mgr.static_onload_handle.wait_host(layer_idx)
+                # check data
+                total_onload_pages = len(kv_metadata.offload_page_ids)
+                origin_kvdata = async_kvcache_mgr.cache_table[
+                    :, kv_metadata.offload_page_ids, ...
+                ]
+                onload_kvdata = async_kvcache_mgr.cache_table[
+                    :,
+                    blocks_in_primary_pool : blocks_in_primary_pool + total_onload_pages,
+                    ...,
+                ]
+                assert torch.allclose(onload_kvdata, origin_kvdata)
+                torch.cuda.synchronize()
+                uid_min_limit += batch_size
+        finally:
+            _shutdown_mgr(async_kvcache_mgr)
 
-        uid_min_limit = 0
-        for batch_size, seq_len in [
-            (3, 5000),
-            (5, 10000),
-            (6, 8000),
-        ]:
-            uids, kv_metadata = get_test_userids_and_metadata(
-                uid_min_limit,
-                torch.tensor([seq_len] * batch_size).int().cuda(),
-                num_layers,
-                async_kvcache_mgr.gpu_kvcache_mgr,
-            )
-            async_kvcache_mgr.offload_kvcache(kv_metadata)
+def test_lookup_allocate_contract():
+    mgr_split, _, _ = get_small_test_kvcache_mgr()
+    try:
+        batch_size = 2
+        user_ids = [301, 302]
+        total_history_lengths = [80, 112]
+        lookup = mgr_split.lookup_kvcache(user_ids, total_history_lengths)
+        kv_index_meta, prepare_obj = mgr_split.allocate_kvcache(
+            lookup,
+            static_page_ids_gpu_buffer=mgr_split.static_page_ids_gpu_buffer,
+            static_offload_page_ids_gpu_buffer=mgr_split.static_offload_page_ids_gpu_buffer,
+            static_metadata_gpu_buffer=mgr_split.static_metadata_gpu_buffer,
+            static_onload_handle=mgr_split.static_onload_handle,
+        )
+        assert lookup.batch_size == batch_size
+        assert len(lookup.old_cached_lengths) == batch_size
+        assert kv_index_meta.batch_size == batch_size
+        assert len(kv_index_meta.user_ids) == batch_size
+        assert len(kv_index_meta.seq_start_indices) == batch_size
+        assert len(kv_index_meta.seq_lengths) == batch_size
+        assert int(prepare_obj.new_tokens) >= 0
+        prepare_obj.kvcache_metadata_fut.result(timeout=30)
+        prepare_obj.onload_fut.result(timeout=30)
+    finally:
+        _shutdown_mgr(mgr_split)
 
-            for layer_idx in range(num_layers):
-                kv_metadata.kv_offload_handle.mark_ready(layer_idx)
 
-            while async_kvcache_mgr.gpu_kvcache_mgr.is_busy_offloading():
-                pass
+def test_prepare_kvcache_wait_smoke():
+    mgr, _, _ = get_small_test_kvcache_mgr()
+    try:
+        batch_size = 2
+        user_ids = [401, 402]
+        total_history_lengths = [48, 64]
+        lookup = mgr.lookup_kvcache(
+            user_ids,
+            total_history_lengths,
+        )
+        _, prepare_result = mgr.allocate_kvcache(
+            lookup,
+            mgr.static_page_ids_gpu_buffer,
+            mgr.static_offload_page_ids_gpu_buffer,
+            mgr.static_metadata_gpu_buffer,
+            mgr.static_onload_handle,
+        )
+        metadata = mgr.prepare_kvcache_wait(
+            prepare_result.onload_fut,
+            prepare_result.kvcache_metadata_fut,
+            batch_size,
+            prepare_result.new_tokens,
+            mgr.static_page_ids_gpu_buffer,
+            mgr.static_offload_page_ids_gpu_buffer,
+            prepare_result.offload_uids_buffer,
+            prepare_result.metadata_host_buffer,
+            prepare_result.metadata_gpu_buffer,
+            mgr.static_onload_handle,
+        )
+        assert isinstance(metadata, KVCacheMetadata)
+        assert metadata.kv_indices is not None
+        assert metadata.kv_indptr is not None
+        assert int(metadata.new_history_nnz) >= 0
+    finally:
+        _shutdown_mgr(mgr)
 
-            async_kvcache_mgr.static_onload_handle.reset()
-            async_kvcache_mgr.gpu_kvcache_mgr.onload_kvcache(
-                uids.tolist(), async_kvcache_mgr.static_onload_handle
-            )
-
-            for layer_idx in range(num_layers):
-                async_kvcache_mgr.static_onload_handle.wait_host(layer_idx)
-
-            # check data
-            total_onload_pages = len(kv_metadata.offload_page_ids)
-            origin_kvdata = async_kvcache_mgr.cache_table[
-                :, kv_metadata.offload_page_ids, ...
-            ]
-            onload_kvdata = async_kvcache_mgr.cache_table[
-                :,
-                blocks_in_primary_pool : blocks_in_primary_pool + total_onload_pages,
-                ...,
-            ]
-            assert torch.allclose(onload_kvdata, origin_kvdata)
-
-            torch.cuda.synchronize()
-
-            uid_min_limit += batch_size
-
+#from_config smoke test and nop secondary test
+def test_from_config_smoke_and_nop_secondary():
+    max_batch_size = 4
+    max_seqlen = 256
+    hstu_config = get_inference_hstu_config(
+        hidden_size=128,
+        num_layers=2,
+        num_attention_heads=2,
+        head_dim=64,
+        max_batch_size=max_batch_size,
+        max_seq_len=max_seqlen,
+        dtype=torch.bfloat16,
+    )
+    kv_cfg = get_kvcache_config(
+        blocks_in_primary_pool=512,
+        page_size=32,
+        offload_chunksize=128,
+    )
+    mgr = AsyncHSTUKVCacheManager.from_config(hstu_config, kv_cfg)
+    try:
+        lookup = mgr.lookup_kvcache([777], [32])
+        assert isinstance(lookup.secondary_lookup, dict)
+        assert lookup.secondary_lookup.get("backend") == "nop"
+    finally:
+        _shutdown_mgr(mgr)
 
 if __name__ == "__main__":
     random.seed(1)


### PR DESCRIPTION
## Description
This PR completes Phase 2 of HSTU KV cache integration by moving from a placeholder implementation to a real FlexKV lifecycle.
### What is included
- Integrated real secondary backend construction from config:
  - `secondary_backend=nop` -> `NopSecondaryKVCacheManager`
  - `secondary_backend=flexkv` -> `FlexKVStorageManager`
- Made `secondary_wait_timeout_ms` and `secondary_fail_policy` effective in real wait/failure paths.
- Bridged secondary lookup outputs into `KVIndexMeta` during `allocate_kvcache`:
  - `secondary_hit_mask`, `secondary_get_task_ids`, `secondary_matched_lengths`
  - `restore_slot_mapping`, `append_slot_mapping`
- Materialized restore/append mappings from real GPU metadata and used real append `page_ids + indptr` for offload.
- Split responsibilities:
  - `FlexKVStorageManager`: lifecycle + SDK calls
  - `FlexKVClientAdapter`: payload/data transformation only
- Added/updated integration coverage for direct mode, server-client mode, fail policy behavior, timeout surface, and mapping contracts.
Closes #369
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.