### PR TITLE
Add an example for disabling contextual mask in training

### DIFF
--- a/corelib/dynamicemb/benchmark/benchmark_batched_dynamicemb_tables.py
+++ b/corelib/dynamicemb/benchmark/benchmark_batched_dynamicemb_tables.py
@@ -439,9 +439,7 @@ def create_dynamic_embedding_tables(
                     torch.arange(start, end_t, device=device, dtype=torch.int64)
                 )
                 tids_list.append(
-                    torch.full(
-                        (end_t - start,), t, dtype=torch.int64, device=device
-                    )
+                    torch.full((end_t - start,), t, dtype=torch.int64, device=device)
                 )
             if not keys_list:
                 break
@@ -907,9 +905,7 @@ def benchmark_with_nsys(dynamic_emb, torchrec_emb, sparse_features, cfg):
     torch.cuda.synchronize()
     torch.cuda.cudart().cudaProfilerStop()
 
-    print(
-        f"  Nsys profiled {len(sparse_features)} iters (dyn + trc, fwd+bwd each)."
-    )
+    print(f"  Nsys profiled {len(sparse_features)} iters (dyn + trc, fwd+bwd each).")
 
 
 # ── NCU (Nsight Compute) profiler integration ────────────────────────────────
@@ -988,7 +984,9 @@ def print_ncu_command(cfg: BenchmarkConfig):
         f" {single_inner}"
     )
 
