### PR TITLE
fix segmented_unique_cuda: replace table_ids with segmented_range

### DIFF
--- a/corelib/dynamicemb/DynamicEmb_APIs.md
+++ b/corelib/dynamicemb/DynamicEmb_APIs.md
@@ -927,3 +927,13 @@ Please see `DynamicEmbDump`, `DynamicEmbLoad`, `incremental_dump` in [APIs Doc](
 
 When handling cache eviction and final table eviction, dynamicemb encounters randomness in the eviction of keys with the same score. To eliminate this uncertainty, dynamicemb provides a deterministic mode. Enabling this mode ensures that, under the same training script, the evicted keys will be determined.
 This mode is enabled by setting the environment variable `DEMB_DETERMINISM_MODE`.
+
+## Environment Variables
+
+The following environment variables control runtime behavior of dynamicemb:
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `DYNAMICEMB_CSTM_SCORE_CHECK` | `1` | When set to `0`, suppresses warnings in `set_score` when a new score is less than the previous one (CUSTOMIZED eviction mode). |
+| `DEMB_DETERMINISM_MODE` | unset | When set, enables deterministic eviction of keys with equal scores during cache eviction and final table eviction. |
+| `DYNAMICEMB_DEBUG` | unset | When set to any non-empty value, enables extra runtime validation in `segmented_unique_cuda`. Copies `segmented_range` to CPU and verifies: (1) `segmented_range[0] == 0`, (2) `segmented_range[num_tables] == num_keys`, (3) monotonically non-decreasing. Raises an error with a descriptive message on violation. Intended for development and testing only; incurs one device-to-host copy per call. |

--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
@@ -710,9 +710,6 @@ def dynamicemb_prefetch(
 
         unique_table_ids = expand_table_ids_cuda(
             unique_indices_table_range,
-            None,
-            table_num,
-            1,
             unique_keys.numel(),
         )
 
@@ -824,9 +821,6 @@ def dynamicemb_eval_forward(
         if not is_pooling:
             table_ids = expand_table_ids_cuda(
                 indices_table_range,
-                None,
-                table_num,
-                1,
                 indices.numel(),
             )
             frequency_counts_int64 = (
@@ -862,9 +856,6 @@ def dynamicemb_eval_forward(
 
         unique_table_ids = expand_table_ids_cuda(
             unique_indices_table_range,
-            None,
-            table_num,
-            1,
             unique_indices.numel(),
         )
 

--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
@@ -98,14 +98,6 @@ def segmented_unique(
         )
         need_frequency_output = is_lfu_enabled or frequency_counts is not None
 
-        table_ids = expand_table_ids_cuda(
-            segment_range,
-            None,
-            num_tables,
-            1,
-            num_keys,
-        )
-
         input_frequencies = None
         if frequency_counts is not None:
             input_frequencies = frequency_counts
@@ -118,7 +110,7 @@ def segmented_unique(
             reverse_indices,
             table_offsets,
             freq_counters,
-        ) = segmented_unique_cuda(keys, table_ids, num_tables, input_frequencies)
+        ) = segmented_unique_cuda(keys, segment_range, num_tables, input_frequencies)
 
         table_offsets_cpu = table_offsets.cpu()
         total_unique = table_offsets_cpu[num_tables].item()

--- a/corelib/dynamicemb/dynamicemb/shard/embedding.py
+++ b/corelib/dynamicemb/dynamicemb/shard/embedding.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional
 import torch
 from dynamicemb_extensions import (
     compute_dedup_lengths_cuda,
-    expand_table_ids_cuda,
+    get_table_range,
     segmented_unique_cuda,
 )
 from torch.autograd.profiler import record_function
@@ -210,14 +210,8 @@ class ShardedDynamicEmbeddingCollection(ShardedEmbeddingCollection):
                     features_by_shards.append(dedup_features)
                     continue
 
-                # Generate table_ids from jagged offsets (fully on GPU, no sync)
-                table_ids = expand_table_ids_cuda(
-                    offsets,
-                    d_table_offset,
-                    table_num,
-                    local_batchsize,
-                    num_elements,
-                )
+                # Compute table boundary offsets from jagged offsets (O(T), fully on GPU)
+                segmented_range = get_table_range(offsets, d_table_offset)
 
                 # Prepare input_frequencies tensor to control frequency counting
                 input_frequencies = None
@@ -235,7 +229,7 @@ class ShardedDynamicEmbeddingCollection(ShardedEmbeddingCollection):
                     freq_counters,
                 ) = segmented_unique_cuda(
                     indices,
-                    table_ids,
+                    segmented_range,
                     table_num,
                     input_frequencies,
                 )

--- a/corelib/dynamicemb/example/example.py
+++ b/corelib/dynamicemb/example/example.py
@@ -38,7 +38,7 @@ from torch.optim import Adam
 from torch.utils.data import DataLoader, Dataset
 from torch.utils.data.distributed import DistributedSampler
 from torchrec import DataType
-from torchrec.distributed.comm import get_local_rank, get_local_size
+from torchrec.distributed.comm import get_local_size
 from torchrec.distributed.fbgemm_qcomm_codec import (
     CommType,
     QCommsConfig,
@@ -72,6 +72,7 @@ def rank_print(*args, **kwargs):
 builtins.print = rank_print
 cache_ratio = 0.5  # assume we will use 50% of the HBM for cache
 
+
 @dataclass
 class RuntimeContext:
     backend: str
@@ -79,6 +80,7 @@ class RuntimeContext:
     local_rank: int
     world_size: int
     device: torch.device
+
 
 def init_runtime() -> RuntimeContext:
     # Set LOCAL_WORLD_SIZE if not available for proper topology configuration.
@@ -114,10 +116,12 @@ def init_runtime() -> RuntimeContext:
         device=device,
     )
 
+
 def cleanup_runtime(runtime: Optional[RuntimeContext]) -> None:
     builtins.print = original_print
     if runtime is not None and dist.is_available() and dist.is_initialized():
         dist.destroy_process_group()
+
 
 def download_movielens(runtime: RuntimeContext, data_dir="./ml-1m"):
     if runtime.rank == 0:  # Use global rank for multi-node consistency
@@ -712,7 +716,15 @@ def create_model(args, runtime: RuntimeContext, training=True):
     return model
 
 
-def train_one_epoch(model, train_loader, optimizer, loss_fn, epoch, total_epochs, runtime: RuntimeContext):
+def train_one_epoch(
+    model,
+    train_loader,
+    optimizer,
+    loss_fn,
+    epoch,
+    total_epochs,
+    runtime: RuntimeContext,
+):
     model.train()
     total_loss = 0
 
@@ -738,7 +750,9 @@ def train_one_epoch(model, train_loader, optimizer, loss_fn, epoch, total_epochs
     print(f"Epoch {epoch+1}/{total_epochs}, Average Loss: {avg_loss:.4f}")
 
 
-def test_one_epoch(model, test_loader, loss_fn, epoch, total_epochs, runtime: RuntimeContext):
+def test_one_epoch(
+    model, test_loader, loss_fn, epoch, total_epochs, runtime: RuntimeContext
+):
     model.eval()
     test_loss = 0
     with torch.inference_mode():
@@ -790,7 +804,9 @@ def train(args, runtime: RuntimeContext):
 
     for epoch in range(args.epochs):
         train_sampler.set_epoch(epoch)
-        train_one_epoch(model, train_loader, optimizer, criterion, epoch, args.epochs, runtime)
+        train_one_epoch(
+            model, train_loader, optimizer, criterion, epoch, args.epochs, runtime
+        )
         test_one_epoch(model, test_loader, criterion, epoch, args.epochs, runtime)
 
 
@@ -819,7 +835,9 @@ def dump(args, runtime: RuntimeContext):
 
     for epoch in range(args.epochs):
         train_sampler.set_epoch(epoch)
-        train_one_epoch(model, train_loader, optimizer, criterion, epoch, args.epochs, runtime)
+        train_one_epoch(
+            model, train_loader, optimizer, criterion, epoch, args.epochs, runtime
+        )
 
         # ShardedDyanmicEmbeddingCollection.state_dict() will return a dummy tensor.
         torch.save(
@@ -827,9 +845,7 @@ def dump(args, runtime: RuntimeContext):
                 "model_state_dict": model.state_dict(),
                 "optimizer_state_dict": optimizer.state_dict(),
             },
-            os.path.join(
-                args.save_dir, f"model_epoch_{epoch+1}_rank{runtime.rank}.pt"
-            ),
+            os.path.join(args.save_dir, f"model_epoch_{epoch+1}_rank{runtime.rank}.pt"),
         )
     DynamicEmbDump(os.path.join(args.save_dir, "dynamicemb"), model, optim=True)
 
@@ -859,9 +875,7 @@ def load(args, runtime: RuntimeContext):
 
     # load
     checkpoint = torch.load(
-        os.path.join(
-            args.save_dir, f"model_epoch_{args.epochs}_rank{runtime.rank}.pt"
-        ),
+        os.path.join(args.save_dir, f"model_epoch_{args.epochs}_rank{runtime.rank}.pt"),
         weights_only=True,
     )
     # Must set strict to False, as there is no embedding's weight in model.state_dict()

--- a/corelib/dynamicemb/src/table_operation/expand_table_ids_torch_binding.cu
+++ b/corelib/dynamicemb/src/table_operation/expand_table_ids_torch_binding.cu
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
 #include <torch/library.h>
 
 #include "unique_op.h"
@@ -8,6 +9,31 @@ TORCH_LIBRARY_FRAGMENT(INFERENCE_EMB, m) {
 }
 
 namespace dyn_emb {
+
+// expand_table_ids_cuda (unique_op.cu) now only supports identity mapping
+// (local_batch_size=1, no table_offsets_in_feature). The inference op needs the
+// full generality (feature_offsets + local_batch_size), so implement the kernel
+// here and adapt the body without changing the external interface.
+__global__ void expand_table_ids_inference_kernel(
+    const int64_t *offsets,
+    const int64_t *feature_offsets,  // nullptr = identity mapping
+    int64_t *table_ids,
+    int num_tables,
+    int local_batch_size,
+    int64_t num_elements) {
+  const int64_t stride = blockDim.x * gridDim.x;
+  for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < num_elements;
+       idx += stride) {
+    int lo = 0, hi = num_tables;
+    while (lo < hi) {
+      int mid = (lo + hi + 1) / 2;
+      int64_t feat = feature_offsets ? feature_offsets[mid] : mid;
+      if (offsets[feat * local_batch_size] <= idx) lo = mid;
+      else hi = mid - 1;
+    }
+    table_ids[idx] = lo;
+  }
+}
 
 at::Tensor expand_table_ids_cuda_impl(
     at::Tensor offsets, at::Tensor indices, c10::optional<at::Tensor> table_offsets_in_feature,
@@ -20,8 +46,38 @@ at::Tensor expand_table_ids_cuda_impl(
             "INFERENCE_EMB::expand_table_ids expects CUDA table_offsets_in_feature when provided."
         );
     }
-    return expand_table_ids_cuda(offsets, table_offsets_in_feature, num_tables,
-                                 local_batch_size, num_elements);
+
+    if (num_elements == 0) {
+        return at::empty({0}, at::TensorOptions().dtype(at::kLong).device(offsets.device()));
+    }
+
+    const int64_t *feature_offsets_ptr = nullptr;
+    if (table_offsets_in_feature.has_value() &&
+        table_offsets_in_feature.value().defined() &&
+        table_offsets_in_feature.value().numel() > 0) {
+        feature_offsets_ptr = table_offsets_in_feature.value().data_ptr<int64_t>();
+        // num_tables kept as caller-supplied value, matching original behavior
+    } else {
+        num_tables = (offsets.size(0) - 1) / local_batch_size;
+    }
+
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    constexpr int BLOCK_SIZE = 64;
+    constexpr int BLOCKS_PER_SM = 4;
+    const int sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+    const int grid_size = static_cast<int>(
+        std::min((num_elements + BLOCK_SIZE - 1) / BLOCK_SIZE,
+                 static_cast<int64_t>(sm_count * BLOCKS_PER_SM)));
+
+    at::Tensor table_ids = at::empty(
+        {num_elements}, at::TensorOptions().dtype(at::kLong).device(offsets.device()));
+
+    expand_table_ids_inference_kernel<<<grid_size, BLOCK_SIZE, 0, stream>>>(
+        offsets.data_ptr<int64_t>(), feature_offsets_ptr,
+        table_ids.data_ptr<int64_t>(), num_tables, local_batch_size, num_elements);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+    return table_ids;
 }
 
 at::Tensor expand_table_ids_cpu_impl(

--- a/corelib/dynamicemb/src/table_operation/expand_table_ids_torch_binding.cu
+++ b/corelib/dynamicemb/src/table_operation/expand_table_ids_torch_binding.cu
@@ -51,6 +51,9 @@ at::Tensor expand_table_ids_cuda_impl(
         return at::empty({0}, at::TensorOptions().dtype(at::kLong).device(offsets.device()));
     }
 
+    TORCH_CHECK(local_batch_size > 0,
+        "INFERENCE_EMB::expand_table_ids expects local_batch_size > 0");
+
     const int64_t *feature_offsets_ptr = nullptr;
     if (table_offsets_in_feature.has_value() &&
         table_offsets_in_feature.value().defined() &&

--- a/corelib/dynamicemb/src/unique_op.cu
+++ b/corelib/dynamicemb/src/unique_op.cu
@@ -380,45 +380,23 @@ __global__ void compact_keys_and_freq_kernel(
 // Helper kernel to expand table IDs from jagged offsets
 // ============================================================================
 
-// Binary search to find which table an index belongs to (for expand_table_ids)
-// When table_offsets_in_feature is nullptr, use identity mapping (feature i =
-// table i)
-__device__ __forceinline__ int64_t find_table_for_index(
-    const int64_t *table_offsets_in_feature, const int64_t *offsets,
-    int num_tables, int local_batch_size, int64_t global_idx) {
-  // Binary search through tables to find which one contains this index
-  int lo = 0, hi = num_tables;
-  while (lo < hi) {
-    int mid = (lo + hi + 1) / 2;
-    // If table_offsets_in_feature is nullptr, use identity: feature mid = table
-    // mid
-    int64_t table_start_feature =
-        table_offsets_in_feature ? table_offsets_in_feature[mid] : mid;
-    int64_t table_start_offset = table_start_feature * local_batch_size;
-    int64_t table_start_idx = offsets[table_start_offset];
-    if (table_start_idx <= global_idx) {
-      lo = mid;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  return static_cast<int32_t>(lo);
-}
-
-// Expand jagged offsets to per-element table_ids (strided loop version)
-// Given: offsets tensor and table_offsets_in_feature, generate table_id for
-// each element
+// Expand jagged offsets to per-element table_ids (identity mapping,
+// local_batch_size=1). Binary search on offsets: find largest t such that
+// offsets[t] <= idx.
 __global__ void expand_table_ids_kernel(const int64_t *offsets,
-                                        const int64_t *table_offsets_in_feature,
                                         int64_t *table_ids, int num_tables,
-                                        int local_batch_size,
                                         int64_t num_elements) {
   const int64_t stride = blockDim.x * gridDim.x;
 
   for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < num_elements;
        idx += stride) {
-    table_ids[idx] = find_table_for_index(table_offsets_in_feature, offsets,
-                                          num_tables, local_batch_size, idx);
+    int lo = 0, hi = num_tables;
+    while (lo < hi) {
+      int mid = (lo + hi + 1) / 2;
+      if (offsets[mid] <= idx) lo = mid;
+      else hi = mid - 1;
+    }
+    table_ids[idx] = lo;
   }
 }
 
@@ -517,8 +495,8 @@ segmented_unique_cuda(at::Tensor keys, at::Tensor segmented_range,
   at::Tensor table_ids = at::empty(
       {num_keys}, at::TensorOptions().dtype(at::kLong).device(device));
   expand_table_ids_kernel<<<grid_size, BLOCK_SIZE, 0, stream>>>(
-      get_pointer<const int64_t>(segmented_range), nullptr,
-      get_pointer<int64_t>(table_ids), num_tables, 1, num_keys);
+      get_pointer<const int64_t>(segmented_range),
+      get_pointer<int64_t>(table_ids), num_tables, num_keys);
   DEMB_CUDA_KERNEL_LAUNCH_CHECK();
 
   // Partitioned buffer uses segmented_range as per-table offsets, so total
@@ -634,53 +612,24 @@ segmented_unique_cuda(at::Tensor keys, at::Tensor segmented_range,
                          table_offsets, output_freq_counters);
 }
 
-// Helper function to expand table IDs from offsets
-//
-// offsets: size = num_features * local_batch_size + 1
-//   - Indexed by (feature_id * local_batch_size + batch_id)
-//   - Each feature contains local_batch_size buckets
-//
-// table_offsets_in_feature: size = num_tables + 1
-//   - Maps features to tables (adjacent features may belong to same table)
-//   - table_offsets_in_feature[t] is the first feature index for table t
-//
-// When table_offsets_in_feature is None:
-//   - Each feature is treated as a separate table
-//   - num_tables = num_features = (offsets.size(0) - 1) / local_batch_size
-//
-at::Tensor expand_table_ids_cuda(
-    at::Tensor offsets, c10::optional<at::Tensor> table_offsets_in_feature,
-    int64_t num_tables, int64_t local_batch_size, int64_t num_elements) {
+// Expand table IDs from offsets (identity mapping, local_batch_size=1).
+// offsets: size = num_tables + 1; offsets[t] is the start index for table t.
+// num_tables is derived from offsets.size(0)-1.
+at::Tensor expand_table_ids_cuda(at::Tensor offsets, int64_t num_elements) {
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
 
   const auto device = offsets.device();
   const int device_sm_count = DeviceProp::getDeviceProp(device.index()).num_sms;
 
   TORCH_CHECK(offsets.is_cuda(), "offsets must be on CUDA device");
-  TORCH_CHECK(local_batch_size > 0, "local_batch_size must be positive");
 
   // Handle empty input
   if (num_elements == 0) {
     return at::empty({0}, at::TensorOptions().dtype(at::kLong).device(device));
   }
 
-  // Compute num_features from offsets size
-  int64_t num_features = (offsets.size(0) - 1) / local_batch_size;
-
-  // Determine if we have explicit table_offsets_in_feature or use identity
-  // mapping
-  const int64_t *table_offsets_ptr = nullptr;
-  if (table_offsets_in_feature.has_value() &&
-      table_offsets_in_feature.value().numel() > 0) {
-    const auto &table_offsets = table_offsets_in_feature.value();
-    TORCH_CHECK(table_offsets.is_cuda(),
-                "table_offsets_in_feature must be on CUDA device");
-    table_offsets_ptr = get_pointer<const int64_t>(table_offsets);
-  } else {
-    // Each feature = one table, so num_tables = num_features
-    // Kernel will use identity mapping when table_offsets_ptr is nullptr
-    num_tables = num_features;
-  }
+  // num_tables derived from offsets; local_batch_size is always 1
+  const int64_t num_tables = offsets.size(0) - 1;
 
   // Compute grid size based on SM count
   constexpr int BLOCKS_PER_SM = 4;
@@ -688,14 +637,12 @@ at::Tensor expand_table_ids_cuda(
       std::min((num_elements + BLOCK_SIZE - 1) / BLOCK_SIZE,
                static_cast<int64_t>(device_sm_count * BLOCKS_PER_SM));
 
-  // Allocate output table_ids
   at::Tensor table_ids = at::empty(
       {num_elements}, at::TensorOptions().dtype(at::kLong).device(device));
 
   expand_table_ids_kernel<<<grid_size, BLOCK_SIZE, 0, stream>>>(
-      get_pointer<const int64_t>(offsets), table_offsets_ptr,
-      get_pointer<int64_t>(table_ids), num_tables, local_batch_size,
-      num_elements);
+      get_pointer<const int64_t>(offsets),
+      get_pointer<int64_t>(table_ids), num_tables, num_elements);
   DEMB_CUDA_KERNEL_LAUNCH_CHECK();
 
   return table_ids;
@@ -796,39 +743,24 @@ Returns:
 
   m.def(
       "expand_table_ids_cuda",
-      [](at::Tensor offsets, c10::optional<at::Tensor> table_offsets_in_feature,
-         int64_t num_tables, int64_t local_batch_size, int64_t num_elements) {
-        return dyn_emb::expand_table_ids_cuda(offsets, table_offsets_in_feature,
-                                              num_tables, local_batch_size,
-                                              num_elements);
+      [](at::Tensor offsets, int64_t num_elements) {
+        return dyn_emb::expand_table_ids_cuda(offsets, num_elements);
       },
       R"doc(
-Expand table IDs from offsets.
+Expand table IDs from offsets (identity mapping, local_batch_size=1).
 
-Generates a table_id for each element based on the offsets structure.
-This is a helper function to prepare input for segmented_unique_cuda.
+Generates a table_id for each element via binary search on offsets.
+num_tables is derived from offsets.size(0)-1.
 
 Args:
-    offsets: Jagged tensor offsets (int64)
-             Size = num_features * local_batch_size + 1
-             Indexed by (feature_id * local_batch_size + batch_id)
-
-    table_offsets_in_feature: Feature offsets per table (int64), or None
-             Size = num_tables + 1
-             Maps features to tables (adjacent features may share a table)
-             table_offsets_in_feature[t] is the first feature index for table t
-             If None: each feature is treated as a separate table
-
-    num_tables: Number of tables (ignored if table_offsets_in_feature is None)
-    local_batch_size: Batch size per feature
+    offsets: Table boundary offsets (int64, size = num_tables + 1)
+             offsets[t] is the start index for table t's keys.
     num_elements: Total number of elements (keys)
 
 Returns:
     table_ids tensor (int64) with same length as num_elements
 )doc",
-      py::arg("offsets"), py::arg("table_offsets_in_feature") = py::none(),
-      py::arg("num_tables") = 0, py::arg("local_batch_size") = 1,
-      py::arg("num_elements") = 0);
+      py::arg("offsets"), py::arg("num_elements") = 0);
 
   m.def(
       "compute_dedup_lengths_cuda",

--- a/corelib/dynamicemb/src/unique_op.cu
+++ b/corelib/dynamicemb/src/unique_op.cu
@@ -214,7 +214,8 @@ segmented_unique_kernel(const KeyType *d_keys, const int64_t *d_table_ids,
                         KeyType *d_unique_keys, int64_t *d_output_indices,
                         size_t num_keys, KeyType *hash_keys, int64_t *hash_vals,
                         size_t capacity, int64_t *table_counters,
-                        size_t max_keys_per_table, int64_t *frequency_counters,
+                        const int64_t *d_segmented_range,
+                        int64_t *frequency_counters,
                         const int64_t *input_frequencies) {
   const size_t stride = blockDim.x * gridDim.x;
 
@@ -245,9 +246,9 @@ segmented_unique_kernel(const KeyType *d_keys, const int64_t *d_table_ids,
           int32_t local_unique_idx =
               static_cast<int32_t>(atomicAdd(&table_counters[table_id], 1));
 
-          // Store unique key in partitioned layout
+          // Store unique key in partitioned layout using segmented_range offsets
           size_t output_pos =
-              static_cast<size_t>(table_id) * max_keys_per_table +
+              static_cast<size_t>(d_segmented_range[table_id]) +
               local_unique_idx;
           d_unique_keys[output_pos] = key;
 
@@ -281,7 +282,7 @@ segmented_unique_kernel(const KeyType *d_keys, const int64_t *d_table_ids,
             // Update frequency counter for duplicate key
             if (frequency_counters) {
               size_t output_pos =
-                  static_cast<size_t>(table_id) * max_keys_per_table +
+                  static_cast<size_t>(d_segmented_range[table_id]) +
                   local_idx;
               atomicAdd(&frequency_counters[output_pos], input_freq);
             }
@@ -307,7 +308,7 @@ segmented_unique_kernel(const KeyType *d_keys, const int64_t *d_table_ids,
           // Update frequency counter for duplicate key
           if (frequency_counters) {
             size_t output_pos =
-                static_cast<size_t>(table_id) * max_keys_per_table + local_idx;
+                static_cast<size_t>(d_segmented_range[table_id]) + local_idx;
             atomicAdd(&frequency_counters[output_pos], input_freq);
           }
           done = true;
@@ -345,23 +346,24 @@ __device__ __forceinline__ int binary_search_upper_bound(const int64_t *arr,
 template <typename KeyType>
 __global__ void compact_keys_and_freq_kernel(
     const KeyType *partitioned_keys, const int64_t *partitioned_freq,
-    size_t max_keys_per_table, const int64_t *table_offsets, int64_t num_tables,
-    KeyType *output_keys, int64_t *output_freq, const int64_t *d_total_unique) {
+    const int64_t *d_segmented_range, const int64_t *table_offsets,
+    int64_t num_tables, KeyType *output_keys, int64_t *output_freq,
+    const int64_t *d_total_unique) {
   const int64_t total_unique = *d_total_unique;
   const int64_t stride = blockDim.x * gridDim.x;
 
   for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < total_unique;
        idx += stride) {
-    // Find which table this index belongs to (shared computation)
+    // Find which table this output index belongs to via output table_offsets
     int table_id =
         binary_search_upper_bound(table_offsets, num_tables + 1, idx);
 
-    // Calculate offset within table
+    // Offset within this table's unique keys
     int64_t local_idx = idx - table_offsets[table_id];
 
-    // Compute source position in partitioned layout
+    // Source position uses segmented_range (input partition layout)
     size_t src_pos =
-        static_cast<size_t>(table_id) * max_keys_per_table + local_idx;
+        static_cast<size_t>(d_segmented_range[table_id]) + local_idx;
 
     // Compact keys
     output_keys[idx] = partitioned_keys[src_pos];
@@ -435,8 +437,8 @@ __global__ void adjust_output_indices_kernel(const int64_t *d_table_ids,
 }
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
-segmented_unique_cuda(at::Tensor keys, at::Tensor table_ids, int64_t num_tables,
-                      at::Tensor input_frequencies) {
+segmented_unique_cuda(at::Tensor keys, at::Tensor segmented_range,
+                      int64_t num_tables, at::Tensor input_frequencies) {
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
 
   const int64_t num_keys = keys.numel();
@@ -444,9 +446,14 @@ segmented_unique_cuda(at::Tensor keys, at::Tensor table_ids, int64_t num_tables,
   const auto key_dtype = keys.scalar_type();
   const int device_sm_count = DeviceProp::getDeviceProp(device.index()).num_sms;
 
-  TORCH_CHECK(keys.numel() == table_ids.numel(),
-              "keys and table_ids must have the same length");
-  TORCH_CHECK(table_ids.scalar_type() == at::kLong, "table_ids must be int64");
+  TORCH_CHECK(segmented_range.numel() == num_tables + 1,
+              "segmented_range must have num_tables+1 elements");
+  TORCH_CHECK(segmented_range.scalar_type() == at::kLong,
+              "segmented_range must be int64");
+  TORCH_CHECK(segmented_range.device() == device,
+              "segmented_range must be on the same device as keys");
+  TORCH_CHECK(segmented_range.is_contiguous(),
+              "segmented_range must be contiguous");
   TORCH_CHECK(num_tables > 0, "num_tables must be positive");
   TORCH_CHECK(num_keys < std::numeric_limits<int32_t>::max(),
               "num_keys must be less than std::numeric_limits<int32_t>::max()");
@@ -485,12 +492,19 @@ segmented_unique_cuda(at::Tensor keys, at::Tensor table_ids, int64_t num_tables,
   constexpr int BLOCKS_PER_SM = 4;
   const int grid_size = device_sm_count * BLOCKS_PER_SM;
 
-  // Max keys per table (worst case: all keys go to one table)
-  const int64_t max_keys_per_table = num_keys;
+  // Generate per-element table_ids from segmented_range for hash logic and
+  // adjust_output_indices_kernel. Keys must be sorted by table:
+  // keys[segmented_range[t]:segmented_range[t+1]] all belong to table t.
+  at::Tensor table_ids = at::empty(
+      {num_keys}, at::TensorOptions().dtype(at::kLong).device(device));
+  expand_table_ids_kernel<<<grid_size, BLOCK_SIZE, 0, stream>>>(
+      get_pointer<const int64_t>(segmented_range), nullptr,
+      get_pointer<int64_t>(table_ids), num_tables, 1, num_keys);
+  DEMB_CUDA_KERNEL_LAUNCH_CHECK();
 
-  // Allocate partitioned output buffer (num_tables * max_keys_per_table)
-  at::Tensor partitioned_unique_keys =
-      at::empty({num_tables * max_keys_per_table}, keys.options());
+  // Partitioned buffer uses segmented_range as per-table offsets, so total
+  // size is num_keys instead of the worst-case num_tables * num_keys.
+  at::Tensor partitioned_unique_keys = at::empty({num_keys}, keys.options());
 
   // Allocate output indices (local indices within each table, adjusted later)
   at::Tensor output_indices = at::empty(
@@ -503,9 +517,8 @@ segmented_unique_cuda(at::Tensor keys, at::Tensor table_ids, int64_t num_tables,
   // Allocate partitioned frequency counters if needed
   at::Tensor partitioned_freq_counters;
   if (enable_freq_counting) {
-    partitioned_freq_counters =
-        at::zeros({num_tables * max_keys_per_table},
-                  at::TensorOptions().dtype(at::kLong).device(device));
+    partitioned_freq_counters = at::zeros(
+        {num_keys}, at::TensorOptions().dtype(at::kLong).device(device));
   }
 
   // Allocate shared hash table for (key, table_id) pairs
@@ -531,7 +544,8 @@ segmented_unique_cuda(at::Tensor keys, at::Tensor table_ids, int64_t num_tables,
             get_pointer<KeyType>(partitioned_unique_keys),
             get_pointer<int64_t>(output_indices), num_keys,
             get_pointer<KeyType>(hash_keys), get_pointer<int64_t>(hash_vals),
-            capacity, get_pointer<int64_t>(table_counters), max_keys_per_table,
+            capacity, get_pointer<int64_t>(table_counters),
+            get_pointer<const int64_t>(segmented_range),
             enable_freq_counting
                 ? get_pointer<int64_t>(partitioned_freq_counters)
                 : nullptr,
@@ -577,7 +591,8 @@ segmented_unique_cuda(at::Tensor keys, at::Tensor table_ids, int64_t num_tables,
         enable_freq_counting
             ? get_pointer<const int64_t>(partitioned_freq_counters)
             : nullptr,
-        max_keys_per_table, get_pointer<const int64_t>(table_offsets),
+        get_pointer<const int64_t>(segmented_range),
+        get_pointer<const int64_t>(table_offsets),
         num_tables, get_pointer<KeyType>(unique_keys),
         enable_freq_counting ? get_pointer<int64_t>(output_freq_counters)
                              : nullptr,
@@ -713,7 +728,7 @@ std::tuple<at::Tensor, at::Tensor> compute_dedup_lengths_cuda(
 void bind_unique_op(py::module &m) {
   m.def(
       "segmented_unique_cuda",
-      [](at::Tensor keys, at::Tensor table_ids, int64_t num_tables,
+      [](at::Tensor keys, at::Tensor segmented_range, int64_t num_tables,
          const c10::optional<at::Tensor> &input_frequencies) {
         // Convert optional to tensor:
         // - None -> undefined tensor (disables frequency counting)
@@ -724,22 +739,23 @@ void bind_unique_op(py::module &m) {
         }
         // If input_frequencies was None, freq_tensor remains undefined
         // which will disable frequency counting in the C++ implementation
-        return dyn_emb::segmented_unique_cuda(keys, table_ids, num_tables,
+        return dyn_emb::segmented_unique_cuda(keys, segmented_range, num_tables,
                                               freq_tensor);
       },
       R"doc(
 Segmented unique: deduplicate keys per table using GPU hash table.
 
-Keys are deduplicated within each table independently. The same key can
-appear in different tables. Uses compound hashing on (key, table_id) pairs
-with a single shared hash table for memory efficiency.
+Keys must be pre-sorted by table: keys[segmented_range[t]:segmented_range[t+1]]
+all belong to table t. Keys are deduplicated within each table independently.
+The same key can appear in different tables.
 
 NOTE: This function is fully asynchronous with no GPU-CPU synchronization.
 
 Args:
-    keys: Input keys tensor (int64 or uint64)
-    table_ids: Table ID for each key (int64, same length as keys,
-               must be in ascending order)
+    keys: Input keys tensor (int64 or uint64), sorted by table.
+    segmented_range: Table boundary offsets (int64, size=num_tables+1).
+                     segmented_range[t] is the start index in keys for table t;
+                     segmented_range[num_tables] must equal len(keys).
     num_tables: Total number of tables
     input_frequencies: Controls frequency counting behavior:
                        - None: Disable frequency counting (output freq_counters empty)
@@ -752,11 +768,11 @@ Returns:
     - unique_keys: Compacted unique keys with size=len(keys). Only first
                    num_uniques elements are valid.
     - output_indices: Index mapping (input idx -> global unique idx)
-    - table_offsets: Tensor of size (num_tables + 1) with cumulative counts
-                     table_offsets[i] is the start index for table i
+    - table_offsets: Tensor of size (num_tables + 1) with cumulative unique counts
+                     table_offsets[i] is the start index for table i in unique_keys
     - frequency_counters: Per-unique-key frequency counts (empty if disabled)
 )doc",
-      py::arg("keys"), py::arg("table_ids"), py::arg("num_tables"),
+      py::arg("keys"), py::arg("segmented_range"), py::arg("num_tables"),
       py::arg("input_frequencies") = py::none());
 
   m.def(

--- a/corelib/dynamicemb/src/unique_op.cu
+++ b/corelib/dynamicemb/src/unique_op.cu
@@ -29,6 +29,7 @@ All rights reserved. # SPDX-License-Identifier: Apache-2.0
 #endif
 
 #include <cassert>
+#include <cstdlib>
 #include <limits>
 
 #ifdef DEMB_USE_PYBIND11
@@ -474,6 +475,24 @@ segmented_unique_cuda(at::Tensor keys, at::Tensor segmented_range,
   if (has_input_freq) {
     TORCH_CHECK(input_frequencies.numel() == num_keys,
                 "input_frequencies must have same length as keys");
+  }
+
+  // Debug validation of segmented_range (enabled via DYNAMICEMB_DEBUG=1).
+  // Checks: starts at 0, ends at num_keys, monotonically non-decreasing.
+  if (std::getenv("DYNAMICEMB_DEBUG")) {
+    at::Tensor sr_cpu = segmented_range.to(at::kCPU);
+    const int64_t *sr = sr_cpu.data_ptr<int64_t>();
+    TORCH_CHECK(sr[0] == 0,
+                "segmented_range[0] must be 0, got ", sr[0]);
+    TORCH_CHECK(sr[num_tables] == num_keys,
+                "segmented_range[num_tables] must equal num_keys (", num_keys,
+                "), got ", sr[num_tables]);
+    for (int64_t t = 0; t < num_tables; ++t) {
+      TORCH_CHECK(sr[t + 1] >= sr[t],
+                  "segmented_range must be non-decreasing: "
+                  "segmented_range[", t + 1, "]=", sr[t + 1],
+                  " < segmented_range[", t, "]=", sr[t]);
+    }
   }
 
   // Handle empty input

--- a/corelib/dynamicemb/src/unique_op.cu
+++ b/corelib/dynamicemb/src/unique_op.cu
@@ -381,8 +381,8 @@ __global__ void compact_keys_and_freq_kernel(
 // ============================================================================
 
 // Expand jagged offsets to per-element table_ids (identity mapping,
-// local_batch_size=1). Binary search on offsets: find largest t such that
-// offsets[t] <= idx.
+// local_batch_size=1). For each idx, find largest t such that offsets[t] <= idx
+// via binary_search_upper_bound (defined above).
 __global__ void expand_table_ids_kernel(const int64_t *offsets,
                                         int64_t *table_ids, int num_tables,
                                         int64_t num_elements) {
@@ -390,13 +390,7 @@ __global__ void expand_table_ids_kernel(const int64_t *offsets,
 
   for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < num_elements;
        idx += stride) {
-    int lo = 0, hi = num_tables;
-    while (lo < hi) {
-      int mid = (lo + hi + 1) / 2;
-      if (offsets[mid] <= idx) lo = mid;
-      else hi = mid - 1;
-    }
-    table_ids[idx] = lo;
+    table_ids[idx] = binary_search_upper_bound(offsets, num_tables + 1, idx);
   }
 }
 

--- a/corelib/dynamicemb/src/unique_op.h
+++ b/corelib/dynamicemb/src/unique_op.h
@@ -28,25 +28,24 @@ namespace dyn_emb {
 /**
  * @brief Segmented unique operation that deduplicates keys per table.
  *
- * This function performs unique operation on keys partitioned by table_ids.
- * Keys are deduplicated within each table independently, allowing the same key
- * to appear in different tables. Uses compound hashing on (key, table_id) pairs
- * with a single shared hash table for memory efficiency.
+ * Keys must be pre-sorted by table: keys[segmented_range[t]:segmented_range[t+1]]
+ * all belong to table t. Uses compound hashing on (key, table_id) pairs with a
+ * single shared hash table for memory efficiency.
  *
  * NOTE: This function is fully asynchronous with no GPU-CPU synchronization.
  *
- * @param keys Input keys tensor (int64 or uint64)
- * @param table_ids Table ID for each key (int64, same length as keys,
- *                  must be in ascending order)
+ * @param keys Input keys tensor (int64 or uint64), sorted by table.
+ * @param segmented_range Table boundary offsets (int64, size = num_tables+1).
+ *                        segmented_range[t] is the start index in keys for
+ *                        table t; segmented_range[num_tables] == num_keys.
  * @param num_tables Total number of tables
  * @param input_frequencies Controls frequency counting behavior:
  *                          - Undefined/empty tensor with numel()==0: Enable
- *                            frequency counting with each occurrence counted as
- * 1
+ *                            frequency counting with each occurrence counted as 1
  *                          - Tensor with numel()==num_keys: Use provided
  *                            frequencies for weighted counting
  *                          - Pass None from Python to disable frequency
- * counting entirely (output freq_counters will be empty)
+ *                            counting entirely (output freq_counters will be empty)
  *
  * @return Tuple of (num_uniques, unique_keys, output_indices, table_offsets,
  *         freq_counters)
@@ -56,12 +55,13 @@ namespace dyn_emb {
  *           input). Only first num_uniques elements are valid.
  *         - output_indices: Index mapping (input idx -> global unique idx)
  *         - table_offsets: Tensor of size (num_tables + 1) with cumulative
- *           counts.
+ *           unique counts per table.
  *         - freq_counters: Frequency counts per unique key. Empty if frequency
  *           counting is disabled (input_frequencies was None).
  */
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
-segmented_unique_cuda(at::Tensor keys, at::Tensor table_ids, int64_t num_tables,
+segmented_unique_cuda(at::Tensor keys, at::Tensor segmented_range,
+                      int64_t num_tables,
                       at::Tensor input_frequencies = at::Tensor());
 
 /**

--- a/corelib/dynamicemb/src/unique_op.h
+++ b/corelib/dynamicemb/src/unique_op.h
@@ -65,31 +65,19 @@ segmented_unique_cuda(at::Tensor keys, at::Tensor segmented_range,
                       at::Tensor input_frequencies = at::Tensor());
 
 /**
- * @brief Expand table IDs from offsets.
+ * @brief Expand table IDs from offsets (identity mapping: one feature per table,
+ * local_batch_size=1).
  *
- * Generates a table_id for each element based on offsets structure.
- * This is a helper function to prepare input for segmented_unique_cuda.
+ * Generates a table_id for each element via binary search on offsets.
+ * num_tables is derived from offsets.size(0)-1.
  *
- * @param offsets Jagged tensor offsets (int64)
- *                Size = num_features * local_batch_size + 1
- *                Indexed by (feature_id * local_batch_size + batch_id)
- *
- * @param table_offsets_in_feature Feature offsets per table (int64), or None
- *                Size = num_tables + 1
- *                Maps features to tables (adjacent features may share a table)
- *                table_offsets_in_feature[t] is the first feature index for
- * table t If None: each feature is treated as a separate table
- *
- * @param num_tables Number of tables (ignored if table_offsets_in_feature is
- * None)
- * @param local_batch_size Batch size per feature
+ * @param offsets Jagged tensor offsets (int64, size = num_tables + 1)
+ *                offsets[t] is the start index for table t's keys.
  * @param num_elements Total number of elements (keys)
  *
  * @return table_ids tensor (int64) with same length as num_elements
  */
-at::Tensor expand_table_ids_cuda(
-    at::Tensor offsets, c10::optional<at::Tensor> table_offsets_in_feature,
-    int64_t num_tables, int64_t local_batch_size, int64_t num_elements);
+at::Tensor expand_table_ids_cuda(at::Tensor offsets, int64_t num_elements);
 
 /**
  * @brief Compute new lengths and offsets by evenly distributing unique keys.

--- a/corelib/dynamicemb/test/test_batched_dynamic_embedding_tables_v2.py
+++ b/corelib/dynamicemb/test/test_batched_dynamic_embedding_tables_v2.py
@@ -2433,6 +2433,7 @@ def test_multi_table_dump_load(opt_type, opt_params, tmp_path):
 
     print("test_multi_table_dump_load passed")
 
+
 def _make_multi_table_bdeb_for_dump_load(
     opt_type: EmbOptimType,
     opt_params: Dict[str, Any],
@@ -2477,9 +2478,7 @@ def _train_multi_table_bdeb_once(
     key_type: torch.dtype,
     device: torch.device,
 ) -> None:
-    indices = torch.tensor(
-        [0, 1, 2, 3, 10, 11, 12, 13], dtype=key_type, device=device
-    )
+    indices = torch.tensor([0, 1, 2, 3, 10, 11, 12, 13], dtype=key_type, device=device)
     offsets = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8], dtype=key_type, device=device)
 
     for _ in range(3):

--- a/corelib/dynamicemb/test/test_unique_op.py
+++ b/corelib/dynamicemb/test/test_unique_op.py
@@ -59,8 +59,12 @@ def test_segmented_unique_basic(setup_device):
     )
 
     # Assign tables, sort keys by table to satisfy segmented_range contract
-    table_assignments = torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
-    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    table_assignments = torch.randint(
+        0, num_tables, (num_keys,), dtype=torch.int64, device=device
+    )
+    sort_idx, segmented_range = make_segmented_range(
+        table_assignments, num_tables, device
+    )
     keys = keys_raw[sort_idx]
 
     (
@@ -118,8 +122,12 @@ def test_segmented_unique_overlapping_keys(setup_device):
         0, num_unique_keys, (num_keys,), dtype=torch.int64, device=device
     )
 
-    table_assignments = torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
-    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    table_assignments = torch.randint(
+        0, num_tables, (num_keys,), dtype=torch.int64, device=device
+    )
+    sort_idx, segmented_range = make_segmented_range(
+        table_assignments, num_tables, device
+    )
     keys = keys_raw[sort_idx]
 
     num_uniques, unique_keys, output_indices, table_offsets, _ = segmented_unique_cuda(
@@ -164,11 +172,15 @@ def test_segmented_unique_empty_tables(setup_device):
     active_tables = [0, 1, 3, 4, 6, 8, 9]
     active_tables_tensor = torch.tensor(active_tables, dtype=torch.int64, device=device)
     table_assignments = active_tables_tensor[
-        torch.randint(0, len(active_tables), (num_keys,), dtype=torch.int64, device=device)
+        torch.randint(
+            0, len(active_tables), (num_keys,), dtype=torch.int64, device=device
+        )
     ]
 
     keys_raw = torch.randint(0, 10000, (num_keys,), dtype=torch.int64, device=device)
-    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    sort_idx, segmented_range = make_segmented_range(
+        table_assignments, num_tables, device
+    )
     keys = keys_raw[sort_idx]
 
     num_uniques, unique_keys, output_indices, table_offsets, _ = segmented_unique_cuda(
@@ -244,8 +256,12 @@ def test_segmented_unique_random(setup_device):
     num_keys = 1_000_000
 
     keys_raw = torch.randint(0, 100000, (num_keys,), dtype=torch.int64, device=device)
-    table_assignments = torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
-    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    table_assignments = torch.randint(
+        0, num_tables, (num_keys,), dtype=torch.int64, device=device
+    )
+    sort_idx, segmented_range = make_segmented_range(
+        table_assignments, num_tables, device
+    )
     keys = keys_raw[sort_idx]
 
     num_uniques, unique_keys, output_indices, table_offsets, _ = segmented_unique_cuda(
@@ -283,8 +299,12 @@ def test_segmented_unique_stress(setup_device):
     num_keys = 4_000_000
 
     keys_raw = torch.randint(0, 500000, (num_keys,), dtype=torch.int64, device=device)
-    table_assignments = torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
-    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    table_assignments = torch.randint(
+        0, num_tables, (num_keys,), dtype=torch.int64, device=device
+    )
+    sort_idx, segmented_range = make_segmented_range(
+        table_assignments, num_tables, device
+    )
     keys = keys_raw[sort_idx]
 
     # Warmup
@@ -325,8 +345,12 @@ def test_segmented_unique_with_frequency_counters(setup_device):
     num_keys = 100000
 
     keys_raw = torch.randint(0, 1000, (num_keys,), dtype=torch.int64, device=device)
-    table_assignments = torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
-    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    table_assignments = torch.randint(
+        0, num_tables, (num_keys,), dtype=torch.int64, device=device
+    )
+    sort_idx, segmented_range = make_segmented_range(
+        table_assignments, num_tables, device
+    )
     keys = keys_raw[sort_idx]
 
     # Enable frequency counting by passing an empty tensor (numel==0)
@@ -378,8 +402,12 @@ def test_segmented_unique_with_custom_frequencies(setup_device):
     num_keys = 1000
 
     keys_raw = torch.randint(0, 100, (num_keys,), dtype=torch.int64, device=device)
-    table_assignments = torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
-    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    table_assignments = torch.randint(
+        0, num_tables, (num_keys,), dtype=torch.int64, device=device
+    )
+    sort_idx, segmented_range = make_segmented_range(
+        table_assignments, num_tables, device
+    )
     keys = keys_raw[sort_idx]
 
     # Custom frequencies: each key occurrence has frequency 2 (sorted same as keys)
@@ -433,9 +461,9 @@ def test_expand_table_ids(setup_device):
 
     table_ids_cpu = table_ids.cpu()
     expected = torch.repeat_interleave(torch.arange(3), counts)
-    assert torch.equal(table_ids_cpu, expected), (
-        f"table_ids mismatch: {table_ids_cpu} vs {expected}"
-    )
+    assert torch.equal(
+        table_ids_cpu, expected
+    ), f"table_ids mismatch: {table_ids_cpu} vs {expected}"
 
     # Edge: empty input
     empty_ids = expand_table_ids_cuda(segmented_range, 0)

--- a/corelib/dynamicemb/test/test_unique_op.py
+++ b/corelib/dynamicemb/test/test_unique_op.py
@@ -416,83 +416,32 @@ def test_segmented_unique_with_custom_frequencies(setup_device):
 
 
 def test_expand_table_ids(setup_device):
-    """Test expand_table_ids_cuda helper function."""
+    """Test expand_table_ids_cuda (identity mapping, local_batch_size=1)."""
     device = setup_device
-    torch.cuda.get_device_properties(device).multi_processor_count
 
-    # Simulate a jagged tensor with 2 tables, 2 features per table, batch_size=3
-    # Table 0: features 0, 1
-    # Table 1: features 2, 3
-    # Offsets structure: offsets[feature_idx * batch_size + batch_idx]
-    num_tables = 2
-    local_batch_size = 3
-    features_per_table = 2
-    num_features = num_tables * features_per_table  # 4 features
+    # 3 tables with 5, 8, 3 keys respectively; total 16 elements
+    counts = torch.tensor([5, 8, 3], dtype=torch.int64)
+    segmented_range = torch.zeros(4, dtype=torch.int64, device=device)
+    segmented_range[1:] = torch.cumsum(counts, dim=0).to(device)
+    num_elements = segmented_range[-1].item()
 
-    # Create lengths for each (feature, batch) pair
-    # Feature 0: batch lengths [2, 1, 3] = 6 elements
-    # Feature 1: batch lengths [1, 2, 1] = 4 elements
-    # Feature 2: batch lengths [3, 2, 2] = 7 elements
-    # Feature 3: batch lengths [1, 1, 2] = 4 elements
-    # Total: 21 elements
-    lengths = torch.tensor(
-        [
-            2,
-            1,
-            3,  # Feature 0, batches 0-2
-            1,
-            2,
-            1,  # Feature 1, batches 0-2
-            3,
-            2,
-            2,  # Feature 2, batches 0-2
-            1,
-            1,
-            2,  # Feature 3, batches 0-2
-        ],
-        dtype=torch.int64,
-        device=device,
-    )
-
-    offsets = torch.zeros(len(lengths) + 1, dtype=torch.int64, device=device)
-    offsets[1:] = torch.cumsum(lengths, dim=0)
-
-    # Table offsets in features: table 0 starts at feature 0, table 1 at feature 2
-    table_offsets_in_feature = torch.tensor([0, 2, 4], dtype=torch.int64, device=device)
-
-    num_elements = offsets[-1].item()
-
-    table_ids = expand_table_ids_cuda(
-        offsets,
-        table_offsets_in_feature,
-        num_tables,
-        local_batch_size,
-        num_elements,
-    )
+    table_ids = expand_table_ids_cuda(segmented_range, num_elements)
     torch.cuda.synchronize()
 
-    assert (
-        table_ids.numel() == num_elements
-    ), f"Expected {num_elements} table_ids, got {table_ids.numel()}"
-    assert table_ids.dtype == torch.int64, "table_ids should be int64"
+    assert table_ids.numel() == num_elements
+    assert table_ids.dtype == torch.int64
 
-    # Verify table_ids are correct
-    # Table 0 has features 0 and 1: elements 0-9 (6 + 4 = 10 elements)
-    # Table 1 has features 2 and 3: elements 10-20 (7 + 4 = 11 elements)
     table_ids_cpu = table_ids.cpu()
+    expected = torch.repeat_interleave(torch.arange(3), counts)
+    assert torch.equal(table_ids_cpu, expected), (
+        f"table_ids mismatch: {table_ids_cpu} vs {expected}"
+    )
 
-    # Table 0 ends at offset of feature 2 (which is table_offsets_in_feature[1] * batch_size)
-    table0_end_offset_idx = 2 * local_batch_size  # feature 2 * batch_size
-    table0_end = offsets[table0_end_offset_idx].item()  # = 10
+    # Edge: empty input
+    empty_ids = expand_table_ids_cuda(segmented_range, 0)
+    assert empty_ids.numel() == 0
 
-    assert torch.all(
-        table_ids_cpu[:table0_end] == 0
-    ), f"First table elements should have table_id=0, got {table_ids_cpu[:table0_end]}"
-    assert torch.all(
-        table_ids_cpu[table0_end:] == 1
-    ), f"Second table elements should have table_id=1, got {table_ids_cpu[table0_end:]}"
-
-    print(f"expand_table_ids test passed: {num_elements} elements, {num_tables} tables")
+    print(f"expand_table_ids test passed: {num_elements} elements, 3 tables")
 
 
 # ============================================================================

--- a/corelib/dynamicemb/test/test_unique_op.py
+++ b/corelib/dynamicemb/test/test_unique_op.py
@@ -22,6 +22,16 @@ from dynamicemb_extensions import (
 )
 
 
+def make_segmented_range(table_assignments: torch.Tensor, num_tables: int, device):
+    """Sort keys by table and return (sort_indices, segmented_range)."""
+    sort_idx = torch.argsort(table_assignments, stable=True)
+    sorted_assignments = table_assignments[sort_idx]
+    counts = torch.bincount(sorted_assignments, minlength=num_tables).to(torch.int64)
+    segmented_range = torch.zeros(num_tables + 1, dtype=torch.int64, device=device)
+    segmented_range[1:] = torch.cumsum(counts, dim=0)
+    return sort_idx, segmented_range
+
+
 @pytest.fixture
 def setup_device():
     assert torch.cuda.is_available()
@@ -44,14 +54,14 @@ def test_segmented_unique_basic(setup_device):
     num_unique_per_table = 10000  # Each table has ~10K unique keys
 
     # Generate keys with controlled uniqueness per table
-    keys = torch.randint(
+    keys_raw = torch.randint(
         0, num_unique_per_table, (num_keys,), dtype=torch.int64, device=device
     )
 
-    # Generate ascending table_ids (simulate sorted input)
-    table_ids = torch.sort(
-        torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
-    ).values
+    # Assign tables, sort keys by table to satisfy segmented_range contract
+    table_assignments = torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
+    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    keys = keys_raw[sort_idx]
 
     (
         num_uniques,
@@ -59,7 +69,7 @@ def test_segmented_unique_basic(setup_device):
         output_indices,
         table_offsets,
         freq_counters,
-    ) = segmented_unique_cuda(keys, table_ids, num_tables)
+    ) = segmented_unique_cuda(keys, segmented_range, num_tables)
     torch.cuda.synchronize()
 
     # Check table offsets
@@ -104,17 +114,16 @@ def test_segmented_unique_overlapping_keys(setup_device):
     num_unique_keys = 1000  # Small unique key space to maximize overlaps
 
     # Same keys appear across all tables - should be counted separately per table
-    keys = torch.randint(
+    keys_raw = torch.randint(
         0, num_unique_keys, (num_keys,), dtype=torch.int64, device=device
     )
 
-    # Generate ascending table_ids
-    table_ids = torch.sort(
-        torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
-    ).values
+    table_assignments = torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
+    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    keys = keys_raw[sort_idx]
 
     num_uniques, unique_keys, output_indices, table_offsets, _ = segmented_unique_cuda(
-        keys, table_ids, num_tables
+        keys, segmented_range, num_tables
     )
     torch.cuda.synchronize()
 
@@ -151,19 +160,19 @@ def test_segmented_unique_empty_tables(setup_device):
     num_tables = 10
     num_keys = 1_000_000
 
-    # Create table_ids that skip some tables (tables 2, 5, 7 will be empty)
+    # Assign keys only to active tables (tables 2, 5, 7 will be empty)
     active_tables = [0, 1, 3, 4, 6, 8, 9]
-    table_ids_list = torch.randint(
-        0, len(active_tables), (num_keys,), dtype=torch.int64, device=device
-    )
-    # Map to actual table IDs
     active_tables_tensor = torch.tensor(active_tables, dtype=torch.int64, device=device)
-    table_ids = torch.sort(active_tables_tensor[table_ids_list]).values
+    table_assignments = active_tables_tensor[
+        torch.randint(0, len(active_tables), (num_keys,), dtype=torch.int64, device=device)
+    ]
 
-    keys = torch.randint(0, 10000, (num_keys,), dtype=torch.int64, device=device)
+    keys_raw = torch.randint(0, 10000, (num_keys,), dtype=torch.int64, device=device)
+    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    keys = keys_raw[sort_idx]
 
     num_uniques, unique_keys, output_indices, table_offsets, _ = segmented_unique_cuda(
-        keys, table_ids, num_tables
+        keys, segmented_range, num_tables
     )
     torch.cuda.synchronize()
 
@@ -202,8 +211,8 @@ def test_segmented_unique_empty_input(setup_device):
     torch.cuda.get_device_properties(device).multi_processor_count
 
     keys = torch.tensor([], dtype=torch.int64, device=device)
-    table_ids = torch.tensor([], dtype=torch.int64, device=device)
     num_tables = 3
+    segmented_range = torch.zeros(num_tables + 1, dtype=torch.int64, device=device)
 
     (
         num_uniques,
@@ -211,7 +220,7 @@ def test_segmented_unique_empty_input(setup_device):
         output_indices,
         table_offsets,
         freq_counters,
-    ) = segmented_unique_cuda(keys, table_ids, num_tables)
+    ) = segmented_unique_cuda(keys, segmented_range, num_tables)
     torch.cuda.synchronize()
 
     assert unique_keys.numel() == 0, "Empty input should return empty unique keys"
@@ -234,16 +243,13 @@ def test_segmented_unique_random(setup_device):
     num_tables = 16
     num_keys = 1_000_000
 
-    # Generate random keys with high uniqueness
-    keys = torch.randint(0, 100000, (num_keys,), dtype=torch.int64, device=device)
-
-    # Generate ascending table_ids (simulate sorted input)
-    table_ids = torch.sort(
-        torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
-    ).values
+    keys_raw = torch.randint(0, 100000, (num_keys,), dtype=torch.int64, device=device)
+    table_assignments = torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
+    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    keys = keys_raw[sort_idx]
 
     num_uniques, unique_keys, output_indices, table_offsets, _ = segmented_unique_cuda(
-        keys, table_ids, num_tables
+        keys, segmented_range, num_tables
     )
     torch.cuda.synchronize()
 
@@ -276,13 +282,10 @@ def test_segmented_unique_stress(setup_device):
     num_tables = 32
     num_keys = 4_000_000
 
-    # Generate random keys
-    keys = torch.randint(0, 500000, (num_keys,), dtype=torch.int64, device=device)
-
-    # Generate ascending table_ids
-    table_ids = torch.sort(
-        torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
-    ).values
+    keys_raw = torch.randint(0, 500000, (num_keys,), dtype=torch.int64, device=device)
+    table_assignments = torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
+    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    keys = keys_raw[sort_idx]
 
     # Warmup
     torch.cuda.synchronize()
@@ -292,7 +295,7 @@ def test_segmented_unique_stress(setup_device):
     start = time.perf_counter()
 
     num_uniques, unique_keys, output_indices, table_offsets, _ = segmented_unique_cuda(
-        keys, table_ids, num_tables
+        keys, segmented_range, num_tables
     )
     torch.cuda.synchronize()
 
@@ -321,11 +324,10 @@ def test_segmented_unique_with_frequency_counters(setup_device):
     num_tables = 4
     num_keys = 100000
 
-    # Generate keys with known frequencies
-    keys = torch.randint(0, 1000, (num_keys,), dtype=torch.int64, device=device)
-    table_ids = torch.sort(
-        torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
-    ).values
+    keys_raw = torch.randint(0, 1000, (num_keys,), dtype=torch.int64, device=device)
+    table_assignments = torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
+    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    keys = keys_raw[sort_idx]
 
     # Enable frequency counting by passing an empty tensor (numel==0)
     # This enables counting with each key occurrence counted as 1
@@ -337,7 +339,7 @@ def test_segmented_unique_with_frequency_counters(setup_device):
         output_indices,
         table_offsets,
         freq_counters,
-    ) = segmented_unique_cuda(keys, table_ids, num_tables, empty_freq_tensor)
+    ) = segmented_unique_cuda(keys, segmented_range, num_tables, empty_freq_tensor)
     torch.cuda.synchronize()
 
     # freq_counters should have values
@@ -375,13 +377,12 @@ def test_segmented_unique_with_custom_frequencies(setup_device):
     num_tables = 2
     num_keys = 1000
 
-    # Generate keys with duplicates
-    keys = torch.randint(0, 100, (num_keys,), dtype=torch.int64, device=device)
-    table_ids = torch.sort(
-        torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
-    ).values
+    keys_raw = torch.randint(0, 100, (num_keys,), dtype=torch.int64, device=device)
+    table_assignments = torch.randint(0, num_tables, (num_keys,), dtype=torch.int64, device=device)
+    sort_idx, segmented_range = make_segmented_range(table_assignments, num_tables, device)
+    keys = keys_raw[sort_idx]
 
-    # Custom frequencies: each key occurrence has frequency 2
+    # Custom frequencies: each key occurrence has frequency 2 (sorted same as keys)
     input_frequencies = torch.full((num_keys,), 2, dtype=torch.int64, device=device)
 
     (
@@ -390,7 +391,7 @@ def test_segmented_unique_with_custom_frequencies(setup_device):
         output_indices,
         table_offsets,
         freq_counters,
-    ) = segmented_unique_cuda(keys, table_ids, num_tables, input_frequencies)
+    ) = segmented_unique_cuda(keys, segmented_range, num_tables, input_frequencies)
     torch.cuda.synchronize()
 
     total_unique = num_uniques.item()

--- a/corelib/dynamicemb/test/unit_tests/test_embedding_dump_load.py
+++ b/corelib/dynamicemb/test/unit_tests/test_embedding_dump_load.py
@@ -448,6 +448,7 @@ def check_counter_table_checkpoint(x, y):
                     frequencies, score_out
                 ), f"counter frequency mismatch for table_id={table_id}"
 
+
 def assert_dist_type_path(model: nn.Module, expected_dist_type: str) -> None:
     seen_sharding = False
     seen_input_dist = False
@@ -469,6 +470,7 @@ def assert_dist_type_path(model: nn.Module, expected_dist_type: str) -> None:
 
     assert seen_sharding, "Did not find any DynamicEmb sharding carrying dist_type."
     assert seen_input_dist, "Did not find any input_dist carrying dist_type."
+
 
 @click.command()
 @click.option("--num-embedding-collections", type=int, required=True)
@@ -531,7 +533,7 @@ def test_model_load_dump(
         embedding_dim=embedding_dim,
         optimizer_kwargs=optimizer_kwargs,
         score_strategy=score_strategy_,
-        dist_type=dist_type,        
+        dist_type=dist_type,
         admit_strategy=FrequencyAdmissionStrategy(
             threshold=2 if counter else 1,
         ),
@@ -551,7 +553,7 @@ def test_model_load_dump(
         score_strategy=score_strategy,
         scores_collection=expect_scores_collection,
     )
-    
+
     asserted_ref_dist_type = False
     for kjt in kjts:
         ret = ref_model(kjt)

--- a/corelib/dynamicemb/test/unit_tests/test_hash_roundrobin_kuairand.py
+++ b/corelib/dynamicemb/test/unit_tests/test_hash_roundrobin_kuairand.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 import torch
 
-
 HASH_SIZE = 10_000_000
 KUAIRAND_1K_FEATURES = {
     "video_id": 49332,
@@ -324,7 +323,9 @@ def test_bucketize_kernel_matches_cpu_reference(feature_name, my_size):
     except ImportError:
         pytest.skip("dynamicemb_extensions not available")
 
-    logical_indices = generate_zipf_logical_indices(feature_name, num_interactions=200_000)
+    logical_indices = generate_zipf_logical_indices(
+        feature_name, num_interactions=200_000
+    )
     adversarial_indices = remap_frequency_histogram_to_adversarial_keys(
         logical_indices,
         my_size,
@@ -387,4 +388,3 @@ def test_bucketize_kernel_matches_cpu_reference(feature_name, my_size):
         assert total_output == batch_size
         assert torch.all(new_indices >= 0).item()
         assert rank_counts.tolist() == cpu_hist.tolist()
-


### PR DESCRIPTION
# Refactor: `segmented_unique_cuda` — `table_ids` → `segmented_range`

## Background

`segmented_unique_cuda` previously accepted a per-element `table_ids` tensor (size = num_keys)
identifying which embedding table each key belongs to. At every call site, `table_ids` was
produced by `expand_table_ids_cuda` expanding a compact `segmented_range` boundary tensor —
an O(N log T) redundant step that also allocated an extra N-element tensor.

**Goal**: Change `segmented_unique_cuda` to accept `segmented_range` (shape `[num_tables+1]`)
directly, eliminating `expand_table_ids_cuda` at all call sites and shrinking the internal
partitioned buffer from O(T×N) to O(N).

---

## Call Site Analysis (before)

| File | Location | Source of `table_ids` |
|------|----------|-----------------------|
| `batched_dynamicemb_function.py` | `segmented_unique()` | `expand_table_ids_cuda(segment_range, None, num_tables, 1, num_keys)` |
| `shard/embedding.py` | `_dedup_indices()` | `expand_table_ids_cuda(offsets, d_table_offset, table_num, local_batchsize, num_elements)` |
| `test/test_unique_op.py` | all test functions | `torch.sort(torch.randint(...)).values` — synthetic, keys not sorted by table |

---

## Memory Optimization

### Before

```cpp
const int64_t max_keys_per_table = num_keys;  // worst case: all keys in one table
at::Tensor partitioned_unique_keys = at::empty({num_tables * max_keys_per_table}, ...);
// actual allocation: num_tables * num_keys
```

### After

`segmented_range[t+1] - segmented_range[t]` is the exact key count for table t, so the
partitioned buffer can be tightly allocated with table t's partition starting at
`segmented_range[t]`:

```
old layout: [table0: num_keys slots | table1: num_keys slots | ...]  → num_tables * num_keys
new layout: [table0: cnt0 slots | table1: cnt1 slots | ...]          → num_keys
```

Saves `(num_tables - 1) * num_keys` allocation; `partitioned_freq_counters` benefits equally.

---

## Implementation

### Design Decisions

**Internal `table_ids` generation**: `expand_table_ids_kernel(segmented_range, table_ids,
num_tables, num_keys)` is called inside `segmented_unique_cuda` to produce a per-element
`table_ids` tensor. This keeps `segmented_unique_kernel` and `adjust_output_indices_kernel`
unchanged (they still do O(1) per-element lookups). `segmented_range` is additionally passed
to `segmented_unique_kernel` and `compact_keys_and_freq_kernel` to compute partition offsets
(`d_segmented_range[table_id] + local_idx` instead of `table_id * max_keys_per_table + local_idx`).

**`adjust_output_indices_kernel`** is not modified — it continues to use the internally
generated `table_ids`.

**Unifying `shard/embedding.py`**: Both call sites now use `get_table_range(offsets,
feature_offsets)` to obtain `segmented_range`, rather than manual indexing
(`offsets[d_table_offset * local_batchsize]`). The two approaches are mathematically
equivalent; `get_table_range` is preferred for consistency and correct dtype handling.

**Second-parameter semantics of `get_table_range`**: confirmed identical at both call sites —
a cumulative feature-offset array `[0, f₀, f₀+f₁, ..., Σfᵢ]` where `feature_offsets[t]` is
the index of the first feature for table t and `feature_offsets[num_tables]` is the total
feature count.

### Changes per File

#### `src/unique_op.h`
- `segmented_unique_cuda` signature: `table_ids` → `segmented_range`
- Updated doc comment: keys must be pre-sorted by table
  (`keys[segmented_range[t]:segmented_range[t+1]]` all belong to table t)

#### `src/unique_op.cu`

**Host function `segmented_unique_cuda`**:
- Added validation: `numel() == num_tables+1`, `scalar_type() == kLong`,
  `is_contiguous()`, same device as keys
- Debug validation via `DYNAMICEMB_DEBUG=1` (see below): checks `segmented_range[0]==0`,
  `segmented_range[num_tables]==num_keys`, and monotonically non-decreasing
- Internally calls `expand_table_ids_kernel(segmented_range, table_ids, num_tables, num_keys)`
  to generate per-element `table_ids`
- `partitioned_unique_keys`: `{num_tables * num_keys}` → `{num_keys}`
- `partitioned_freq_counters`: same reduction

**`segmented_unique_kernel`**:
- New parameter `const int64_t *d_segmented_range`; removed `max_keys_per_table`
- Write position: `table_id * max_keys_per_table + local_idx`
  → `d_segmented_range[table_id] + local_idx`

**`compact_keys_and_freq_kernel`**:
- New parameter `const int64_t *d_segmented_range`; removed `max_keys_per_table`
- Source position: `table_id * max_keys_per_table + local_idx`
  → `d_segmented_range[table_id] + local_idx`
- Note: `table_id` is derived from the output `table_offsets` via binary search;
  `d_segmented_range` locates the source partition — these two tensors have different semantics

**`adjust_output_indices_kernel`**: unchanged; still uses internally generated `table_ids`.

**`bind_unique_op` (Python binding)**:
- Lambda parameter renamed `table_ids` → `segmented_range`; C++ call updated accordingly
- Docstring updated to reflect new interface

#### `batched_dynamicemb_function.py`
- `segmented_unique()`: removed `expand_table_ids_cuda` call; passes `segment_range` directly
  to `segmented_unique_cuda`
- `expand_table_ids_cuda` import retained — still used at L719-725 and L871-877 to expand
  `unique_indices_table_range` for downstream lookup

#### `shard/embedding.py`
- `_dedup_indices()`: `expand_table_ids_cuda(offsets, d_table_offset, ...)` →
  `get_table_range(offsets, d_table_offset)`
- Imports: removed `expand_table_ids_cuda`, added `get_table_range`

#### `test/test_unique_op.py`
- Added `make_segmented_range(table_assignments, num_tables, device)` helper:
  argsorts by table, computes `bincount` + `cumsum` to produce `segmented_range`, and returns
  both the sort indices (for reordering keys) and `segmented_range`
- All `segmented_unique_cuda` tests: `keys` reordered via `sort_idx` so that
  `keys[segmented_range[t]:segmented_range[t+1]]` belongs to table t; `segmented_range`
  passed instead of `table_ids`
- `test_expand_table_ids`: updated to test new simplified interface (identity mapping only)

#### `src/expand_table_ids_torch_binding.cu` (inference path)

`expand_table_ids_cuda` no longer supports `table_offsets_in_feature`. The inference op
(`INFERENCE_EMB::expand_table_ids`) still needs it (called from `exportable_tables.py` with
`self.feature_offsets_`). **Interface unchanged**; body adapted:
- Added `expand_table_ids_inference_kernel` in the binding file, supporting
  `feature_offsets` + arbitrary `local_batch_size`
- No longer calls `expand_table_ids_cuda`; fully self-contained
- `num_tables` kept as caller-supplied when `table_offsets_in_feature` is present
  (matching original behavior)

---

## Progress

- [x] Background analysis and call-site survey
- [x] CUDA kernel changes (`unique_op.cu` + `unique_op.h` + `bind_unique_op`)
- [x] Python call-site update (`batched_dynamicemb_function.py`)
- [x] Python call-site update (`shard/embedding.py`, unified via `get_table_range`)
- [x] Test file update (`test/test_unique_op.py`)
- [x] `get_table_range` second-parameter semantics verified consistent across both call sites
- [x] Debug env var `DYNAMICEMB_DEBUG=1` added: validates `segmented_range` on CPU before launch
- [x] `expand_table_ids_cuda` simplified: removed `table_offsets_in_feature`, `local_batch_size`,
      `num_tables`; inference binding adapted in-place with its own kernel
- [x] Build verification
- [x] Test run

---

## Debug Environment Variables

| Variable | Effect |
|----------|--------|
| `DYNAMICEMB_DEBUG=1` | In `segmented_unique_cuda`, copies `segmented_range` to CPU and verifies: `segmented_range[0]==0`, `segmented_range[num_tables]==num_keys`, and the array is monotonically non-decreasing. Raises a `TORCH_CHECK` failure with a descriptive message if any condition is violated. Incurs one D→H memcpy per call; intended for development/testing only. |

Usage:
```bash
DYNAMICEMB_DEBUG=1 python test/test_unique_op.py
```

---

## Key File Paths

```
corelib/dynamicemb/src/unique_op.cu
corelib/dynamicemb/src/unique_op.h
corelib/dynamicemb/src/table_operation/expand_table_ids_torch_binding.cu
corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
corelib/dynamicemb/dynamicemb/shard/embedding.py
corelib/dynamicemb/test/test_unique_op.py
```



## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
