### PR TITLE
fix(ddp): bucket_size=True silently disables grad bucketing

### DIFF
--- a/examples/commons/distributed/sharding.py
+++ b/examples/commons/distributed/sharding.py
@@ -86,7 +86,7 @@ def apply_megatron_ddp(
         overlap_grad_reduce=False,
         use_distributed_optimizer=False,
         check_for_nan_in_grad=False,
-        bucket_size=True,
+        bucket_size=None,
     )
     # MCORE DDP does not broadcast parameters implicitly
     if isinstance(original_model, DistributedModelParallel):


### PR DESCRIPTION
## Summary

`apply_megatron_ddp` in [examples/commons/distributed/sharding.py:89](examples/commons/distributed/sharding.py#L89) constructs `DistributedDataParallelConfig(..., bucket_size=True)`. The field is typed `Optional[int]` (size threshold for grad bucket flush; `None` = use Megatron's default). `True` is a `bool`, which slips past Python's runtime because `bool` is a subclass of `int` and would compare as `1` if it ever reached the bucketing path.

This PR corrects the typo: `True` → `None`.

## Current runtime behavior (verified, Megatron core_v0.12.1)

The repo pins Megatron at `core_v0.12.1` ([docker/Dockerfile:39](docker/Dockerfile#L39)). Tracing `bucket_size=True` through Megatron with our exact config (`overlap_grad_reduce=False`):

[`distributed_data_parallel.py:54-75`](https://github.com/NVIDIA/Megatron-LM/blob/core_v0.12.1/megatron/core/distributed/distributed_data_parallel.py#L54)

```python
# 1) Default fallback: True is not None, so this branch is skipped
if ddp_config.bucket_size is None:
    ddp_config.bucket_size = max(40000000, 1000000 * dp_size)

# 2) overlap_grad_reduce=False -> bucket_size is FORCED to None here, clobbering True
if not ddp_config.overlap_grad_reduce:
    ddp_config.bucket_size = None

self.bucket_size = self.ddp_config.bucket_size  # -> None
```

[`param_and_grad_buffer.py`](https://github.com/NVIDIA/Megatron-LM/blob/core_v0.12.1/megatron/core/distributed/param_and_grad_buffer.py) bucket-split test:

```python
if (bucket_size is not None and (param_end_index - bucket_start_index) >= bucket_size) \
    or _does_param_require_new_bucket(param):
    ...
```

Because step (2) zeros `bucket_size` to `None`, the size-based split short-circuits in the buffer. **At runtime today this config behaves identically to `bucket_size=None` — no per-tensor allreduce, no inflated comm time.** The bug is masked, not active.

## Why this still matters (latent footgun)

The `overlap_grad_reduce=False` clobber is the **only** thing keeping `True` from reaching the comparison. The moment anyone flips `overlap_grad_reduce=True` (the obvious next optimization for DP training overlap), step (2) is skipped, and `(param_end_index - bucket_start_index) >= True` is evaluated as `>= 1` per parameter — every parameter triggers a fresh bucket, degenerating into per-tensor allreduce. The breakage would surface as a sudden DP comm-time regression at the moment overlap is enabled, with no obvious code change to blame.

Fixing it now closes the trap before someone walks into it.

## Change

```diff
-        bucket_size=True,
+        bucket_size=None,
```

One line in [examples/commons/distributed/sharding.py:89](examples/commons/distributed/sharding.py#L89).

## Why no regression test

A faithful regression test would need (a) `overlap_grad_reduce=True`, (b) a multi-GPU DP run, (c) introspection of `_ParamAndGradBuffer.buckets` to assert the bucket count is `O(num_dtype_groups)` rather than `O(num_params)`. The fix is a one-token correction of an `Optional[int]` field given a `bool`; the type error itself is the proof, and the test infrastructure cost dwarfs the change.

## Test plan

- [ ] CI green on existing HSTU + DLRM training jobs (no behavior change with the current `overlap_grad_reduce=False`)
- [ ] (Optional sanity) Spot-check a DP training run with `overlap_grad_reduce=True` flipped locally to confirm bucketing now activates correctly

Generated with Claude Code.
