### PR TITLE
Refactor _print_memory_consume to report real per-tier value bytes

### DIFF
--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_tables.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_tables.py
@@ -17,6 +17,7 @@ import os
 import warnings
 from collections import deque
 from copy import deepcopy
+from enum import Enum
 from functools import partial
 from itertools import accumulate
 from typing import Deque, Dict, List, Optional, Tuple
@@ -56,7 +57,7 @@ from dynamicemb.optimizer import (
     SGDDynamicEmbeddingOptimizer,
     get_optimizer_state_dim,
 )
-from dynamicemb.utils import DTYPE_NUM_BYTES, tabulate
+from dynamicemb.utils import DTYPE_NUM_BYTES
 from dynamicemb_extensions import device_timestamp
 from fbgemm_gpu.split_table_batched_embeddings_ops_training import (
     BoundsCheckMode,
@@ -206,82 +207,241 @@ def get_loading_files(
     )
 
 
-def _print_memory_consume(
-    table_names,
-    dynamicemb_options,
-    optimizer,
-    device_id,
+class StorageLayout(Enum):
+    HBM_ONLY = "HBM-only (single tier, GPU)"
+    HOST_ONLY = "Host-only (single tier, CPU)"
+    HYBRID = "Hybrid (HBM + Host, disjoint partitions; total = HBM + Host)"
+    CACHING = "Caching (HBM cache + Host full backing; HBM rows duplicate Host)"
+    CACHING_PS = "Caching (HBM cache + external PS backing; HBM rows duplicate PS)"
+    HOST_PS = "External PS only (host-resident, opaque)"
+
+
+def _tier_bytes_from_state(state) -> List[Tuple[int, int, int, int, int, int]]:
+    """Per-table value bytes for a built tier: (init total/emb/opt, peak total/emb/opt).
+
+    ``init`` is the current ``ExtendableBuffer`` logical size (post bucket-align,
+    pre-rehash). ``peak`` is ``max_capacity * value_dim * element_size`` — what
+    the buffer grows to after rehashing fully.
+    """
+    rows = []
+    for t in range(state.num_tables):
+        buf = state.tables[t]
+        opt = state.options_list[t]
+        value_dim = state.table_value_dims_cpu[t]
+        emb_dim = state.table_emb_dims_cpu[t]
+        elem = DTYPE_NUM_BYTES[opt.embedding_dtype]
+        init_total = buf.num_bytes()
+        init_emb = init_total * emb_dim // value_dim
+        init_opt = init_total - init_emb
+        peak_total = opt.max_capacity * value_dim * elem
+        peak_emb = peak_total * emb_dim // value_dim
+        peak_opt = peak_total - peak_emb
+        rows.append((init_total, init_emb, init_opt, peak_total, peak_emb, peak_opt))
+    return rows
+
+
+def _tier_bytes_from_options(
+    options_list: List[DynamicEmbTableOptions],
+    optimizer: Optional["BaseDynamicEmbeddingOptimizer"],
     emb_optimizer_type: EmbOptimType,
-) -> None:
-    subtitle = [
-        "",
-        "total",
-        "embedding",
-        "optim_state",
-        "total",
-        "embedding",
-        "optim_state",
-        "total",
-        "embedding",
-        "optim_state",
-    ]
-    table_consume = []
-    table_consume.append(subtitle)
+) -> List[Tuple[Optional[int], Optional[int], Optional[int], int, int, int]]:
+    """Fallback for external-PS tiers where we can't peek into the storage.
 
-    def MB_(x) -> int:
-        return x // (1024 * 1024)
-
-    def KB_(x) -> int:
-        return x // (1024)
-
-    F = None
-
-    for table_name, table_option in zip(table_names, dynamicemb_options):
-        element_size = DTYPE_NUM_BYTES[table_option.embedding_dtype]
-        emb_dim = table_option.dim
+    Init bytes are unknown (PS is opaque) — reported as ``None``. Peak uses the
+    original options' ``max_capacity``.
+    """
+    rows = []
+    for opt in options_list:
+        emb_dim = opt.dim
         if optimizer is not None:
             optim_state_dim = optimizer.get_state_dim(emb_dim)
         else:
             optim_state_dim = get_optimizer_state_dim(
-                emb_optimizer_type, emb_dim, table_option.embedding_dtype
+                emb_optimizer_type, emb_dim, opt.embedding_dtype
             )
-        total_dim = emb_dim + optim_state_dim
-        total_memory = table_option.max_capacity * element_size * total_dim
-        if F is None:
-            if total_memory // (1024 * 1024) != 0:
-                F = MB_
-            else:
-                F = KB_
-        local_hbm_for_values = min(table_option.local_hbm_for_values, total_memory)
-        local_dram_for_values = total_memory - local_hbm_for_values
-        table_consume.append(
+        value_dim = emb_dim + optim_state_dim
+        elem = DTYPE_NUM_BYTES[opt.embedding_dtype]
+        peak_total = opt.max_capacity * value_dim * elem
+        peak_emb = peak_total * emb_dim // value_dim
+        peak_opt = peak_total - peak_emb
+        rows.append((None, None, None, peak_total, peak_emb, peak_opt))
+    return rows
+
+
+def _build_tier_block(
+    tier_label: str,
+    tier_rows: List[Tuple],
+    table_names: List[str],
+    fmt,
+) -> Tuple[List[List[str]], List[str]]:
+    """Per-tier long-format rows + per-tier TOTAL row.
+
+    ``tier_label`` is emitted only on the first row; later rows leave that cell
+    blank so the tier column visually groups its tables. TOTAL aggregates
+    init/peak/emb/opt; init becomes ``N/A`` if any contributing row's init is
+    unknown (external PS).
+    """
+    rows: List[List[str]] = []
+    init_known = True
+    sum_init = sum_pt = sum_pe = sum_po = 0
+    for ti, (it, _ie, _io, pt, pe, po) in enumerate(tier_rows):
+        rows.append(
             [
-                table_name,
-                F(total_memory),
-                F(table_option.max_capacity * element_size * emb_dim),
-                F(table_option.max_capacity * element_size * optim_state_dim),
-                F(local_hbm_for_values),
-                F(int(local_hbm_for_values * emb_dim // total_dim)),
-                F(int(local_hbm_for_values * optim_state_dim // total_dim)),
-                F(local_dram_for_values),
-                F(int(local_dram_for_values * emb_dim // total_dim)),
-                F(int(local_dram_for_values * optim_state_dim // total_dim)),
+                tier_label if ti == 0 else "",
+                table_names[ti],
+                fmt(it),
+                fmt(pt),
+                f"{fmt(pe)} / {fmt(po)}",
             ]
         )
-    unit = "MB" if F == MB_ else "KB"
-    title = [
-        "table name",
+        if it is None:
+            init_known = False
+        else:
+            sum_init += it
+        sum_pt += pt
+        sum_pe += pe
+        sum_po += po
+    total = [
         "",
-        f"memory({unit})",
-        "",
-        "",
-        f"hbm({unit})/cuda:{device_id}",
-        "",
-        "",
-        f"dram({unit})",
-        "",
+        "TOTAL",
+        fmt(sum_init) if init_known else "N/A",
+        fmt(sum_pt),
+        f"{fmt(sum_pe)} / {fmt(sum_po)}",
     ]
-    output = "\n\n" + tabulate(table_consume, title, sub_headers=True)
+    return rows, total
+
+
+def _render_tier_table(
+    header: List[str],
+    tier_blocks: List[Tuple[List[List[str]], List[str]]],
+) -> str:
+    """Render the long-format table.
+
+    Two kinds of horizontal rules:
+      * ``sep_full`` — top border, under the header, between tier blocks, and
+        the closing bottom border.
+      * ``sep_blank_tier`` — frames each TOTAL row (tier column left blank so
+        the rule reads as part of the TOTAL row, not as a tier boundary).
+    """
+    all_rows: List[List[str]] = [header]
+    for table_rows, total_row in tier_blocks:
+        all_rows.extend(table_rows)
+        all_rows.append(total_row)
+    widths = [max(len(row[i]) for row in all_rows) for i in range(len(header))]
+
+    def fmt_row(cells: List[str], center: bool = False) -> str:
+        return " | ".join(
+            (c.center(w) if center else c.ljust(w)) for c, w in zip(cells, widths)
+        )
+
+    sep_full = "-+-".join("-" * w for w in widths)
+    sep_blank_tier = " " * widths[0] + " | " + "-+-".join("-" * w for w in widths[1:])
+
+    lines = [sep_full, fmt_row(header, center=True), sep_full]
+    last = len(tier_blocks) - 1
+    for i, (table_rows, total_row) in enumerate(tier_blocks):
+        if i > 0:
+            lines.append(sep_full)
+        for r in table_rows:
+            lines.append(fmt_row(r))
+        lines.append(sep_blank_tier)
+        lines.append(fmt_row(total_row))
+        if i == last:
+            lines.append(sep_full)
+    return "\n".join(lines)
+
+
+def _print_memory_consume(
+    table_names: List[str],
+    storage: "Storage",
+    cache: Optional["Cache"],
+    layout: StorageLayout,
+    dynamicemb_options: List[DynamicEmbTableOptions],
+    optimizer: Optional["BaseDynamicEmbeddingOptimizer"],
+    device_id: int,
+    emb_optimizer_type: EmbOptimType,
+) -> None:
+    """Value-only memory accounting (embedding + optimizer state rows).
+
+    The caller passes the ``StorageLayout`` set by ``_create_cache_storage`` so
+    the report matches the code path that ran (no inference from buffer state).
+    Per-tier bytes come from the constructed ``ExtendableBuffer`` (init) and
+    ``options.max_capacity`` (peak), capturing bucket alignment, hybrid
+    ``cap_scale`` rebalancing, and caching's HBM/backing duplication. Does
+    *not* include hash-table metadata (keys/digests/scores/ref_counter), which
+    always live on HBM regardless of value tier.
+    """
+    # Build (tier_label, per-table rows) list. Each row is the 6-tuple above.
+    tiers: List[Tuple[str, List[Tuple]]] = []
+    if layout == StorageLayout.HBM_ONLY:
+        tiers.append((f"hbm/cuda:{device_id}", _tier_bytes_from_state(storage._state)))
+    elif layout == StorageLayout.HOST_ONLY:
+        tiers.append(("host (CPU)", _tier_bytes_from_state(storage._state)))
+    elif layout == StorageLayout.HYBRID:
+        tiers.append((f"hbm/cuda:{device_id}", _tier_bytes_from_state(storage._hbm)))
+        tiers.append(("host (CPU)", _tier_bytes_from_state(storage._host)))
+    elif layout == StorageLayout.CACHING:
+        tiers.append(
+            (f"hbm cache/cuda:{device_id}", _tier_bytes_from_state(cache._state))
+        )
+        tiers.append(("host backing (full)", _tier_bytes_from_state(storage._state)))
+    elif layout == StorageLayout.CACHING_PS:
+        tiers.append(
+            (f"hbm cache/cuda:{device_id}", _tier_bytes_from_state(cache._state))
+        )
+        tiers.append(
+            (
+                "external PS",
+                _tier_bytes_from_options(
+                    dynamicemb_options, optimizer, emb_optimizer_type
+                ),
+            )
+        )
+    else:  # HOST_PS
+        tiers.append(
+            (
+                "external PS",
+                _tier_bytes_from_options(
+                    dynamicemb_options, optimizer, emb_optimizer_type
+                ),
+            )
+        )
+
+    # Pick a single unit (MB if any value reaches 1 MB; else KB).
+    max_byte = 0
+    for _, rows in tiers:
+        for row in rows:
+            for v in row:
+                if v is not None and v > max_byte:
+                    max_byte = v
+    use_mb = max_byte >= 1024 * 1024
+    unit = "MB" if use_mb else "KB"
+    divisor = 1024 * 1024 if use_mb else 1024
+
+    def F(x):
+        if x is None:
+            return "N/A"
+        # Up to 3 decimals; drop trailing zeros so whole values render as ints.
+        s = f"{x / divisor:.3f}".rstrip("0").rstrip(".")
+        return s or "0"
+
+    header = [
+        "tier",
+        "table",
+        f"init({unit})",
+        f"peak({unit})",
+        f"emb/opt peak({unit})",
+    ]
+    tier_blocks = [
+        _build_tier_block(label, rows, table_names, F) for label, rows in tiers
+    ]
+    body = _render_tier_table(header, tier_blocks)
+    output = f"\n\nStorage layout: {layout.value}\n" + body
+    if layout in (StorageLayout.CACHING, StorageLayout.CACHING_PS):
+        output += (
+            "\nNote: HBM cache rows duplicate backing rows; "
+            "total memory ≈ HBM cache + Host/PS backing (no subtract)."
+        )
     print(output)
 
 
@@ -537,6 +697,9 @@ class BatchedDynamicEmbeddingTablesV2(nn.Module):
                     if PS
                     else DynamicEmbStorage(storage_options, self._optimizer)
                 )
+                self._storage_layout = (
+                    StorageLayout.CACHING_PS if PS else StorageLayout.CACHING
+                )
             else:
                 # No caching and no HBM budget for values: single-tier host/PS storage.
                 if local_hbm <= 0:
@@ -548,6 +711,9 @@ class BatchedDynamicEmbeddingTablesV2(nn.Module):
                         PS(storage_options, self._optimizer)
                         if PS
                         else DynamicEmbStorage(storage_options, self._optimizer)
+                    )
+                    self._storage_layout = (
+                        StorageLayout.HOST_PS if PS else StorageLayout.HOST_ONLY
                     )
                 else:
                     # No caching: HybridStorage (HBM tier + host tier)
@@ -590,6 +756,7 @@ class BatchedDynamicEmbeddingTablesV2(nn.Module):
                     self._storage = HybridStorage(
                         hbm_options, host_options, self._optimizer
                     )
+                    self._storage_layout = StorageLayout.HYBRID
         else:
             # HBM-only: everything fits in GPU memory.
             if any(
@@ -602,9 +769,13 @@ class BatchedDynamicEmbeddingTablesV2(nn.Module):
                     UserWarning,
                 )
             self._storage = DynamicEmbStorage(self._dynamicemb_options, self._optimizer)
+            self._storage_layout = StorageLayout.HBM_ONLY
 
         _print_memory_consume(
             self._table_names,
+            self._storage,
+            self._cache,
+            self._storage_layout,
             self._dynamicemb_options,
             self._optimizer,
             self.device_id,

--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_tables.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_tables.py
@@ -397,7 +397,7 @@ def _print_memory_consume(
                 ),
             )
         )
-    else:  # HOST_PS
+    elif layout == StorageLayout.HOST_PS:
         tiers.append(
             (
                 "external PS",
@@ -406,6 +406,8 @@ def _print_memory_consume(
                 ),
             )
         )
+    else:
+        raise ValueError(f"Unhandled StorageLayout: {layout!r}")
 
     # Pick a single unit (MB if any value reaches 1 MB; else KB).
     max_byte = 0


### PR DESCRIPTION
- Add StorageLayout enum set explicitly by _create_cache_storage so the printed layout matches the code path that ran (no inference from buffer state, which only reflects options[0].local_hbm_for_values).
- Read per-tier value bytes from the constructed ExtendableBuffer (init, post bucket-alignment) and options.max_capacity (peak); this fixes caching mode where the HBM cache duplicates the host backing — the old code reported HBM+DRAM=total_memory and missed the cache copy entirely. Also captures hybrid cap_scale + bucket-alignment rounding.
- Switch to long-format tier-major output: one row per (tier, table), per-tier TOTAL rows. Full top/bottom/inter-tier borders; a blanked-tier-column rule frames each TOTAL row inside its block.
- Extract _build_tier_block / _render_tier_table helpers so the print function only does dispatch + layout footnote.
- Bytes formatter renders MB/KB as float with up to 3 decimals, trimming trailing zeros.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/recsys-examples/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
