### PR TITLE
fix offload_try_wait

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/jiayus-nvidia/FBGEMM.git
 [submodule "third_party/FlexKV"]
 	path = third_party/FlexKV
-	url = git@github.com:taco-project/FlexKV.git
+	url = https://github.com/taco-project/FlexKV.git

--- a/corelib/recsys_kvcache_manager/recsys_kvcache_manager/flex_kvcache_manager.py
+++ b/corelib/recsys_kvcache_manager/recsys_kvcache_manager/flex_kvcache_manager.py
@@ -487,16 +487,29 @@ class FlexKVStorageManager(HostKVStorageManagerBase):
         user_ids = task_handle.handle.uids
 
         remain_task_ids = [t for t in task_ids if t not in task_handle.handle.responses]
-        responses = self._client.try_wait(remain_task_ids)
+        if not remain_task_ids:
+            return HostKVWaitResult(status=HostKVTaskStatus.READY, ready=True)
 
+        responses = self._client.try_wait(remain_task_ids)
+        # print(f"responses: {responses}")
+        # print(f"task_ids: {task_ids}")
+
+        # try_wait is non-blocking: empty or partial result means tasks are still pending.
         has_unready = False
         # has_timeout = False
         has_cancelled = False
         has_failed = False
         msgs: List[str] = []
+        
+        missing_task_ids = [t for t in remain_task_ids if t not in responses]
+        if missing_task_ids:
+            has_unready = True
+            msgs.extend(f"{task_id}:{KVResponseStatus.UNREADY}" for task_id in missing_task_ids)
+
         for task_id, resp in responses.items():
             task_handle.handle.responses[task_id] = resp
             msgs.append(f"{task_id}:{resp.status}")
+            # print(f"task_id: {task_id}, resp: {resp.status}")
             if resp.status == KVResponseStatus.SUCCESS:
                 continue
             elif resp.status == KVResponseStatus.UNREADY:

--- a/corelib/recsys_kvcache_manager/recsys_kvcache_manager/flex_kvcache_manager.py
+++ b/corelib/recsys_kvcache_manager/recsys_kvcache_manager/flex_kvcache_manager.py
@@ -546,9 +546,23 @@ class FlexKVStorageManager(HostKVStorageManagerBase):
         return HostKVWaitResult(status=HostKVTaskStatus.READY, ready=True)
 
     def finish_task(self, task_handle: HostKVTaskHandle) -> List[int]:
-        # FlexKV wait success equals finish
+        # FlexKV wait success equals finish.
+        # offload_kvcache_wait() may already try_wait() to SUCCESS and release tasks in
+        # FlexKV; waiting again on those ids logs "not submitted" (NOTFOUND). Only wait
+        # on tasks that are not yet SUCCESS in handle.responses.
         # TODO(junyiq): Make sure gpu kvcache locks the pages when offloading for flexkv backend.
-        self._client.wait(task_handle.handle.task_ids, completely=True)
+        responses = getattr(task_handle.handle, "responses", None)
+        if responses is None:
+            pending_task_ids = list(task_handle.handle.task_ids)
+        else:
+            pending_task_ids = [
+                task_id
+                for task_id in task_handle.handle.task_ids
+                if responses.get(task_id) is None
+                or responses[task_id].status != KVResponseStatus.SUCCESS
+            ]
+        if pending_task_ids:
+            self._client.wait(pending_task_ids, completely=True)
         return [1 for _ in range(task_handle.handle.uids.size(0))]
 
     def cancel_task(self, task_handle: HostKVTaskHandle) -> bool:

--- a/corelib/recsys_kvcache_manager/recsys_kvcache_manager/flex_kvcache_manager.py
+++ b/corelib/recsys_kvcache_manager/recsys_kvcache_manager/flex_kvcache_manager.py
@@ -491,8 +491,6 @@ class FlexKVStorageManager(HostKVStorageManagerBase):
             return HostKVWaitResult(status=HostKVTaskStatus.READY, ready=True)
 
         responses = self._client.try_wait(remain_task_ids)
-        # print(f"responses: {responses}")
-        # print(f"task_ids: {task_ids}")
 
         # try_wait is non-blocking: empty or partial result means tasks are still pending.
         has_unready = False
@@ -500,16 +498,17 @@ class FlexKVStorageManager(HostKVStorageManagerBase):
         has_cancelled = False
         has_failed = False
         msgs: List[str] = []
