### PR TITLE
[Fea] beam search sm8x support

### DIFF
--- a/examples/sid_gr/model/gpt_model.py
+++ b/examples/sid_gr/model/gpt_model.py
@@ -1077,6 +1077,7 @@ class SIDGRModel(MegatronModule):
             prefill_output, context_kv_caches = fa_block.prefill(
                 flat_history,
                 cu_seqlens=input_offsets.to(torch.int32),
+                max_seqlen=input_max_seqlen,
                 seqlen=total_tokens,
             )
             prefill_output = prefill_output.squeeze(0)  # [total_tokens, D]

--- a/examples/sid_gr/model/jagged_flash_attn_block.py
+++ b/examples/sid_gr/model/jagged_flash_attn_block.py
@@ -459,6 +459,7 @@ class JaggedGPTLayer(nn.Module):
         hidden_states: torch.Tensor,
         arbitrary_func: Optional[torch.Tensor] = None,
         cu_seqlens: Optional[torch.Tensor] = None,
+        max_seqlen: Optional[int] = None,
         linear_k: Optional[object] = None,
         linear_q: Optional[object] = None,
     ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
@@ -466,21 +467,23 @@ class JaggedGPTLayer(nn.Module):
 
         Three mutually exclusive attention modes:
           1. ``cu_seqlens`` is set → flattened jagged input, plain
-             per-sample causal. Uses FA's ``flash_attn_varlen_func``
-             fast path (orders of magnitude faster than the
-             arbitrary-mask path for the same semantics). The cute
-             interface infers ``max_seqlen`` from ``cu_seqlens``, so
-             we don't pass it explicitly.
+             per-sample causal. Uses upstream Tri Dao FA2
+             ``flash_attn_varlen_func`` (``flash_attn.flash_attn_interface``),
+             which is shipped pre-built in the nvcr base image and
+             supports SM80+. ``max_seqlen`` must be supplied (FA2
+             requires it; cute could infer but we don't use cute here).
           2. ``arbitrary_func`` is set → generic mask (e.g. beam
-             isolation in ``generate()``). Uses the arbitrary-mask FA
-             path.
+             isolation in ``generate()``). Uses the cute FA
+             arbitrary-mask path (SM90+ only).
           3. Neither → dense per-batch causal (``[B, S, ...]`` input,
-             padded). Uses FA's ``causal=True`` fast path.
+             padded). Uses cute FA ``causal=True`` (SM90+ only).
 
         Args:
             hidden_states: ``[1, total_tokens, hidden]`` for mode 1,
                 ``[B, S, hidden]`` for modes 2/3.
             cu_seqlens: ``[B + 1]`` int32 offsets for mode 1.
+            max_seqlen: max sequence length across the batch, required
+                in mode 1.
 
         Returns:
             hidden_states: same leading shape as input.
@@ -491,8 +494,6 @@ class JaggedGPTLayer(nn.Module):
         ), "arbitrary_func and cu_seqlens are mutually exclusive"
         residual, q, k, v = self._qkv_projection(hidden_states)
 
-        from flash_attn.cute.interface import flash_attn_func, flash_attn_varlen_func
-
         input_dtype = q.dtype
         if q.dtype not in (torch.float16, torch.bfloat16):
             q, k, v = q.bfloat16(), k.bfloat16(), v.bfloat16()
@@ -501,22 +502,32 @@ class JaggedGPTLayer(nn.Module):
         v_cache = v.clone()
 
         if cu_seqlens is not None:
-            # Mode 1: jagged + plain causal via FA varlen fast path.
+            # Mode 1: jagged + plain causal via upstream FA2 varlen.
             # Squeeze B=1 leading dim so the call sees [total, H, D].
             assert q.shape[0] == 1, "cu_seqlens mode expects B=1 flattened input"
+            assert max_seqlen is not None, (
+                "max_seqlen is required when cu_seqlens is set "
+                "(FA2 flash_attn_varlen_func needs it explicitly)"
+            )
+            from flash_attn.flash_attn_interface import flash_attn_varlen_func
+
             q_flat, k_flat, v_flat = q.squeeze(0), k.squeeze(0), v.squeeze(0)
