### PR TITLE
[dynamicemb] Add spawn-based multi-worker DataLoader option to MovieL…

### DIFF
--- a/corelib/dynamicemb/example/README.md
+++ b/corelib/dynamicemb/example/README.md
@@ -32,6 +32,39 @@ bash ./run_example.sh --dist_type hash_roundrobin
 
 `hash_roundrobin` is an opt-in routing mode intended to reduce sensitivity to pathological raw-key patterns that can break plain modulo-based `roundrobin`.
 
+- Multi-worker data loading (`--num_workers`):
+```shell
+export NGPU=2
+
+# default: load data in the main process (no worker subprocesses)
+torchrun --standalone --nproc_per_node=${NGPU} example.py --train
+
+# offload dataset reads + collate to 4 background worker processes per rank
+torchrun --standalone --nproc_per_node=${NGPU} example.py --train --num_workers 4
+
+# also works through the helper script
+bash ./run_example.sh --num_workers 4
+```
+
+`--num_workers` controls how many subprocesses each rank uses to prefetch and
+collate batches (default `0`, i.e. loading happens in the main process).
+
+When `--num_workers > 0` the example builds the `DataLoader` with the **`spawn`**
+multiprocessing start method (plus `persistent_workers=True`). This is required
+because the main process has already initialized a CUDA context
+(`torch.cuda.set_device`): the default `fork` start method would hand each worker
+an unusable copy of that context and trigger `RuntimeError: initialization error`
+on the worker's first CUDA touch. `spawn` instead launches a fresh interpreter
+per worker with no inherited CUDA state. The workers only do CPU work (dataset
+reads and `collate_fn`); the host-to-device copy stays in the main process, so
+the workers never need their own CUDA context.
+
+Notes:
+- `spawn` re-imports `example.py` in every worker, so its startup is heavier than
+  `fork`; for the small MovieLens dataset the speedup from extra workers is
+  usually marginal. Treat `--num_workers > 0` mainly as a reference for safely
+  enabling multi-worker loading in CUDA + distributed setups.
+- Pick a value no larger than the CPU cores available per rank.
 
 - For detailed explanations of specific APIs and parameters, please refer to [API Doc](../DynamicEmb_APIs.md).
 

--- a/corelib/dynamicemb/example/example.py
+++ b/corelib/dynamicemb/example/example.py
@@ -61,15 +61,11 @@ warnings.filterwarnings(
 )
 
 BACKEND = "nccl"
-# print with rank info
+# Keep a handle to the original print; the rank-aware print is installed in
+# init_runtime(). Do NOT override builtins.print at module scope: with
+# spawn-based DataLoader workers the module is re-imported in each worker, and a
+# module-level override would run before any RuntimeContext exists.
 original_print = builtins.print
-
-
-def rank_print(*args, **kwargs):
-    original_print(f"[RANK {local_rank}] ", *args, **kwargs)
-
-
-builtins.print = rank_print
 cache_ratio = 0.5  # assume we will use 50% of the HBM for cache
 
 
@@ -207,6 +203,14 @@ def parse_args():
         choices=["continuous", "roundrobin", "hash_roundrobin"],
         default="roundrobin",
         help="DynamicEmb row-wise input distribution policy.",
+    )
+    parser.add_argument(
+        "--num_workers",
+        type=int,
+        default=0,
+        help="Number of DataLoader worker processes. 0 (default) loads data in "
+        "the main process. When > 0, spawn-based workers are used to avoid "
+        "cloning the parent's CUDA context.",
     )
     return parser.parse_args()
 
@@ -354,6 +358,33 @@ def collate_fn(batch):
     )
 
     return kjt, torch.tensor(labels, dtype=torch.float)
+
+
+def build_dataloader(dataset, sampler, args):
+    """Construct a DataLoader, optionally with spawn-based multi-worker loading.
+
+    The parent process initializes CUDA (torch.cuda.set_device in init_runtime),
+    so the default ``fork`` start method cannot be used for workers: a forked
+    child inherits an unusable copy of the CUDA context and raises
+    ``RuntimeError: initialization error`` on its first CUDA touch. When
+    ``num_workers > 0`` we therefore use the ``spawn`` start method, which gives
+    each worker a fresh interpreter with no inherited CUDA state. Workers only do
+    CPU work (dataset reads + collate_fn); the host->device copy stays in the
+    main process. ``persistent_workers`` keeps the (relatively expensive to
+    spawn) workers alive across epochs.
+    """
+    loader_kwargs = {
+        "batch_size": args.batch_size,
+        "shuffle": False,
+        "collate_fn": collate_fn,
+        "num_workers": args.num_workers,
+        "sampler": sampler,
+        "pin_memory": torch.cuda.is_available(),
+    }
+    if args.num_workers > 0:
+        loader_kwargs["multiprocessing_context"] = "spawn"
+        loader_kwargs["persistent_workers"] = True
+    return DataLoader(dataset, **loader_kwargs)
 
 
 class MovieLensModel(nn.Module):
