### PR TITLE
[FEAT] add HDFS support for DynamicEmb checkpoint dump and load

### DIFF
--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_tables.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_tables.py
@@ -38,6 +38,7 @@ from dynamicemb.dynamicemb_config import (
     warning_for_cstm_score,
 )
 from dynamicemb.embedding_admission import MultiTableKVCounter
+from dynamicemb.filesystem import get_filesystem
 from dynamicemb.initializer import create_initializer_from_args
 from dynamicemb.key_value_table import (
     Cache,
@@ -90,6 +91,17 @@ def encode_counter_checkpoint_file_path(
     )
 
 
+def _strip_scheme_prefix(path: str) -> str:
+    """Strip ``hdfs://host:port`` prefix if present, returning ``/path``."""
+    if path.startswith("hdfs://"):
+        # hdfs://host:port/path  →  /path
+        without_scheme = path[len("hdfs://") :]
+        idx = without_scheme.find("/")
+        if idx != -1:
+            return without_scheme[idx:]
+    return path
+
+
 def find_files(root_path: str, table_name: str, suffix: str) -> Tuple[List[str], int]:
     suffix_to_encode_file_path_func = {
         "emb_keys": partial(encode_checkpoint_file_path, item="keys"),
@@ -105,10 +117,10 @@ def find_files(root_path: str, table_name: str, suffix: str) -> Tuple[List[str],
         raise RuntimeError(f"Invalid suffix: {suffix}")
     encode_file_path_func = suffix_to_encode_file_path_func[suffix]
 
-    import glob
-
     # v2 version
-    files = glob.glob(encode_file_path_func(root_path, table_name, "*", "*"))
+    files = get_filesystem(root_path).glob(
+        encode_file_path_func(root_path, table_name, "*", "*")
+    )
     if len(files) == 0:
         return [], 0
     files = sorted(files)
@@ -118,11 +130,23 @@ def find_files(root_path: str, table_name: str, suffix: str) -> Tuple[List[str],
             f"Checkpoints is corrupted. Found {len(files)} under path {root_path} for table {table_name}, but the number of checkpointed world size is {world_size}."
         )
 
+    # HDFS backends (fsspec/pyarrow) strip the scheme prefix from glob
+    # results.  Rewrite returned paths to include the original scheme so
+    # downstream code can use them directly.
+    if root_path.startswith("hdfs://"):
+        scheme = root_path[: root_path.index("/", len("hdfs://"))]  # hdfs://host:port
+        files = [f if f.startswith("hdfs://") else scheme + f for f in files]
+
+    # Validate that every expected rank file is present.
+    files_set = set(files)
     for i in range(world_size):
-        expected_file_path = encode_file_path_func(root_path, table_name, i, world_size)
-        if expected_file_path not in set(files):
+        expected = encode_file_path_func(root_path, table_name, i, world_size)
+        if (
+            expected not in files_set
+            and _strip_scheme_prefix(expected) not in files_set
+        ):
             raise RuntimeError(
-                f"Checkpoints is corrupted. Expected file path {expected_file_path} for table {table_name}, but it is not found."
+                f"Checkpoints is corrupted. Expected file path {expected} for table {table_name}, but it is not found."
             )
 
     return files, len(files)
@@ -134,7 +158,7 @@ def get_loading_files(
     rank: int,
     world_size: int,
 ) -> Tuple[List[str], List[str], List[str], List[str], int, int]:
-    if not os.path.exists(root_path):
+    if not get_filesystem(root_path).exists(root_path):
         raise RuntimeError(f"can't find path to load, path:", root_path)
 
     key_files, num_key_files = find_files(root_path, name, "emb_keys")

--- a/corelib/dynamicemb/dynamicemb/dump_load.py
+++ b/corelib/dynamicemb/dynamicemb/dump_load.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Optional, Set, Tuple
 import torch
 import torch.distributed as dist
 from dynamicemb.batched_dynamicemb_tables import BatchedDynamicEmbeddingTablesV2
+from dynamicemb.filesystem import get_filesystem
 from torch import nn
 from torchrec.distributed.embedding import ShardedEmbeddingCollection
 from torchrec.distributed.embeddingbag import ShardedEmbeddingBagCollection
@@ -142,15 +143,16 @@ def DynamicEmbDump(
         torch.cuda.synchronize()
     # create path
     created_dirs = []
-    if not os.path.exists(path):
+    fs = get_filesystem(path)
+    if not fs.exists(path):
         created_dirs.append(path)
         try:
-            os.makedirs(path, exist_ok=True)
+            fs.makedirs(path, exist_ok=True)
         except Exception as e:
             raise Exception("can't build path:", path) from e
     else:
-        if os.path.isdir(path):
-            if not os.listdir(path):
+        if fs.isdir(path):
+            if not fs.ls(path):
                 pass
             elif not allow_overwrite:
                 raise Exception(
@@ -174,8 +176,9 @@ def DynamicEmbDump(
 
     for collection_path, _, _ in collections_list:
         full_collection_path = os.path.join(path, collection_path)
-        if not os.path.exists(full_collection_path):
-            os.makedirs(full_collection_path, exist_ok=True)
+        col_fs = get_filesystem(full_collection_path)
+        if not col_fs.exists(full_collection_path):
+            col_fs.makedirs(full_collection_path, exist_ok=True)
     dist.barrier(group=pg, device_ids=[torch.cuda.current_device()])
 
     for collection_path, _, current_collection_module in collections_list:
@@ -246,7 +249,7 @@ def DynamicEmbLoad(
     if torch.cuda.is_available():
         torch.cuda.synchronize()
 
-    if not os.path.exists(path):
+    if not get_filesystem(path).exists(path):
         raise Exception("can't find path to load, path:", path)
 
     collections_list: List[Tuple[str, str, nn.Module]] = find_sharded_modules(model, "")

--- a/corelib/dynamicemb/dynamicemb/exportable_tables.py
+++ b/corelib/dynamicemb/dynamicemb/exportable_tables.py
@@ -10,7 +10,6 @@ This module owns:
 """
 
 import itertools
-import os
 from typing import Dict, List, Optional
 
 import pynve.torch.nve_layers as nve_layers
@@ -24,6 +23,7 @@ from dynamicemb.batched_dynamicemb_tables import (
     encode_meta_json_file_path,
     get_loading_files,
 )
+from dynamicemb.filesystem import get_filesystem
 from dynamicemb.key_value_table import _iter_batches_from_files, load_from_json
 from dynamicemb.scored_hashtable import ScorePolicy
 from dynamicemb_extensions import table_insert
@@ -380,7 +380,7 @@ class InferenceEmbeddingCollection(torch.nn.Module):
         save_dir: str,
         table_names: Optional[List[str]] = None,
     ) -> None:
-        if not os.path.exists(save_dir):
+        if not get_filesystem(save_dir).exists(save_dir):
             raise RuntimeError(f"Save directory does not exist: {save_dir}")
 
         if (
@@ -409,7 +409,7 @@ class InferenceEmbeddingCollection(torch.nn.Module):
                 continue
 
             meta_json_file = encode_meta_json_file_path(save_dir, table_name)
-            if os.path.exists(meta_json_file):
+            if get_filesystem(meta_json_file).exists(meta_json_file):
                 try:
                     _ = load_from_json(meta_json_file)
                 except Exception as e:

--- a/corelib/dynamicemb/dynamicemb/filesystem.py
+++ b/corelib/dynamicemb/dynamicemb/filesystem.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lightweight filesystem abstraction for DynamicEmb checkpoint I/O.
+
+Supports local POSIX filesystems natively and HDFS via the optional
+``fsspec[arrow]`` package.  The factory :func:`get_filesystem` selects
+the backend based on the path prefix (``hdfs://`` → Hdfs, otherwise
+local), so no public API signatures need to change.
+"""
+
+from __future__ import annotations
+
+import abc
+import glob as _glob
+import os
+from typing import IO, Any, List
+
+
+class AbstractFileSystem(abc.ABC):
+    """Minimal filesystem interface covering the operations used by
+    DynamicEmb dump / load.
+    """
+
+    @abc.abstractmethod
+    def open(self, path: str, mode: str = "rb") -> IO[Any]:
+        ...
+
+    @abc.abstractmethod
+    def exists(self, path: str) -> bool:
+        ...
+
+    @abc.abstractmethod
+    def isdir(self, path: str) -> bool:
+        ...
+
+    @abc.abstractmethod
+    def makedirs(self, path: str, exist_ok: bool = True) -> None:
+        ...
+
+    @abc.abstractmethod
+    def ls(self, path: str) -> List[str]:
+        ...
+
+    @abc.abstractmethod
+    def glob(self, pattern: str) -> List[str]:
+        ...
+
+    @abc.abstractmethod
+    def size(self, path: str) -> int:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Local filesystem (always available, zero extra dependencies)
+# ---------------------------------------------------------------------------
+
+
+class LocalFileSystem(AbstractFileSystem):
+    """Thin wrapper around Python's built-in file I/O and ``os.path``."""
+
+    def open(self, path: str, mode: str = "rb") -> IO[Any]:
+        return open(path, mode)
+
+    def exists(self, path: str) -> bool:
+        return os.path.exists(path)
+
+    def isdir(self, path: str) -> bool:
+        return os.path.isdir(path)
+
+    def makedirs(self, path: str, exist_ok: bool = True) -> None:
+        os.makedirs(path, exist_ok=exist_ok)
+
+    def ls(self, path: str) -> List[str]:
+        return os.listdir(path)
+
+    def glob(self, pattern: str) -> List[str]:
+        return _glob.glob(pattern)
+
+    def size(self, path: str) -> int:
+        return os.path.getsize(path)
+
+
+# ---------------------------------------------------------------------------
+# HDFS filesystem (requires ``fsspec[arrow]``)
+# ---------------------------------------------------------------------------
+
+
+class HdfsFileSystem(AbstractFileSystem):
+    """Filesystem backed by an HDFS cluster via *fsspec* / *pyarrow*.
+
+    The *fsspec* + *pyarrow* dependency is only imported when the first
+    I/O operation is performed.  Host and port are parsed from ``hdfs://``
+    URIs and passed explicitly to *pyarrow*, so the Hadoop configuration
+    files (``core-site.xml``) do **not** need to set ``fs.defaultFS``.
+    """
+
+    def __init__(self) -> None:
+        self._fs = None  # lazily initialised on first use
+        self._host: str | None = None
+        self._port: int = 0
+
+    # -- lazy init helper -----------------------------------------------
+
+    def _ensure_fs(self) -> None:
+        if self._fs is not None:
+            return
+        try:
+            import fsspec  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "HDFS support requires the 'fsspec[arrow]' package. "
+                "Install it with:  pip install fsspec[arrow]"
+            )
+        try:
+            import pyarrow.fs as _pafs
+        except ImportError:
+            raise ImportError(
+                "HDFS support requires the 'pyarrow' package (bundled with "
+                "fsspec[arrow]). Install it with:  pip install fsspec[arrow]"
+            )
+
+        # pyarrow HadoopFileSystem needs explicit host:port when the
+        # environment's core-site.xml does not set fs.defaultFS correctly.
+        # Otherwise libhdfs falls back to RawLocalFileSystem (file:///).
+        if self._host:
+            arrow_fs = _pafs.HadoopFileSystem(host=self._host, port=self._port)
+        else:
+            arrow_fs = _pafs.HadoopFileSystem()
+
+        from fsspec.implementations.arrow import ArrowFSWrapper
+
+        self._fs = ArrowFSWrapper(arrow_fs)
+
+    def _parse_uri(self, path: str) -> None:
+        """Extract host + port from an ``hdfs://host:port/...`` URI."""
+        if self._host is not None or not path.startswith("hdfs://"):
+            return
+        rest = path[len("hdfs://") :]
+        host_part = rest.split("/", 1)[0]
+        if ":" in host_part:
+            self._host, port_s = host_part.rsplit(":", 1)
+            self._port = int(port_s)
+        else:
+            self._host = host_part
+            self._port = 8020  # default HDFS NameNode port
+
+    # -- I/O methods ----------------------------------------------------
+
+    def open(self, path: str, mode: str = "rb") -> IO[Any]:
+        self._parse_uri(path)
+        self._ensure_fs()
+        return self._fs.open(path, mode)
+
+    def exists(self, path: str) -> bool:
+        self._parse_uri(path)
+        self._ensure_fs()
+        return self._fs.exists(path)
+
+    def isdir(self, path: str) -> bool:
+        self._parse_uri(path)
+        self._ensure_fs()
+        return self._fs.isdir(path)
+
+    def makedirs(self, path: str, exist_ok: bool = True) -> None:
+        self._parse_uri(path)
+        self._ensure_fs()
+        self._fs.makedirs(path, exist_ok=exist_ok)
+
+    def ls(self, path: str) -> List[str]:
+        self._parse_uri(path)
+        self._ensure_fs()
+        return self._fs.ls(path)
+
+    def glob(self, pattern: str) -> List[str]:
+        self._parse_uri(pattern)
+        self._ensure_fs()
+        return self._fs.glob(pattern)
+
+    def size(self, path: str) -> int:
+        self._parse_uri(path)
+        self._ensure_fs()
+        return self._fs.size(path)
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+_HDFS: HdfsFileSystem | None = None
+_LOCAL: LocalFileSystem | None = None
+
+
+def get_filesystem(path: str) -> AbstractFileSystem:
+    """Return the appropriate filesystem for *path*.
+
+    Parameters
+    ----------
+    path : str
+        A filesystem path.  If it starts with ``"hdfs://"`` an
+        :class:`HdfsFileSystem` is returned; otherwise the default
+        :class:`LocalFileSystem` is returned.
+
+    Returns
+    -------
+    AbstractFileSystem
+    """
+    if path.startswith("hdfs://"):
+        global _HDFS
+        if _HDFS is None:
+            _HDFS = HdfsFileSystem()
+        return _HDFS
+    global _LOCAL
+    if _LOCAL is None:
+        _LOCAL = LocalFileSystem()
+    return _LOCAL

--- a/corelib/dynamicemb/dynamicemb/key_value_table.py
+++ b/corelib/dynamicemb/dynamicemb/key_value_table.py
@@ -15,7 +15,6 @@
 
 import json
 import math
-import os
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
@@ -32,6 +31,7 @@ from dynamicemb.extendable_tensor import (
     ExtendableBuffer,
     HostExtendableBuffer,
 )
+from dynamicemb.filesystem import get_filesystem
 from dynamicemb.optimizer import (
     BaseDynamicEmbeddingOptimizer,
     pad_optimizer_states_from_checkpoint,
@@ -116,7 +116,7 @@ def _all_gather_dumped_keys_values(
 
 def save_to_json(data: Dict[str, Any], file_path: str) -> None:
     try:
-        with open(file_path, "w") as json_file:
+        with get_filesystem(file_path).open(file_path, "w") as json_file:
             json.dump(data, json_file, indent=4)
     except Exception as e:
         raise RuntimeError(f"Error saving data to JSON file: {e}")
@@ -124,7 +124,7 @@ def save_to_json(data: Dict[str, Any], file_path: str) -> None:
 
 def load_from_json(file_path: str) -> Dict[str, Any]:
     try:
-        with open(file_path, "r") as json_file:
+        with get_filesystem(file_path).open(file_path, "r") as json_file:
             data = json.load(json_file)
         return data
     except Exception as e:
@@ -1090,33 +1090,32 @@ def _dump_table(
         save_to_json(meta_data, meta_json_file_path)
 
     mode = "ab" if append else "wb"
-    fkey = open(emb_key_path, mode)
-    fembedding = open(embedding_file_path, mode)
-    fscore = open(score_file_path, mode)
-    fopt_states = open(opt_file_path, mode) if include_optim else None
+    fs = get_filesystem(emb_key_path)
+    with fs.open(emb_key_path, mode) as fkey, fs.open(
+        embedding_file_path, mode
+    ) as fembedding, fs.open(score_file_path, mode) as fscore:
+        fopt_states = None
+        if include_optim:
+            fopt_states = fs.open(opt_file_path, mode)
 
-    for keys, embeddings, opt_states_batch, scores in export_keys_values_iter(
-        state, device=device, table_id=table_id
-    ):
-        fkey.write(keys.cpu().numpy().tobytes())
-        fembedding.write(embeddings.cpu().numpy().tobytes())
-        if state.evict_strategy == EvictStrategy.KLru:
-            scores = timestamp - scores
-        fscore.write(scores.cpu().numpy().tobytes())
-        if fopt_states and opt_states_batch is not None:
-            to_write = truncate_optimizer_states_for_checkpoint(
-                state.optimizer,
-                state.table_emb_dims_cpu[table_id],
-                opt_states_batch,
-            )
-            fopt_states.write(to_write.cpu().numpy().tobytes())
+        for keys, embeddings, opt_states_batch, scores in export_keys_values_iter(
+            state, device=device, table_id=table_id
+        ):
+            fkey.write(keys.cpu().numpy().tobytes())
+            fembedding.write(embeddings.cpu().numpy().tobytes())
+            if state.evict_strategy == EvictStrategy.KLru:
+                scores = timestamp - scores
+            fscore.write(scores.cpu().numpy().tobytes())
+            if fopt_states and opt_states_batch is not None:
+                to_write = truncate_optimizer_states_for_checkpoint(
+                    state.optimizer,
+                    state.table_emb_dims_cpu[table_id],
+                    opt_states_batch,
+                )
+                fopt_states.write(to_write.cpu().numpy().tobytes())
 
-    fkey.close()
-    fembedding.close()
-    if fscore:
-        fscore.close()
-    if fopt_states:
-        fopt_states.close()
+        if fopt_states:
+            fopt_states.close()
 
 
 def _iter_batches_from_files(
@@ -1134,15 +1133,16 @@ def _iter_batches_from_files(
     Handles file I/O, numpy deserialization, and distributed world_size filtering.
     Pass *score_file_path* / *opt_file_path* as ``None`` to skip those files.
     """
-    fkey = open(emb_key_path, "rb")
-    fembedding = open(embedding_file_path, "rb")
+    fs = get_filesystem(emb_key_path)
+    fkey = fs.open(emb_key_path, "rb")
+    fembedding = fs.open(embedding_file_path, "rb")
     fscore = (
-        open(score_file_path, "rb")
-        if score_file_path and os.path.exists(score_file_path)
+        fs.open(score_file_path, "rb")
+        if score_file_path and fs.exists(score_file_path)
         else None
     )
-    fopt = open(opt_file_path, "rb") if opt_file_path else None
-    num_keys = os.path.getsize(emb_key_path) // KEY_TYPE.itemsize
+    fopt = fs.open(opt_file_path, "rb") if opt_file_path else None
+    num_keys = fs.size(emb_key_path) // KEY_TYPE.itemsize
 
     world_size = dist.get_world_size() if dist.is_initialized() else 1
     rank = dist.get_rank() if dist.is_initialized() else 0
@@ -1258,7 +1258,7 @@ def _validate_load_meta(
             f"Score file {score_file_path} does not exist. Will not load score states."
         )
 
-    if not opt_file_path or not os.path.exists(opt_file_path):
+    if not opt_file_path or not get_filesystem(opt_file_path).exists(opt_file_path):
         include_optim = False
         print(
             f"Optimizer file {opt_file_path} does not exist. Will not load optimizer states."
@@ -1273,24 +1273,23 @@ def _validate_load_meta(
     if include_optim:
         state.optimizer.set_opt_args(meta_data)
 
-    num_keys = os.path.getsize(emb_key_path) // KEY_TYPE.itemsize
-    num_embeddings = (
-        os.path.getsize(embedding_file_path) // EMBEDDING_TYPE.itemsize // dim
-    )
+    fs = get_filesystem(emb_key_path)
+    num_keys = fs.size(emb_key_path) // KEY_TYPE.itemsize
+    num_embeddings = fs.size(embedding_file_path) // EMBEDDING_TYPE.itemsize // dim
     if num_keys != num_embeddings:
         raise ValueError(
             f"The number of keys in {emb_key_path} does not match with number of embeddings in {embedding_file_path}."
         )
-    if score_file_path and os.path.exists(score_file_path):
-        num_scores = os.path.getsize(score_file_path) // SCORE_TYPE.itemsize
+    if score_file_path and fs.exists(score_file_path):
+        num_scores = fs.size(score_file_path) // SCORE_TYPE.itemsize
         if num_keys != num_scores:
             raise ValueError(
                 f"The number of keys in {emb_key_path} does not match with number of scores in {score_file_path}."
             )
 
     file_optstate_dim = 0
-    if include_optim and opt_file_path and os.path.exists(opt_file_path):
-        file_bytes = os.path.getsize(opt_file_path)
+    if include_optim and opt_file_path and fs.exists(opt_file_path):
+        file_bytes = fs.size(opt_file_path)
         if num_keys == 0:
             if file_bytes != 0:
                 raise ValueError(

--- a/corelib/dynamicemb/setup.py
+++ b/corelib/dynamicemb/setup.py
@@ -224,4 +224,7 @@ setup(
     python_requires=">=3.9",
     cmdclass={"build_ext": NinjaBuildExtension},
     install_requires=["torch"],
+    extras_require={
+        "hdfs": ["fsspec[arrow]>=2023.0.0"],
+    },
 )


### PR DESCRIPTION
  Add support for reading/writing DynamicEmb checkpoints via HDFS using
  `fsspec[arrow]`, enabling distributed training jobs to store checkpoints
  on Hadoop clusters without any API changes.

  ## What changed

  ### New: `filesystem.py` — lightweight filesystem abstraction

  Two backends, selected automatically by path prefix:

  | Backend | Path prefix | Dependency |
  |---------|-------------|------------|
  | `LocalFileSystem` | (default, any local path) | None |
  | `HdfsFileSystem` | `hdfs://host:port/...` | `fsspec[arrow]>=2023.0.0` (optional) |

  - `HdfsFileSystem` lazily initialises `pyarrow.HadoopFileSystem` on first
    I/O, passing host/port explicitly so `core-site.xml` does **not** need
    to set `fs.defaultFS`.

  ### Refactor: route all checkpoint I/O through `get_filesystem(path)`

  Replaced direct `os.path.exists`, `os.makedirs`, `os.listdir`,
  `os.path.getsize`, `open`, and `glob.glob` calls in:

  - `batched_dynamicemb_tables.py` — `find_files`, `get_loading_files`
  - `dump_load.py` — `DynamicEmbDump`, `DynamicEmbLoad`
  - `exportable_tables.py` — `InferenceEmbeddingCollection.save`
  - `key_value_table.py` — `_dump_table`, `_iter_batches_from_files`,
    `_validate_load_meta`, `save_to_json`, `load_from_json`

  ### Path handling for HDFS glob results

  `find_files` now handles the `hdfs://` scheme prefix: stripped for glob
  pattern matching, then re-attached to returned paths so downstream
  consumers can use them directly, regardless of backend behaviour.

  ### Extras dependency in `setup.py`

  ```python
  extras_require={"hdfs": ["fsspec[arrow]>=2023.0.0"]}
  ```

 ### Usage (no API change)

  - Local (unchanged)
  ```
  DynamicEmbDump(model, "/path/to/checkpoints/model_v1")
```
  - HDFS — works with any hdfs:// URI
 ```
  DynamicEmbDump(model, "hdfs://namenode:8020/path/to/checkpoints/model_v1")
```

 ## Checklist

  - [x] I am familiar with the Contributing Guidelines.
  - [ ] New or existing tests cover these changes.
  - [ ] The documentation is up to date with these changes.
