### PR TITLE
fix(docker): disable build isolation for flash-attention install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,7 @@ RUN pip install --no-deps tensordict orjson && \
 
 RUN git clone -b arbitrary_mask https://github.com/jiayus-nvidia/flash-attention.git flash-attention && \
     cd flash-attention && \
-    pip install --no-deps -e .
+    pip install --no-deps --no-build-isolation -e .
 
 # Install fbgemm_gpu_hstu (package: fbgemm_gpu_hstu, import: hstu) from submodule
 COPY third_party/FBGEMM /workspace/deps/fbgemm_hstu


### PR DESCRIPTION
pip's default build isolation creates a fresh env without torch, so flash-attention's setup.py fails with ModuleNotFoundError: No module named 'torch' while getting requirements to build editable. Add --no-build-isolation to reuse the base image's torch, matching the fbgemm_gpu_hstu install just below.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