@@ -778,23 +809,8 @@ def train(args, runtime: RuntimeContext):
         test_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=False
     )
 
-    train_loader = DataLoader(
-        train_dataset,
-        batch_size=args.batch_size,
-        shuffle=False,
-        collate_fn=collate_fn,
-        num_workers=0,
-        sampler=train_sampler,
-    )
-
-    test_loader = DataLoader(
-        test_dataset,
-        batch_size=args.batch_size,
-        shuffle=False,
-        collate_fn=collate_fn,
-        num_workers=0,
-        sampler=test_sampler,
-    )
+    train_loader = build_dataloader(train_dataset, train_sampler, args)
+    test_loader = build_dataloader(test_dataset, test_sampler, args)
 
     model = create_model(args, runtime)
     model.to(runtime.device)
@@ -818,14 +834,7 @@ def dump(args, runtime: RuntimeContext):
         train_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=True
     )
 
-    train_loader = DataLoader(
-        train_dataset,
-        batch_size=args.batch_size,
-        shuffle=False,
-        collate_fn=collate_fn,
-        num_workers=0,
-        sampler=train_sampler,
-    )
+    train_loader = build_dataloader(train_dataset, train_sampler, args)
 
     model = create_model(args, runtime)
     model.to(runtime.device)
@@ -858,14 +867,7 @@ def load(args, runtime: RuntimeContext):
         test_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=False
     )
 
-    test_loader = DataLoader(
-        test_dataset,
-        batch_size=args.batch_size,
-        shuffle=False,
-        collate_fn=collate_fn,
-        num_workers=0,
-        sampler=test_sampler,
-    )
+    test_loader = build_dataloader(test_dataset, test_sampler, args)
 
     model = create_model(args, runtime)
     model.to(runtime.device)
@@ -904,14 +906,7 @@ def inc_dump(args, runtime: RuntimeContext):
         train_dataset, num_replicas=runtime.world_size, rank=runtime.rank, shuffle=True
     )
 
-    train_loader = DataLoader(
-        train_dataset,
-        batch_size=args.batch_size,
-        shuffle=False,
-        collate_fn=collate_fn,
-        num_workers=0,
-        sampler=train_sampler,
-    )
+    train_loader = build_dataloader(train_dataset, train_sampler, args)
 
     model = create_model(args, runtime)
     model.to(runtime.device)

--- a/corelib/dynamicemb/example/example.py
+++ b/corelib/dynamicemb/example/example.py
@@ -212,7 +212,10 @@ def parse_args():
         "the main process. When > 0, spawn-based workers are used to avoid "
         "cloning the parent's CUDA context.",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.num_workers < 0:
+        parser.error("--num_workers must be >= 0")
+    return args
 
 
 class MovieLensDataset(Dataset):


### PR DESCRIPTION
…ens example

Add an opt-in --num_workers argument to the dynamicemb MovieLens example so data loading can be offloaded to subprocesses.

The main process initializes a CUDA context (torch.cuda.set_device in init_runtime), so the default fork start method cannot be used for DataLoader workers: a forked child inherits an unusable copy of the CUDA context and raises "RuntimeError: initialization error" on its first CUDA touch. When --num_workers > 0 the DataLoader is therefore built with the spawn start method (plus persistent_workers), which gives each worker a fresh interpreter with no inherited CUDA state. Workers only do CPU work (dataset reads + collate_fn); the host-to-device copy stays in the main process.

- Add build_dataloader() helper and route train/dump/load/inc_dump through it.
- Remove the leftover module-level rank_print override that referenced an undefined module-scope local_rank; the rank-aware print is installed in init_runtime(). This matters now that spawn workers re-import the module.
- Document --num_workers usage and the spawn rationale in the example README.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/recsys-examples/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