-    multi_inner = "bash benchmark/benchmark_batched_dynamicemb_tables.sh --profile ncu-run"
+    multi_inner = (
+        "bash benchmark/benchmark_batched_dynamicemb_tables.sh --profile ncu-run"
+    )
     multi_out = os.path.join(os.getcwd(), "ncu_all_configs")
     multi_cmd = (
         f"ncu -f --target-processes all"
@@ -1265,17 +1263,15 @@ def _populate_correctness_tables(
         if half == 0:
             continue
         trc_w_t = trc_weights[t]
-        assert trc_w_t.shape[1] == D, (
-            f"trc_weights[{t}] dim {trc_w_t.shape[1]} != cfg.embedding_dim {D}"
-        )
+        assert (
+            trc_w_t.shape[1] == D
+        ), f"trc_weights[{t}] dim {trc_w_t.shape[1]} != cfg.embedding_dim {D}"
 
         for start in range(0, half, _INSERT_BATCH):
             end = min(start + _INSERT_BATCH, half)
             chunk = end - start
             keys = torch.arange(start, end, device=device, dtype=torch.int64)
-            init_w = trc_w_t[start:end].to(
-                device=device, dtype=torch.float32
-            )
+            init_w = trc_w_t[start:end].to(device=device, dtype=torch.float32)
 
             if optstate_dim > 0:
                 opt_zero = torch.zeros(
@@ -1286,9 +1282,7 @@ def _populate_correctness_tables(
                 values = init_w.contiguous()
             values = values.to(emb_dtype)
 
-            table_ids = torch.full(
-                (chunk,), t, dtype=torch.int64, device=device
-            )
+            table_ids = torch.full((chunk,), t, dtype=torch.int64, device=device)
             scores = (
                 torch.ones(chunk, dtype=torch.uint64, device=device)
                 if cfg.cache_algorithm == "lfu"
@@ -1374,9 +1368,7 @@ def run_single_benchmark(
     # of each table so every lookup hits a key we mirrored from TorchRec
     # into DynamicEmb.  All other modes sample over the full cap.
     half_caps = (
-        [c // 2 for c in cfg.num_embeddings_per_feature]
-        if cfg.correctness
-        else None
+        [c // 2 for c in cfg.num_embeddings_per_feature] if cfg.correctness else None
     )
 
     timer.start()
@@ -1418,9 +1410,7 @@ def run_single_benchmark(
         # PowerLaw/zipf already produce values in [min, max-1] / [min, max),
         # so passing half_caps as the upper bound guarantees every index is
         # strictly less than cap/2 -- the populated range on DynamicEmb.
-        n_keys = _populate_correctness_tables(
-            dynamic_emb, torchrec_emb, cfg, device
-        )
+        n_keys = _populate_correctness_tables(dynamic_emb, torchrec_emb, cfg, device)
         print(
             f"  Correctness: mirrored {n_keys} keys "
             f"(TorchRec[:cap/2] -> DynamicEmb)"

--- a/corelib/dynamicemb/benchmark/nsys_breakdown.py
+++ b/corelib/dynamicemb/benchmark/nsys_breakdown.py
@@ -49,7 +49,6 @@
 #   python nsys_breakdown.py trace.nsys-rep --out-dir /tmp/bd
 
 import argparse
-import bisect
 import csv
 import os
 import re
@@ -59,23 +58,22 @@ import sys
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple
 
+
 # KERNEL_NAME_PATTERNS pulled from the benchmark file via AST, used only as a
 # fallback when an unwrapped kernel falls outside any op:* range.  We don't
 # import the module directly because it pulls in torch/torchrec at import time.
 def _load_kernel_name_patterns() -> Dict[str, List[str]]:
     import ast
+
     src_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "benchmark_batched_dynamicemb_tables.py",
     )
     tree = ast.parse(open(src_path).read())
     for node in tree.body:
-        if (
-            isinstance(node, ast.Assign)
-            and any(
-                isinstance(t, ast.Name) and t.id == "KERNEL_NAME_PATTERNS"
-                for t in node.targets
-            )
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "KERNEL_NAME_PATTERNS"
+            for t in node.targets
         ):
             return ast.literal_eval(node.value)
     return {}
@@ -94,15 +92,20 @@ def ensure_sqlite(nsys_rep: str) -> str:
     sqlite_path = re.sub(r"\.(nsys-rep|qdrep)$", ".sqlite", nsys_rep)
     if sqlite_path == nsys_rep:
         sqlite_path = nsys_rep + ".sqlite"
-    if (
-        os.path.exists(sqlite_path)
-        and os.path.getmtime(sqlite_path) >= os.path.getmtime(nsys_rep)
-    ):
+    if os.path.exists(sqlite_path) and os.path.getmtime(
+        sqlite_path
+    ) >= os.path.getmtime(nsys_rep):
         return sqlite_path
     print(f"[export] {nsys_rep} -> {sqlite_path}", file=sys.stderr)
     subprocess.run(
-        ["nsys", "export", "--type=sqlite",
-         f"--output={sqlite_path}", "--force-overwrite=true", nsys_rep],
+        [
+            "nsys",
+            "export",
+            "--type=sqlite",
+            f"--output={sqlite_path}",
+            "--force-overwrite=true",
+            nsys_rep,
+        ],
         check=True,
     )
     return sqlite_path
@@ -232,7 +235,7 @@ def _attribute_kernels(nvtx, kernels):
     # close) gets the right enclosing context.
     events.sort(key=lambda x: (x[0], x[1]))
 
-    stack: List[Tuple[int, str]] = []      # (open_idx, name)
+    stack: List[Tuple[int, str]] = []  # (open_idx, name)
 
     for t, kind, idx, payload in events:
         if kind == OPEN:
@@ -282,11 +285,11 @@ def _parse_record(k_start: int, k_end: int, k_name: str, stack: List[str]):
 
     # Filter rules.
     if in_trc:
-        return None                # trc side, skip entirely
+        return None  # trc side, skip entirely
     if not in_dyn:
-        return None                # outside dyn (setup / between iters)
+        return None  # outside dyn (setup / between iters)
     if cfg_label is None or phase is None or iter_id is None:
-        return None                # missing context, can't average per iter
+        return None  # missing context, can't average per iter
 
     # When no op:* NVTX wraps this launch, use the kernel name itself as
     # the op label.  Each distinct kernel then becomes its own row,
@@ -298,12 +301,11 @@ def _parse_record(k_start: int, k_end: int, k_name: str, stack: List[str]):
         "cfg_label": cfg_label,
         "phase": phase,
         "iter_id": iter_id,
-        "parent_stages": stages,   # outer -> inner
+        "parent_stages": stages,  # outer -> inner
         "op": op_name,
         "is_wrapped": op_leaf is not None,
         "kernel_name": k_name,
-        "fallback_cat": _classify_kernel_fallback(k_name)
-                          if op_leaf is None else None,
+        "fallback_cat": _classify_kernel_fallback(k_name) if op_leaf is None else None,
         "duration_ns": k_end - k_start,
         "start": k_start,
     }
@@ -323,14 +325,17 @@ def _accumulate(records, file_idx: int, acc):
             continue
         cfg = r["cfg_label"]
         key = (r["phase"], tuple(r["parent_stages"]), r["op"])
-        entry = acc[cfg].setdefault(key, {
-            "calls": defaultdict(int),       # iter -> #invocations
-            "ms":    defaultdict(float),     # iter -> total ms
-            "first_start": None,             # for row ordering
-            "kernel_names": set(),
-            "fallback_cats": set(),
-            "is_wrapped": r["is_wrapped"],
-        })
+        entry = acc[cfg].setdefault(
+            key,
+            {
+                "calls": defaultdict(int),  # iter -> #invocations
+                "ms": defaultdict(float),  # iter -> total ms
+                "first_start": None,  # for row ordering
+                "kernel_names": set(),
+                "fallback_cats": set(),
+                "is_wrapped": r["is_wrapped"],
+            },
+        )
         scoped_iter = (file_idx, r["iter_id"])
         entry["calls"][scoped_iter] += 1
         entry["ms"][scoped_iter] += r["duration_ns"] / 1e6
@@ -356,20 +361,24 @@ def _finalize(acc) -> Dict[str, List[Dict[str, Any]]]:
                 continue
             total_ms = sum(e["ms"].values())
             total_calls = sum(e["calls"].values())
-            rows.append({
-                "phase": phase,
-                "parent_stages": "/".join(parents),
-                "op": op,
-                "calls_per_iter": total_calls / n_iters,
-                "avg_ms_per_iter": total_ms / n_iters,
-                "total_ms": total_ms,
-                "num_iters": n_iters,
-                "kernel_names": ", ".join(sorted(e["kernel_names"]))
-                                  if e["kernel_names"] else "",
-                "fallback_category": ", ".join(sorted(e["fallback_cats"]))
-                                     if e["fallback_cats"] else "",
-                "_sort": e["first_start"],
-            })
+            rows.append(
+                {
+                    "phase": phase,
+                    "parent_stages": "/".join(parents),
+                    "op": op,
+                    "calls_per_iter": total_calls / n_iters,
+                    "avg_ms_per_iter": total_ms / n_iters,
+                    "total_ms": total_ms,
+                    "num_iters": n_iters,
+                    "kernel_names": ", ".join(sorted(e["kernel_names"]))
+                    if e["kernel_names"]
+                    else "",
+                    "fallback_category": ", ".join(sorted(e["fallback_cats"]))
+                    if e["fallback_cats"]
+                    else "",
+                    "_sort": e["first_start"],
+                }
+            )
         rows.sort(key=lambda r: r["_sort"])
         for r in rows:
             r.pop("_sort", None)
@@ -405,17 +414,19 @@ def _write_csv(cfg_label: str, rows: List[Dict[str, Any]], out_dir: str) -> str:
         w = csv.DictWriter(f, fieldnames=_CSV_COLS)
         w.writeheader()
         for r in rows:
-            w.writerow({
-                "phase": r["phase"],
-                "parent_stages": r["parent_stages"],
-                "op": r["op"],
-                "calls_per_iter": f"{r['calls_per_iter']:.3f}",
-                "avg_ms_per_iter": f"{r['avg_ms_per_iter']:.6f}",
-                "total_ms": f"{r['total_ms']:.4f}",
-                "num_iters": r["num_iters"],
-                "kernel_names": r["kernel_names"],
-                "fallback_category": r["fallback_category"],
-            })
+            w.writerow(
+                {
+                    "phase": r["phase"],
+                    "parent_stages": r["parent_stages"],
+                    "op": r["op"],
+                    "calls_per_iter": f"{r['calls_per_iter']:.3f}",
+                    "avg_ms_per_iter": f"{r['avg_ms_per_iter']:.6f}",
+                    "total_ms": f"{r['total_ms']:.4f}",
+                    "num_iters": r["num_iters"],
+                    "kernel_names": r["kernel_names"],
+                    "fallback_category": r["fallback_category"],
+                }
+            )
     return path
 
 
@@ -425,10 +436,11 @@ def _write_csv(cfg_label: str, rows: List[Dict[str, Any]], out_dir: str) -> str:
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Per-config op-call breakdown CSVs from one or more "
-                    "nsys-rep traces.  TorchRec (trc) is dropped.",
+        "nsys-rep traces.  TorchRec (trc) is dropped.",
     )
     parser.add_argument(
-        "inputs", nargs="+",
+        "inputs",
+        nargs="+",
         help="one or more .nsys-rep (or .qdrep) files",
     )
     parser.add_argument(
@@ -448,8 +460,9 @@ def main() -> None:
     for file_idx, rep in enumerate(args.inputs):
         sqlite = ensure_sqlite(rep)
         nvtx, kernels = _fetch_nvtx_and_kernels(sqlite)
-        print(f"[load] {rep}: {len(nvtx)} nvtx + {len(kernels)} kernels",
-              file=sys.stderr)
+        print(
+            f"[load] {rep}: {len(nvtx)} nvtx + {len(kernels)} kernels", file=sys.stderr
+        )
         records = (
             _parse_record(s, e, n, stack)
             for s, e, n, stack in _attribute_kernels(nvtx, kernels)

--- a/corelib/dynamicemb/benchmark/nsys_sunburst.py
+++ b/corelib/dynamicemb/benchmark/nsys_sunburst.py
@@ -29,12 +29,10 @@ import csv
 import math
 import os
 import random
-import sys
 from typing import List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 from matplotlib.patches import Wedge
-
 
 # ── tree ────────────────────────────────────────────────────────────────────
 
@@ -82,8 +80,8 @@ def add_path(root: Node, path: List[str], value: float) -> None:
 # Stage names we collapse into the 3-bucket ring 2.  Matched as substrings
 # (in order) against each segment of parent_stages.
 _STAGE_BUCKETS = [
-    ("dynamicemb_prefetch",            "prefetch"),
-    ("DynamicEmbeddingFunction.forward",  "forward"),
+    ("dynamicemb_prefetch", "prefetch"),
+    ("DynamicEmbeddingFunction.forward", "forward"),
     ("DynamicEmbeddingFunction.backward", "backward"),
 ]
 
@@ -185,28 +183,45 @@ def tree_demo() -> Node:
 
     KERNEL_SEQ = {
         ("dyn", "forward"): [
-            "segmented_unique", "hash_find", "load_from_flat",
-            "init_for_admitted", "gather_embedding", "hash_insert",
+            "segmented_unique",
+            "hash_find",
+            "load_from_flat",
+            "init_for_admitted",
+            "gather_embedding",
+            "hash_insert",
         ],
         ("dyn", "backward"): [
-            "reduce_grads", "optimizer_update", "store_to_flat",
+            "reduce_grads",
+            "optimizer_update",
+            "store_to_flat",
         ],
         ("trc", "forward"): [
-            "bounds_check", "embedding_lookup", "pooling",
+            "bounds_check",
+            "embedding_lookup",
+            "pooling",
         ],
         ("trc", "backward"): [
-            "reduce_grads", "optimizer_update",
+            "reduce_grads",
+            "optimizer_update",
         ],
     }
     BASE_MS = {
-        "segmented_unique":  0.4, "hash_find": 3.0, "load_from_flat": 2.2,
-        "init_for_admitted": 0.3, "gather_embedding": 11.0, "hash_insert": 3.2,
-        "reduce_grads":      0.6, "optimizer_update": 0.3, "store_to_flat": 0.1,
-        "bounds_check":      0.4, "embedding_lookup":  3.5, "pooling":      0.2,
+        "segmented_unique": 0.4,
+        "hash_find": 3.0,
+        "load_from_flat": 2.2,
+        "init_for_admitted": 0.3,
+        "gather_embedding": 11.0,
+        "hash_insert": 3.2,
+        "reduce_grads": 0.6,
+        "optimizer_update": 0.3,
+        "store_to_flat": 0.1,
+        "bounds_check": 0.4,
+        "embedding_lookup": 3.5,
+        "pooling": 0.2,
     }
-    CONFIGS  = ["cfr=0.8", "cfr=1.0"]
+    CONFIGS = ["cfr=0.8", "cfr=1.0"]
     BACKENDS = ["dyn", "trc"]
-    PHASES   = ["forward", "backward"]
+    PHASES = ["forward", "backward"]
 
     root = Node("ALL")
     for cfg in CONFIGS:
@@ -215,10 +230,20 @@ def tree_demo() -> Node:
                 for step, kn in enumerate(KERNEL_SEQ[(back, phase)]):
                     base = BASE_MS[kn]
                     jitter = random.uniform(0.75, 1.25)
-                    shrink = 0.4 if (cfg == "cfr=1.0" and kn in {
-                        "hash_insert", "load_from_flat",
-                        "store_to_flat", "hash_find",
-                    }) else 1.0
+                    shrink = (
+                        0.4
+                        if (
+                            cfg == "cfr=1.0"
+                            and kn
+                            in {
+                                "hash_insert",
+                                "load_from_flat",
+                                "store_to_flat",
+                                "hash_find",
+                            }
+                        )
+                        else 1.0
+                    )
                     ms = round(base * jitter * shrink, 3)
                     add_path(root, [cfg, back, phase, f"{step:02d}_{kn}"], ms)
     return root
@@ -362,13 +387,20 @@ def _draw_node(
         # Leaves get a globally-unique pre-computed color (set in render()
         # before this descent); other nodes fall back to the per-ring
         # palette indexed by sibling order.
-        fc = child.color if child.color is not None \
-             else color_for(draw_depth, idx, n_sibs)
+        fc = (
+            child.color
+            if child.color is not None
+            else color_for(draw_depth, idx, n_sibs)
+        )
         w = Wedge(
-            (0, 0), r_outer, 90 - c_end, 90 - c_start,
+            (0, 0),
+            r_outer,
+            90 - c_end,
+            90 - c_start,
             width=r_outer - r_inner,
             facecolor=fc,
-            edgecolor="white", linewidth=1.2,
+            edgecolor="white",
+            linewidth=1.2,
         )
         ax.add_patch(w)
 
@@ -380,7 +412,7 @@ def _draw_node(
             y = r_label * math.cos(rad)
             rotation = -mid_angle
             if 90 < mid_angle < 270:
-                rotation += 180          # flip bottom-half labels
+                rotation += 180  # flip bottom-half labels
             # Percentage = this wedge's value / total iter time.  Reads
             # as "this slice is X% of the whole iteration", consistent
             # across levels (parent + child pcts sum to parent's pct).
@@ -390,20 +422,24 @@ def _draw_node(
             # table next to the chart.  Stage / phase rings use the
             # human-readable label.
             display_name = child.code if (is_leaf and child.code) else child.label
-            label_text = (f"{display_name}\n{pct:.1f}%"
-                          if extent >= 6.0 else display_name)
+            label_text = (
+                f"{display_name}\n{pct:.1f}%" if extent >= 6.0 else display_name
+            )
             ax.text(
-                x, y, label_text,
-                ha="center", va="center",
-                rotation=rotation, rotation_mode="anchor",
+                x,
+                y,
+                label_text,
+                ha="center",
+                va="center",
+                rotation=rotation,
+                rotation_mode="anchor",
                 fontsize=8.5 if draw_depth < 3 else 7.0,
-                color="black",   # all rings are now light pastels
+                color="black",  # all rings are now light pastels
                 linespacing=0.95,
             )
 
         if not is_leaf:
-            _draw_node(ax, child, c_start, c_end, depth + 1, rings,
-                       grand_total)
+            _draw_node(ax, child, c_start, c_end, depth + 1, rings, grand_total)
         cursor = c_end
 
 
@@ -431,7 +467,7 @@ def render(
     # value triplet rotation as a secondary distinguishing axis so even
     # wedges that happen to share a hue family (every ~3 steps if N is
     # divisible) stay visually separable.
-    GOLDEN_STEP = 1.0 - 1.0 / ((1 + 5 ** 0.5) / 2)   # ≈ 0.381966
+    GOLDEN_STEP = 1.0 - 1.0 / ((1 + 5**0.5) / 2)  # ≈ 0.381966
     sat_levels = (0.32, 0.46, 0.58)
     val_levels = (0.97, 0.92, 0.99)
     for i, (_, leaf) in enumerate(leaves_in_order):
@@ -453,7 +489,8 @@ def render(
     chart_share = 1.0 - table_share
     fig = plt.figure(figsize=(14, 18))
     gs = fig.add_gridspec(
-        2, 1,
+        2,
+        1,
         height_ratios=[chart_share, table_share],
         hspace=0.05,
     )
@@ -468,16 +505,27 @@ def render(
 
     _draw_node(ax_chart, root, 0.0, 360.0, 0, rings, total)
 
-    ax_chart.text(0, 0, f"total\n{total:.2f} {units}",
-                  ha="center", va="center",
-                  fontsize=11, fontweight="bold")
     ax_chart.text(
-        0, -1.18,
-        subtitle or "rings (inside → out): phase → "
-                    "{prefetch / forward / backward} → op  "
-                    "(wedge angle ∝ avg ms / iter, dyn side only; "
-                    "pct = share of full iter)",
-        ha="center", va="top", fontsize=9, color="#444",
+        0,
+        0,
+        f"total\n{total:.2f} {units}",
+        ha="center",
+        va="center",
+        fontsize=11,
+        fontweight="bold",
+    )
+    ax_chart.text(
+        0,
+        -1.18,
+        subtitle
+        or "rings (inside → out): phase → "
+        "{prefetch / forward / backward} → op  "
+        "(wedge angle ∝ avg ms / iter, dyn side only; "
+        "pct = share of full iter)",
+        ha="center",
+        va="top",
+        fontsize=9,
+        color="#444",
     )
 
     # ── legend table ──────────────────────────────────────────────────
@@ -515,7 +563,9 @@ def render(
 
     fig.suptitle(
         title or "GPU time breakdown",
-        y=0.98, fontsize=14, fontweight="bold",
+        y=0.98,
+        fontsize=14,
+        fontweight="bold",
     )
     fig.savefig(out_png, dpi=140, bbox_inches="tight")
     print(f"saved {out_png}")
@@ -540,31 +590,33 @@ def _detect_format(csv_path: str) -> str:
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Multi-ring nested donut from nsys_breakdown CSV(s).  "
-                    "Accepts the per-config 'opcalls__*.csv' (one PNG per "
-                    "input) or the legacy cross-config 'breakdown.csv' "
-                    "(single PNG).",
+        "Accepts the per-config 'opcalls__*.csv' (one PNG per "
+        "input) or the legacy cross-config 'breakdown.csv' "
+        "(single PNG).",
     )
     parser.add_argument(
-        "csv", nargs="*",
+        "csv",
+        nargs="*",
         help="one or more breakdown CSVs (omit when --demo is used)",
     )
     parser.add_argument(
         "--out",
         help="output PNG path -- only honored when exactly one input CSV "
-             "is given (or in --demo).  With multiple inputs the path is "
-             "derived per-CSV as <csv-base>.sunburst.png",
+        "is given (or in --demo).  With multiple inputs the path is "
+        "derived per-CSV as <csv-base>.sunburst.png",
     )
     parser.add_argument(
         "--out-dir",
         help="when given, write per-input PNGs into this dir instead of "
-             "next to the CSV",
+        "next to the CSV",
     )
     parser.add_argument(
         "--filter-config",
         help="legacy CSVs only: keep configs whose label contains this substring",
     )
     parser.add_argument(
-        "--demo", action="store_true",
+        "--demo",
+        action="store_true",
         help="ignore csv args and render a hand-tuned fake-data tree",
     )
     args = parser.parse_args()
@@ -576,10 +628,11 @@ def main() -> None:
             "sunburst_demo.png",
         )
         render(
-            root, out_png,
+            root,
+            out_png,
             title="GPU time breakdown — fake demo data",
             subtitle="rings (inside → out): config → backend → phase → kernel  "
-                     "(wedge angle ∝ ms)",
+            "(wedge angle ∝ ms)",
             units="ms",
         )
         return
@@ -605,16 +658,20 @@ def main() -> None:
             # short config label for the figure title.
             cfg_label = base.replace("opcalls__", "")
             title = f"GPU time breakdown per iteration\n{cfg_label}"
-            subtitle = ("rings (inside → out): phase → "
-                        "{prefetch / forward / backward} → op  "
-                        "(wedge angle ∝ avg ms / iter, dyn side only; "
-                        "pct = share of full iter)")
+            subtitle = (
+                "rings (inside → out): phase → "
+                "{prefetch / forward / backward} → op  "
+                "(wedge angle ∝ avg ms / iter, dyn side only; "
+                "pct = share of full iter)"
+            )
             units = "ms/iter"
         else:
             title_suffix = f" — {args.filter_config}" if args.filter_config else ""
             title = f"GPU time breakdown{title_suffix}"
-            subtitle = ("rings (inside → out): config → backend → phase → "
-                        "kernel  (wedge angle ∝ ms)")
+            subtitle = (
+                "rings (inside → out): config → backend → phase → "
+                "kernel  (wedge angle ∝ ms)"
+            )
             units = "ms"
 
         render(root, out_png, title=title, subtitle=subtitle, units=units)

--- a/corelib/dynamicemb/benchmark/plot_benchmark_results.py
+++ b/corelib/dynamicemb/benchmark/plot_benchmark_results.py
@@ -21,7 +21,6 @@ import os
 from typing import List
 
 import matplotlib.pyplot as plt
-import numpy as np
 
 # Canonical ordering for the four storage modes the suite parametrizes over.
 METRICS = ["forward", "backward", "train", "eval"]
@@ -52,10 +51,13 @@ def build_panels(results: List[dict]):
     keeps cfr=0.8 and cfr=1.0 in the same figure rather than splitting them
     into separate PNGs.
     """
-    ratios = sorted({
-        r.get("cache_footprint_ratio") for r in results
-        if r.get("cache_footprint_ratio") is not None
-    })
+    ratios = sorted(
+        {
+            r.get("cache_footprint_ratio")
+            for r in results
+            if r.get("cache_footprint_ratio") is not None
+        }
+    )
     panels = [("gpu", None)]
     if ratios:
         panels.extend([("caching", r) for r in ratios])
@@ -139,7 +141,8 @@ def make_figure(
     optimizers = sorted({r["optimizer_type"] for r in results})
 
     fig, axes = plt.subplots(
-        len(optimizers), 1,
+        len(optimizers),
+        1,
         figsize=(max(2.6 * len(panels), 10.0), 4.2 * len(optimizers)),
         squeeze=False,
     )
@@ -147,7 +150,7 @@ def make_figure(
 
     width = 0.30
     panel_inner_width = 2.0  # group positions: x=0 (train) and x=1 (eval)
-    panel_gap = 0.9          # blank space between panels
+    panel_gap = 0.9  # blank space between panels
     panel_step = panel_inner_width + panel_gap
 
     first_handles = None  # captured from first non-empty group for fig-level legend
@@ -164,14 +167,36 @@ def make_figure(
             x_eval = col * panel_step + 1
 
             # Train: stacked forward (bottom) + backward (top) per backend.
-            ax.bar(x_train - width / 2, dyn_fwd, width,
-                   color=DYN_FWD_COLOR, label="DynamicEmb · fwd / eval")
-            ax.bar(x_train - width / 2, dyn_bwd, width, bottom=dyn_fwd,
-                   color=DYN_BWD_COLOR, label="DynamicEmb · bwd")
-            ax.bar(x_train + width / 2, trc_fwd, width,
-                   color=TRC_FWD_COLOR, label="TorchRec · fwd / eval")
-            ax.bar(x_train + width / 2, trc_bwd, width, bottom=trc_fwd,
-                   color=TRC_BWD_COLOR, label="TorchRec · bwd")
+            ax.bar(
+                x_train - width / 2,
+                dyn_fwd,
+                width,
+                color=DYN_FWD_COLOR,
+                label="DynamicEmb · fwd / eval",
+            )
+            ax.bar(
+                x_train - width / 2,
+                dyn_bwd,
+                width,
+                bottom=dyn_fwd,
+                color=DYN_BWD_COLOR,
+                label="DynamicEmb · bwd",
+            )
+            ax.bar(
+                x_train + width / 2,
+                trc_fwd,
+                width,
+                color=TRC_FWD_COLOR,
+                label="TorchRec · fwd / eval",
+            )
+            ax.bar(
+                x_train + width / 2,
+                trc_bwd,
+                width,
+                bottom=trc_fwd,
+                color=TRC_BWD_COLOR,
+                label="TorchRec · bwd",
+            )
 
             # Eval is forward-only on each backend so it shares the fwd shade.
             ax.bar(x_eval - width / 2, dyn_eval, width, color=DYN_FWD_COLOR)
@@ -190,8 +215,7 @@ def make_figure(
         # Dotted separators between panel regions
         for i in range(1, len(panels)):
             sep_x = i * panel_step - panel_gap / 2
-            ax.axvline(sep_x, color="#aaa", linestyle=":",
-                       linewidth=0.8, alpha=0.7)
+            ax.axvline(sep_x, color="#aaa", linestyle=":", linewidth=0.8, alpha=0.7)
 
         # Inner x-ticks: train / eval label under every panel.
         xticks: list = []
@@ -201,8 +225,7 @@ def make_figure(
             xticklabels.extend(["train\n(fwd+bwd)", "eval"])
         ax.set_xticks(xticks)
         ax.set_xticklabels(xticklabels, fontsize=8)
-        ax.set_xlim(-panel_gap / 2,
-                    len(panels) * panel_step - panel_gap / 2)
+        ax.set_xlim(-panel_gap / 2, len(panels) * panel_step - panel_gap / 2)
         ax.set_ylabel("ms")
         ax.grid(axis="y", alpha=0.3)
         if log:
@@ -213,7 +236,8 @@ def make_figure(
         sax.set_xticks([i * panel_step + 0.5 for i in range(len(panels))])
         sax.set_xticklabels(
             [panel_label(m, c).replace("\n", " ") for m, c in panels],
-            fontsize=10, fontweight="bold",
+            fontsize=10,
+            fontweight="bold",
         )
         sax.tick_params(axis="x", length=0)  # no tick marks, just labels
 
@@ -229,12 +253,12 @@ def make_figure(
     # the figure height; legend and tight_layout shift down accordingly.
     n_lines = subtitle.count("\n") + 1 if subtitle else 0
     if subtitle:
-        fig.text(0.5, 0.955, subtitle, ha="center", va="top",
-                 fontsize=10, color="#444")
+        fig.text(0.5, 0.955, subtitle, ha="center", va="top", fontsize=10, color="#444")
     if first_handles is not None:
         handles, labels = first_handles
         fig.legend(
-            handles, labels,
+            handles,
+            labels,
             loc="upper center",
             bbox_to_anchor=(0.5, 0.95 - 0.025 * n_lines),
             ncol=len(labels),
@@ -295,17 +319,23 @@ def main() -> None:
     here = os.path.dirname(os.path.abspath(__file__))
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--results", default=os.path.join(here, "benchmark_results.json"),
+        "--results",
+        default=os.path.join(here, "benchmark_results.json"),
         help="path to benchmark_results.json",
     )
     parser.add_argument(
-        "--out-dir", default=os.path.join(here, "plots"),
+        "--out-dir",
+        default=os.path.join(here, "plots"),
         help="directory to write generated PNGs into (created if missing)",
     )
-    parser.add_argument("--log", action="store_true",
-                        help="log-scale y-axis (useful when one mode dominates)")
-    parser.add_argument("--no-values", action="store_true",
-                        help="hide numeric labels on bars")
+    parser.add_argument(
+        "--log",
+        action="store_true",
+        help="log-scale y-axis (useful when one mode dominates)",
+    )
+    parser.add_argument(
+        "--no-values", action="store_true", help="hide numeric labels on bars"
+    )
     args = parser.parse_args()
 
     os.makedirs(args.out_dir, exist_ok=True)
@@ -326,8 +356,9 @@ def main() -> None:
         fig.savefig(path, dpi=130, bbox_inches="tight")
         print(f"Saved -> {path}")
 
-    fig = make_figure(results, panels, log=args.log,
-                      show_values=not args.no_values, subtitle=subtitle)
+    fig = make_figure(
+        results, panels, log=args.log, show_values=not args.no_values, subtitle=subtitle
+    )
     _save(fig, "benchmark_bdet_plot.png")
 
 

--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
@@ -1009,7 +1009,9 @@ def _generic_forward_path(
             )
         key_persisted[positions_in_unique] = True
         with torch.cuda.nvtx.range("op:flagged_compact"):
-            _, persisted_unique_indices, _ = flagged_compact(key_persisted, [unique_keys])
+            _, persisted_unique_indices, _ = flagged_compact(
+                key_persisted, [unique_keys]
+            )
         return unique_values, persisted_unique_indices
 
 

--- a/examples/hstu/configs/hstu_config.py
+++ b/examples/hstu/configs/hstu_config.py
@@ -132,6 +132,7 @@ class HSTUConfig(TransformerConfig):
     add_uvqk_bias: bool = True
     fuse_norm_mul_dropout: bool = True
     scaling_seqlen: int = -1
+    disable_contextual_mask: bool = False
 
     def __post_init__(self):
         super().__post_init__()
@@ -162,6 +163,7 @@ def get_hstu_config(
     add_uvqk_bias: bool = True,
     fuse_norm_mul_dropout: bool = True,
     scaling_seqlen: int = -1,
+    disable_contextual_mask: bool = False,
 ) -> HSTUConfig:
     """
     Create the HSTU configuration.
@@ -238,4 +240,5 @@ def get_hstu_config(
         is_inference=is_inference,
         fuse_norm_mul_dropout=fuse_norm_mul_dropout,
         scaling_seqlen=scaling_seqlen,
+        disable_contextual_mask=disable_contextual_mask,
     )

--- a/examples/hstu/modules/debug/debug_hstu_layer.py
+++ b/examples/hstu/modules/debug/debug_hstu_layer.py
@@ -317,7 +317,9 @@ class HSTULayer(MegatronModule):
                 tk,
                 tv,
                 jd.seqlen_offsets,
-                num_contextuals=jd.contextual_seqlen if not self._disable_contextual_mask else None,
+                num_contextuals=jd.contextual_seqlen
+                if not self._disable_contextual_mask
+                else None,
                 num_candidates=jd.num_candidates,
                 max_seqlen=jd.max_seqlen,
                 scaling_seqlen=jd.scaling_seqlen,

--- a/examples/hstu/modules/debug/debug_hstu_layer.py
+++ b/examples/hstu/modules/debug/debug_hstu_layer.py
@@ -196,6 +196,8 @@ class HSTULayer(MegatronModule):
                         )
                     )
 
+        self._disable_contextual_mask = config.disable_contextual_mask
+
     def get_user_value_query_key_tensors(self, hidden_states: torch.Tensor):
         """
         Splits the hidden states into user, value, query, and key tensors.
@@ -315,7 +317,7 @@ class HSTULayer(MegatronModule):
                 tk,
                 tv,
                 jd.seqlen_offsets,
-                num_contextuals=jd.contextual_seqlen,
+                num_contextuals=jd.contextual_seqlen if not self._disable_contextual_mask else None,
                 num_candidates=jd.num_candidates,
                 max_seqlen=jd.max_seqlen,
                 scaling_seqlen=jd.scaling_seqlen,

--- a/examples/hstu/modules/fused_hstu_layer.py
+++ b/examples/hstu/modules/fused_hstu_layer.py
@@ -120,6 +120,8 @@ class FusedHSTULayer(MegatronModule):
             FusedHSTULayer.forward, key_or_attr_name="values"
         )
 
+        self._disable_contextual_mask = config.disable_contextual_mask
+
     @output_nvtx_hook(nvtx_tag="FusedHSTULayer")
     def forward(self, jd: JaggedData) -> JaggedData:
         input = jd.values
@@ -146,7 +148,7 @@ class FusedHSTULayer(MegatronModule):
             # attn related
             attn_backend=self._attn_backend,
             num_targets=jd.num_candidates,
-            num_contextuals=jd.contextual_seqlen,
+            num_contextuals=jd.contextual_seqlen if not self._disable_contextual_mask else None,
             target_group_size=self._target_group_size,
             alpha=self._alpha,
             causal=self._is_causal,

--- a/examples/hstu/modules/fused_hstu_layer.py
+++ b/examples/hstu/modules/fused_hstu_layer.py
@@ -148,7 +148,9 @@ class FusedHSTULayer(MegatronModule):
             # attn related
             attn_backend=self._attn_backend,
             num_targets=jd.num_candidates,
-            num_contextuals=jd.contextual_seqlen if not self._disable_contextual_mask else None,
+            num_contextuals=jd.contextual_seqlen
+            if not self._disable_contextual_mask
+            else None,
             target_group_size=self._target_group_size,
             alpha=self._alpha,
             causal=self._is_causal,

--- a/examples/hstu/modules/native_hstu_layer.py
+++ b/examples/hstu/modules/native_hstu_layer.py
@@ -151,6 +151,7 @@ class HSTULayer(MegatronModule):
         register_setter_and_getter_for_nvtx(
             HSTULayer.forward, key_or_attr_name="values"
         )
+        self._disable_contextual_mask = config.disable_contextual_mask
 
     def get_user_value_query_key_tensors(self, hidden_states: torch.Tensor):
         """
@@ -234,7 +235,9 @@ class HSTULayer(MegatronModule):
                 tk,
                 tv,
                 jd.seqlen_offsets,
-                num_contextuals=jd.contextual_seqlen,
+                num_contextuals=jd.contextual_seqlen
+                if not self._disable_contextual_mask
+                else None,
                 num_candidates=jd.num_candidates,
                 max_seqlen=jd.max_seqlen,
                 scaling_seqlen=jd.scaling_seqlen,

--- a/examples/hstu/training/configs/kuairand_1k_ranking.gin
+++ b/examples/hstu/training/configs/kuairand_1k_ranking.gin
@@ -14,6 +14,7 @@ NetworkArgs.num_layers = 3
 NetworkArgs.num_attention_heads = 4
 NetworkArgs.hidden_size = 512
 NetworkArgs.kv_channels = 128
+NetworkArgs.disable_contextual_mask = True
 
 RankingArgs.prediction_head_arch = [
     512, 8

--- a/examples/hstu/training/trainer/utils.py
+++ b/examples/hstu/training/trainer/utils.py
@@ -106,6 +106,7 @@ def create_hstu_config(
         recompute_input_layernorm=network_args.recompute_input_layernorm,
         recompute_input_silu=network_args.recompute_input_silu,
         scaling_seqlen=network_args.scaling_seqlen,
+        disable_contextual_mask=network_args.disable_contextual_mask,
     )
 
 

--- a/examples/hstu/utils/gin_config_args.py
+++ b/examples/hstu/utils/gin_config_args.py
@@ -344,6 +344,9 @@ class NetworkArgs:
         recompute_input_silu (bool): Recompute input SiLU activation. Default: False.
         item_embedding_dim (int): Item embedding dimension. Default: -1.
         contextual_embedding_dim (int): Contextual embedding dimension. Default: -1.
+        scaling_seqlen (int): Scaling sequence length. By default, the max sequence length in the batch is used. Default: -1.
+        embedding_backend (str): Embedding backend. Default: None.
+        disable_contextual_mask (bool): Whether to disable contextual mask. Default: False.
     """
 
     num_layers: int
@@ -370,6 +373,8 @@ class NetworkArgs:
 
     scaling_seqlen: int = -1
     embedding_backend: Optional[str] = None
+
+    disable_contextual_mask: bool = False
 
     def __post_init__(self):
         assert self.dtype_str in [


### PR DESCRIPTION
## Description

- Add `disable_contextual_mask` in `HSTUConfig` to compute HSTU attention kernel without contextual mask, with respect to Meta implementation.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-repo-template/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
