### PR TITLE
[bugfix]Add shared-prefix-len argument to parser

### DIFF
--- a/examples/sid-gr-inference/tools/compare_online_generate_outputs.py
+++ b/examples/sid-gr-inference/tools/compare_online_generate_outputs.py
@@ -191,6 +191,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-tokenizer", action="store_true", default=True)
     parser.add_argument("--require-tokenizer", action="store_true")
     parser.add_argument("--extra-phrase", nargs="*", default=())
+    parser.add_argument("--shared-prefix-len", type=int, default=0)
     parser.add_argument("--output-json", required=True)
     parser.add_argument("--output-markdown")
     return parser


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

The argument `shared_prefix_len` is required for downstream processing.

```
  Traceback (most recent call last):
    File ".../tools/compare_online_generate_outputs.py", line 200, in <module>
      main()
    File ".../tools/compare_online_generate_outputs.py", line 24, in main
      rows = build_workload(args)
             ^^^^^^^^^^^^^^^^^^^^
    File ".../tools/make_qwen3_beam_workload.py", line 31, in build_workload
      shared_prefix_len=args.shared_prefix_len,
                        ^^^^^^^^^^^^^^^^^^^^^^
  AttributeError: 'Namespace' object has no attribute 'shared_prefix_len'
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/recsys-examples/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