-        
+
         missing_task_ids = [t for t in remain_task_ids if t not in responses]
         if missing_task_ids:
             has_unready = True
-            msgs.extend(f"{task_id}:{KVResponseStatus.UNREADY}" for task_id in missing_task_ids)
+            msgs.extend(
+                f"{task_id}:{KVResponseStatus.UNREADY}" for task_id in missing_task_ids
+            )
 
         for task_id, resp in responses.items():
             task_handle.handle.responses[task_id] = resp
             msgs.append(f"{task_id}:{resp.status}")
-            # print(f"task_id: {task_id}, resp: {resp.status}")
             if resp.status == KVResponseStatus.SUCCESS:
                 continue
             elif resp.status == KVResponseStatus.UNREADY:
@@ -551,16 +550,13 @@ class FlexKVStorageManager(HostKVStorageManagerBase):
         # FlexKV; waiting again on those ids logs "not submitted" (NOTFOUND). Only wait
         # on tasks that are not yet SUCCESS in handle.responses.
         # TODO(junyiq): Make sure gpu kvcache locks the pages when offloading for flexkv backend.
-        responses = getattr(task_handle.handle, "responses", None)
-        if responses is None:
-            pending_task_ids = list(task_handle.handle.task_ids)
-        else:
-            pending_task_ids = [
-                task_id
-                for task_id in task_handle.handle.task_ids
-                if responses.get(task_id) is None
-                or responses[task_id].status != KVResponseStatus.SUCCESS
-            ]
+        responses = task_handle.handle.responses
+        pending_task_ids = [
+            task_id
+            for task_id in task_handle.handle.task_ids
+            if responses.get(task_id) is None
+            or responses[task_id].status != KVResponseStatus.SUCCESS
+        ]
         if pending_task_ids:
             self._client.wait(pending_task_ids, completely=True)
         return [1 for _ in range(task_handle.handle.uids.size(0))]

--- a/corelib/recsys_kvcache_manager/recsys_kvcache_manager/kvcache_manager.py
+++ b/corelib/recsys_kvcache_manager/recsys_kvcache_manager/kvcache_manager.py
@@ -236,7 +236,6 @@ class KVCacheManager:
         remain_tasks = list()
         for task_handle in self.ongoing_offload_tasks:
             wait_result = self.host_kvstorage_manager.offload_kvcache_wait(task_handle)
-            # print(f"wait_result: {wait_result}")
             if wait_result.status == HostKVTaskStatus.LAUNCHED:
                 remain_tasks.append(task_handle)
                 continue

--- a/corelib/recsys_kvcache_manager/recsys_kvcache_manager/kvcache_manager.py
+++ b/corelib/recsys_kvcache_manager/recsys_kvcache_manager/kvcache_manager.py
@@ -236,6 +236,7 @@ class KVCacheManager:
         remain_tasks = list()
         for task_handle in self.ongoing_offload_tasks:
             wait_result = self.host_kvstorage_manager.offload_kvcache_wait(task_handle)
+            # print(f"wait_result: {wait_result}")
             if wait_result.status == HostKVTaskStatus.LAUNCHED:
                 remain_tasks.append(task_handle)
                 continue

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -111,6 +111,7 @@ RUN cd /workspace/deps/fbgemm_hstu/fbgemm_gpu/experimental/hstu && \
 FROM ${DEVEL_IMAGE} AS build
 ARG TRITONSERVER_BUILD
 
+RUN rm -rf /workspace/recsys-examples
 WORKDIR /workspace/recsys-examples
 COPY . .
 


### PR DESCRIPTION
## Description
This PR commit fix try_wait logic.
Changes:
- **`offload_kvcache_wait` / `try_wait` handling**
  - Return `READY` immediately when there are no remaining task IDs.
  - Treat task IDs missing from non-blocking `try_wait` responses as `UNREADY` instead of failing the wait logic.
  - Keep wait-state handling consistent for partial / non-blocking `try_wait` results.
- **`finish_task` handling**
  - Only call blocking `wait()` on task IDs that are not yet `SUCCESS` in `handle.responses`.
  - Avoids FlexKV "not submitted" / `NOTFOUND` errors when tasks were already completed and released during earlier `try_wait` polling.
- **Submodule URL**
  - Update `third_party/FlexKV` in `.gitmodules` from SSH to HTTPS for easier clone/CI setup.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/recsys-examples/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.