-            attn_flat, _ = flash_attn_varlen_func(
+            attn_flat = flash_attn_varlen_func(
                 q_flat,
                 k_flat,
                 v_flat,
                 cu_seqlens_q=cu_seqlens,
                 cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
                 softmax_scale=self.head_dim ** (-0.5),
                 causal=True,
             )
             attn_out = attn_flat.unsqueeze(0)
         elif arbitrary_func is not None:
             # Mode 2: arbitrary mask (e.g. beam isolation).
+            from flash_attn.cute.interface import flash_attn_func
+
             attn_out, _ = flash_attn_func(
                 q,
                 k,
@@ -530,6 +541,8 @@ class JaggedGPTLayer(nn.Module):
             )
         else:
             # Mode 3: dense per-batch causal fast path.
+            from flash_attn.cute.interface import flash_attn_func
+
             attn_out, _ = flash_attn_func(
                 q,
                 k,
@@ -769,6 +782,7 @@ class JaggedFlashAttnBlock(nn.Module):
         hidden_states: torch.Tensor,
         arbitrary_func: Optional[torch.Tensor] = None,
         cu_seqlens: Optional[torch.Tensor] = None,
+        max_seqlen: Optional[int] = None,
         seqlen: Optional[int] = None,
     ) -> Tuple[torch.Tensor, List[Tuple[torch.Tensor, torch.Tensor]]]:
         """Forward through all layers, returning per-layer KV caches.
@@ -779,8 +793,11 @@ class JaggedFlashAttnBlock(nn.Module):
             arbitrary_func: generic mask (mutually exclusive with
                 ``cu_seqlens``).
             cu_seqlens: ``[B + 1]`` int32 offsets for the varlen + causal
-                fast path (jagged input, per-sample causal). The cute
-                FA interface infers max_seqlen from cu_seqlens itself.
+                fast path (jagged input, per-sample causal). Standard
+                FA2 ``flash_attn_varlen_func`` requires ``max_seqlen``
+                to be supplied alongside.
+            max_seqlen: max sequence length across the batch; required
+                when ``cu_seqlens`` is set.
             seqlen: only used for ``arbitrary_func`` block-sparsity
                 construction; ignored otherwise.
 
@@ -806,6 +823,7 @@ class JaggedFlashAttnBlock(nn.Module):
                 hidden_states,
                 arbitrary_func=arbitrary_func,
                 cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
                 linear_k=linear_k,
                 linear_q=linear_q,
             )

--- a/examples/sid_gr/tests/test_beam_decode_generate.py
+++ b/examples/sid_gr/tests/test_beam_decode_generate.py
@@ -31,6 +31,7 @@ from typing import List
 import pytest
 import torch
 from beam_search.beam_search import BeamSearch
+from tests.test_utils import is_sm90_or_above
 
 # Import jagged_flash_attn_block directly to avoid model/__init__.py
 # which pulls in heavy dependencies (dynamicemb, megatron, torchrec).
@@ -80,14 +81,7 @@ _E2E_SKIP_REASON = (
 # Some paths still go through `flash_attn.cute` (target-aware arbitrary
 # mask in baseline `generate()` and the Mode-3 dense prefill fallback),
 # which asserts SM90+. Tests that exercise either are gated on this.
-def _is_sm90_or_above() -> bool:
-    if not torch.cuda.is_available():
-        return False
-    major, _ = torch.cuda.get_device_capability()
-    return major >= 9
-
-
-_SM90_AVAILABLE = _is_sm90_or_above()
+_SM90_AVAILABLE = is_sm90_or_above()
 _SM90_SKIP_REASON = (
     "requires SM90+ (cute FA arbitrary-mask path / dense Mode-3 prefill); "
     "current device compute capability < 9.0"

--- a/examples/sid_gr/tests/test_beam_decode_generate.py
+++ b/examples/sid_gr/tests/test_beam_decode_generate.py
@@ -77,6 +77,23 @@ _E2E_SKIP_REASON = (
 )
 
 
+# Some paths still go through `flash_attn.cute` (target-aware arbitrary
+# mask in baseline `generate()` and the Mode-3 dense prefill fallback),
+# which asserts SM90+. Tests that exercise either are gated on this.
+def _is_sm90_or_above() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major >= 9
+
+
+_SM90_AVAILABLE = _is_sm90_or_above()
+_SM90_SKIP_REASON = (
+    "requires SM90+ (cute FA arbitrary-mask path / dense Mode-3 prefill); "
+    "current device compute capability < 9.0"
+)
+
+
 # ---------------------------------------------------------------------------
 # Test: BeamSearch.build_beam_topk_indices
 # ---------------------------------------------------------------------------
@@ -268,6 +285,7 @@ class TestJaggedGPTLayerPrefillDecode:
             .bfloat16()
         )
 
+    @pytest.mark.skipif(not _SM90_AVAILABLE, reason=_SM90_SKIP_REASON)
     def test_prefill_returns_kv_cache(self, layer):
         B, S, D = 2, 16, 64
         x = torch.randn(B, S, D, device="cuda", dtype=torch.bfloat16)
@@ -538,6 +556,7 @@ def test_generate_beam_decode_e2e(
 
 
 @pytest.mark.skipif(not _E2E_AVAILABLE, reason=_E2E_SKIP_REASON)
+@pytest.mark.skipif(not _SM90_AVAILABLE, reason=_SM90_SKIP_REASON)
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("max_history_length", [32, 128])
 @pytest.mark.parametrize("num_layers", [2])
@@ -678,6 +697,7 @@ def test_generate_vs_generate_beam_decode_regression_guard(
 
 
 @pytest.mark.skipif(not _E2E_AVAILABLE, reason=_E2E_SKIP_REASON)
+@pytest.mark.skipif(not _SM90_AVAILABLE, reason=_SM90_SKIP_REASON)
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("max_history_length", [32, 128])
 @pytest.mark.parametrize("num_layers", [2])
@@ -1227,6 +1247,7 @@ def test_jagged_target_aware_builder_matches_dense(
 
 
 @pytest.mark.skipif(not _E2E_AVAILABLE, reason=_E2E_SKIP_REASON)
+@pytest.mark.skipif(not _SM90_AVAILABLE, reason=_SM90_SKIP_REASON)
 def test_generate_is_deterministic():
     """generate() called twice on the same batch must produce identical SIDs.
 

--- a/examples/sid_gr/tests/test_model_smoke.py
+++ b/examples/sid_gr/tests/test_model_smoke.py
@@ -7,21 +7,13 @@ from commons.checkpoint import get_unwrapped_module
 from commons.datasets.gpt_sid_batch import FeatureConfig, GPTSIDBatch
 from commons.modules.embedding import ShardedEmbeddingConfig
 from commons.ops.length_to_offsets import length_to_complete_offsets
-from tests.test_utils import create_sid_gr_model_and_optimizer
-
+from tests.test_utils import create_sid_gr_model_and_optimizer, is_sm90_or_above
 
 # Both tests forward through SIDGRModel, which goes through the cute FA
 # arbitrary-mask path. cute asserts SM90+, so the whole file is gated on
 # Hopper-or-newer hardware.
-def _is_sm90_or_above() -> bool:
-    if not torch.cuda.is_available():
-        return False
-    major, _ = torch.cuda.get_device_capability()
-    return major >= 9
-
-
 pytestmark = pytest.mark.skipif(
-    not _is_sm90_or_above(),
+    not is_sm90_or_above(),
     reason=(
         "test_model_smoke forwards through cute FA arbitrary-mask path "
         "(SM90+); current device compute capability < 9.0"

--- a/examples/sid_gr/tests/test_model_smoke.py
+++ b/examples/sid_gr/tests/test_model_smoke.py
@@ -10,6 +10,25 @@ from commons.ops.length_to_offsets import length_to_complete_offsets
 from tests.test_utils import create_sid_gr_model_and_optimizer
 
 
+# Both tests forward through SIDGRModel, which goes through the cute FA
+# arbitrary-mask path. cute asserts SM90+, so the whole file is gated on
+# Hopper-or-newer hardware.
+def _is_sm90_or_above() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major >= 9
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_sm90_or_above(),
+    reason=(
+        "test_model_smoke forwards through cute FA arbitrary-mask path "
+        "(SM90+); current device compute capability < 9.0"
+    ),
+)
+
+
 def generate_batches(
     batchsize: int,
     num_batches: int,

--- a/examples/sid_gr/tests/test_utils.py
+++ b/examples/sid_gr/tests/test_utils.py
@@ -12,6 +12,18 @@ if TYPE_CHECKING:
     from commons.modules.embedding import ShardedEmbeddingConfig
 
 
+def is_sm90_or_above() -> bool:
+    """True if a CUDA device with compute capability >= 9.0 is visible.
+
+    Used by tests gated on Hopper-only kernels (cute FA arbitrary mask,
+    Mode-3 dense prefill).
+    """
+    if not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major >= 9
+
+
 def _check_sids_shapes(*sids_tensors):
     """Validate that all sids tensors share a consistent ``[B, K, H]`` shape."""
     if not sids_tensors:


### PR DESCRIPTION
## Description
  - Fast-path jagged prefill: `flash_attn.cute` → `flash_attn` (upstream FA2). FA2 ships pre-built in
  the nvcr base image, supports SM80+. Zero Dockerfile change.
  - Gate the remaining cute-bound tests (baseline `generate()` + Mode-3 dense prefill) on
  `_SM90_AVAILABLE` so the A100 CI lane skips them.

  ## Effect

  `generate_beam_decode()` runs end-to-end on A100. Training + baseline still SM90+ (out of scope).

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/recsys-examples/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
