### PR TITLE
perf: use pinned host copies in Python hot paths

### DIFF
--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
@@ -45,6 +45,32 @@ from dynamicemb_extensions import (
 )
 
 
+def _copy_cuda_tensor_to_pinned_cpu(tensor: torch.Tensor) -> torch.Tensor:
+    if not tensor.is_cuda:
+        return tensor.detach().cpu()
+    cpu = torch.empty(
+        tuple(tensor.shape),
+        dtype=tensor.dtype,
+        device=torch.device("cpu"),
+        pin_memory=True,
+    )
+    cpu.copy_(tensor.detach(), non_blocking=True)
+    torch.cuda.current_stream(tensor.device).synchronize()
+    return cpu
+
+
+def _scalar_item(tensor: torch.Tensor):
+    if not isinstance(tensor, torch.Tensor):
+        return tensor
+    if tensor.numel() != 1:
+        raise ValueError(f"expected scalar tensor, got shape {tuple(tensor.shape)}")
+    return _copy_cuda_tensor_to_pinned_cpu(tensor.reshape(1))[0].item()
+
+
+def _bool_item(tensor: torch.Tensor) -> bool:
+    return bool(_scalar_item(tensor))
+
+
 def segmented_unique(
     keys: torch.Tensor,
     segment_range: torch.Tensor,
@@ -112,7 +138,7 @@ def segmented_unique(
             freq_counters,
         ) = segmented_unique_cuda(keys, segment_range, num_tables, input_frequencies)
 
-        table_offsets_cpu = table_offsets.cpu()
+        table_offsets_cpu = _copy_cuda_tensor_to_pinned_cpu(table_offsets)
         total_unique = table_offsets_cpu[num_tables].item()
         unique_size_per_table = (
             table_offsets_cpu[1 : num_tables + 1] - table_offsets_cpu[0:num_tables]
@@ -348,7 +374,8 @@ def _prefetch_cache_path(
         non_admitted_positions: Optional[torch.Tensor] = None
         keys_to_insert_mask = storage_founds.clone()
 
-        if new_in_miss.any() and admit_strategy is not None:
+        has_new_in_miss = _bool_item(new_in_miss.any())
+        if has_new_in_miss and admit_strategy is not None:
             new_miss_indices = torch.where(new_in_miss)[0]
             new_keys_sub = miss_keys[new_miss_indices]
             new_tids_sub = miss_tids[new_miss_indices]
@@ -364,23 +391,23 @@ def _prefetch_cache_path(
             freq = admission_counter.add(new_keys_sub, new_tids_sub, counters)
             admit_mask = admit_strategy.admit(new_keys_sub, freq)
 
-            if admit_mask.any():
+            if _bool_item(admit_mask.any()):
                 admission_counter.erase(
                     new_keys_sub[admit_mask], new_tids_sub[admit_mask]
                 )
                 keys_to_insert_mask[new_miss_indices[admit_mask]] = True
 
             non_admit = ~admit_mask
-            if non_admit.any():
+            if _bool_item(non_admit.any()):
                 non_admitted_miss_pos = new_miss_indices[non_admit]
                 non_admitted_positions = miss_compact_idx[non_admitted_miss_pos]
-        elif new_in_miss.any():
+        elif has_new_in_miss:
             keys_to_insert_mask = torch.ones(
                 h_num_miss, dtype=torch.bool, device=device
             )
 
         # 5. Insert only storage-found + admitted-new keys into cache
-        if not keys_to_insert_mask.any():
+        if not _bool_item(keys_to_insert_mask.any()):
             slot_indices[miss_compact_idx] = -1
             update_slot_indices = slot_indices.clone()
             return slot_indices, update_slot_indices, non_admitted_positions
@@ -412,7 +439,7 @@ def _prefetch_cache_path(
 
         # 7. Store storage-found values to their cache slots
         is_sf_in_insert = storage_founds[insert_to_miss]
-        if is_sf_in_insert.any():
+        if _bool_item(is_sf_in_insert.any()):
             store_to_flat(
                 state,
                 cache_insert_indices[is_sf_in_insert],
@@ -422,8 +449,8 @@ def _prefetch_cache_path(
 
         # 8. Initialize admitted-new keys in their cache slots
         is_new_in_insert = ~is_sf_in_insert
-        if is_new_in_insert.any():
-            n_new_admitted = is_new_in_insert.sum().item()
+        if _bool_item(is_new_in_insert.any()):
+            n_new_admitted = int(_scalar_item(is_new_in_insert.sum()))
             init_vals = torch.empty(
                 n_new_admitted, val_dim, dtype=emb_dtype, device=device
             )
@@ -727,10 +754,11 @@ def dynamicemb_prefetch(
             if outstanding_keys_ref is not None:
                 outstanding_keys_ref += num_prefetched_keys
                 cache_capacity = cache._state.capacity
-                if outstanding_keys_ref.item() > cache_capacity:
+                outstanding_keys = _scalar_item(outstanding_keys_ref)
+                if outstanding_keys > cache_capacity:
                     raise RuntimeError(
                         f"Outstanding prefetched keys "
-                        f"({outstanding_keys_ref.item()}) "
+                        f"({outstanding_keys}) "
                         f"exceed cache capacity ({cache_capacity}). "
                         "Reduce prefetch pipeline depth or increase "
                         "cache size."

--- a/examples/commons/distributed/batch_shuffler.py
+++ b/examples/commons/distributed/batch_shuffler.py
@@ -19,6 +19,44 @@ _PRINT_LOAD_BALANCE_STOP = int(os.environ.get("PRINT_LOAD_BALANCE_STOP", "-1"))
 _SHUFFLE_WITH_ALL2ALL = os.environ.get("SHUFFLE_WITH_ALL2ALL", "0") == "1"
 
 
+def _copy_cuda_tensor_to_pinned_cpu(tensor: torch.Tensor) -> torch.Tensor:
+    if not tensor.is_cuda:
+        return tensor.detach().cpu()
+    cpu = torch.empty(
+        tuple(tensor.shape),
+        dtype=tensor.dtype,
+        device=torch.device("cpu"),
+        pin_memory=True,
+    )
+    cpu.copy_(tensor.detach(), non_blocking=True)
+    torch.cuda.current_stream(tensor.device).synchronize()
+    return cpu
+
+
+def _tensor_to_cpu_list(tensor: torch.Tensor) -> Any:
+    return _copy_cuda_tensor_to_pinned_cpu(tensor).tolist()
+
+
+def _int64_tensor_from_cpu_nested_list(
+    values: List[List[int]],
+    device: Union[torch.device, str],
+) -> torch.Tensor:
+    target_device = torch.device(device)
+    cpu = torch.as_tensor(values, dtype=torch.int64, device=torch.device("cpu"))
+    if target_device.type != "cuda":
+        return cpu.to(device=target_device)
+    pinned = torch.empty(
+        tuple(cpu.shape),
+        dtype=cpu.dtype,
+        device=torch.device("cpu"),
+        pin_memory=True,
+    )
+    pinned.copy_(cpu)
+    # The non-blocking H2D copy is ordered only on the current CUDA stream.
+    # Callers must consume the returned tensor on the same stream.
+    return pinned.to(device=target_device, non_blocking=True)
+
+
 class ShuffleHandle:
     """Handle for tracking async shuffle state across start_shuffle_async and finish_shuffle.
 
@@ -111,7 +149,7 @@ def _strip_dense_padding(batch: BaseBatch, actual_bs: int) -> BaseBatch:
 def _log_load_balance(
     batch_idx: int,
     all_workloads: List[float],
-    partitions_indices: torch.Tensor,
+    partitions_indices: Union[torch.Tensor, List[List[int]]],
     local_batch_size: int,
     num_partitions: int,
 ) -> None:
@@ -121,13 +159,18 @@ def _log_load_balance(
     Args:
         partitions_indices: 2-D int64 tensor ``[W, B]`` (may be on GPU).
     """
-    wl = torch.tensor(all_workloads, dtype=torch.float64)
-    pi = partitions_indices.cpu()
+    pi = (
+        _tensor_to_cpu_list(partitions_indices)
+        if isinstance(partitions_indices, torch.Tensor)
+        else partitions_indices
+    )
     before_loads = [
-        wl[r * local_batch_size : (r + 1) * local_batch_size].sum().item()
+        sum(all_workloads[r * local_batch_size : (r + 1) * local_batch_size])
         for r in range(num_partitions)
     ]
-    after_loads = [wl[pi[r]].sum().item() for r in range(num_partitions)]
+    after_loads = [
+        sum(all_workloads[int(idx)] for idx in pi[r]) for r in range(num_partitions)
+    ]
     before_max, before_min = max(before_loads), min(before_loads)
     after_max, after_min = max(after_loads), min(after_loads)
     before_imb = (before_max - before_min) / before_max * 100 if before_max > 0 else 0.0
@@ -249,7 +292,7 @@ class BaseTaskBalancedBatchShuffler:
         # leads to reading incomplete / stale data and non-deterministic KK
         # partitions.  Converting here forces the D2H onto _memcpy_stream,
         # which is serialised after the AllGather.
-        allgather_workloads_cpu = allgather_workloads.tolist()
+        allgather_workloads_cpu = _tensor_to_cpu_list(allgather_workloads)
 
         # Create handle for this batch's shuffle state
         # This allows multiple batches to be in shuffle state simultaneously
@@ -328,8 +371,9 @@ class BaseTaskBalancedBatchShuffler:
         # KK partitions the *global* batch (including padding samples with
         # workload == 0), so ``partitions_indices`` — and consequently
         # ``indices_this_rank`` — may reference padding positions.
-        partitions_indices = torch.tensor(
-            partitions_list, dtype=torch.int64, device=meta["device"]
+        partitions_indices = _int64_tensor_from_cpu_nested_list(
+            partitions_list,
+            meta["device"],
         )
         if has_padding:
             partitions_indices = _sort_partitions_padding_last(
@@ -356,7 +400,11 @@ class BaseTaskBalancedBatchShuffler:
         # stripped from dense tensors at the end of this method.
         indices_this_rank = partitions_indices[meta["rank"]]
         actual_bs = (
-            (allgather_wl[indices_this_rank] > 0).sum().item()
+            sum(
+                1
+                for idx in partitions_list[meta["rank"]]
+                if meta["allgather_workloads_cpu"][int(idx)] > 0
+            )
             if has_padding
             else indices_this_rank.numel()
         )
@@ -448,7 +496,7 @@ class BaseTaskBalancedBatchShuffler:
         # 1. Allgather the workloads
         allgather_workloads = gather_along_first_dim(workloads, pg_group)
         # KK runs on CPU; .tolist() is needed regardless.
-        allgather_wl_cpu = allgather_workloads.tolist()
+        allgather_wl_cpu = _tensor_to_cpu_list(allgather_workloads)
         # Padding sits at the tail of each rank's chunk — O(W) check.
         has_padding = any(
             allgather_wl_cpu[(i + 1) * local_batch_size - 1] == 0
@@ -462,8 +510,9 @@ class BaseTaskBalancedBatchShuffler:
         partitions_list = karmarkar_karp(
             allgather_wl_cpu, num_partitions, equal_size=True
         )
-        partitions_indices = torch.tensor(
-            partitions_list, dtype=torch.int64, device=workloads.device
+        partitions_indices = _int64_tensor_from_cpu_nested_list(
+            partitions_list,
+            workloads.device,
         )
         if has_padding:
             partitions_indices = _sort_partitions_padding_last(


### PR DESCRIPTION
## Summary
- Use pinned host buffers when Python hot paths materialize CUDA tensors on CPU.
- Use pinned host buffers when batch shuffling builds CUDA partition tensors from CPU KK results.
- Reuse CPU workload metadata to avoid an extra CUDA scalar read when computing padded batch sizes.

## Tests
- `python -m py_compile examples/commons/distributed/batch_shuffler.py corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py`
- `pytest -q examples/tests/commons/test_batch_shuffler_factory.py`
- `torchrun --standalone --nproc_per_node=1 -m pytest -q examples/tests/commons/test_distributed.py -k "batch_allgather or all2all_vs_allgather"`
- CUDA smoke test for the pinned-copy helpers and batch-shuffler partition helper.

Note: DynamicEmb CUDA extension tests require an extension built from the same checkout. The available installed extension used an older `segmented_unique_cuda(keys, table_ids, ...)` signature, so that local failure was not treated as a signal for this Python-only change.