### PR TITLE
Fix residual gradient in non-learnable LayerNorm backward

### DIFF
--- a/examples/hstu/ops/triton_ops/triton_layer_norm.py
+++ b/examples/hstu/ops/triton_ops/triton_layer_norm.py
@@ -139,9 +139,12 @@ def _layer_norm_bwd_dx(
     stride_dx,
     stride_dy,
     stride_x,
+    stride_acc,
     D,
     eps,
+    DX_ACC,
     BLOCK_D: tl.constexpr,
+    DGRAD_ACCUM: tl.constexpr,
 ):
     row = tl.program_id(0)
     cols = tl.arange(0, BLOCK_D)
@@ -149,10 +152,14 @@ def _layer_norm_bwd_dx(
     X += row.to(tl.int64) * stride_x
     DY += row.to(tl.int64) * stride_dy
     DX += row.to(tl.int64) * stride_dx
+    if DGRAD_ACCUM:
+        dx_acc_ptrs = DX_ACC + row.to(tl.int64) * stride_acc
 
     # Load data to SRAM
     x = tl.load(X + cols, mask=mask, other=0).to(tl.float32)
     dy = tl.load(DY + cols, mask=mask, other=0).to(tl.float32)
+    if DGRAD_ACCUM:
+        dx_acc = tl.load(dx_acc_ptrs + cols, mask=mask, other=0).to(tl.float32)
     mean = tl.load(Mean + row)
     rstd = tl.load(Rstd + row)
 
@@ -163,6 +170,8 @@ def _layer_norm_bwd_dx(
     c1 = tl.sum(xhat * dy, axis=0) / D
     c2 = tl.sum(dy, axis=0) / D
     dx = (dy - (xhat * c1 + c2)) * rstd
+    if DGRAD_ACCUM:
+        dx += dx_acc
     # Write dx
     tl.store(DX + cols, dx.to(DX.dtype.element_ty), mask=mask)
 
@@ -473,10 +482,15 @@ def triton_weighted_layer_norm_bwd(
             dx.stride(0),
             dy.stride(0),
             x.stride(0),
+            dx_accumulate.stride(0)
+            if dx_accumulate is not None
+            else 0,  # pyre-ignore [16]
             D,
             eps,
+            DX_ACC=dx_accumulate,  # pyre-ignore [16]
             BLOCK_D=BLOCK_D,
             num_warps=num_warps,
+            DGRAD_ACCUM=dx_accumulate is not None,
         )
         return dx, None, None
 

--- a/examples/tests/commons/test_triton_layer_norm.py
+++ b/examples/tests/commons/test_triton_layer_norm.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import torch.nn.functional as F
+from ops.triton_ops.triton_layer_norm import (
+    triton_weighted_layer_norm_bwd,
+)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "rtol", "atol"),
+    [
+        (torch.float32, 1e-4, 1e-4),
+        (torch.bfloat16, 2e-2, 2e-2),
+    ],
+)
+@pytest.mark.parametrize("shape", [(7, 64), (33, 257)])
+@pytest.mark.parametrize("accumulate", [False, True])
+def test_non_learnable_layer_norm_backward_residual_gradient(
+    dtype, rtol, atol, shape, accumulate
+):
+    torch.manual_seed(1234)
+    device = torch.device("cuda")
+    eps = 1e-5
+    rows, columns = shape
+
+    # Slicing keeps the feature dimension contiguous while exercising a row
+    # stride larger than the logical feature dimension.
+    x = torch.randn((rows, columns + 11), device=device, dtype=dtype)[:, :columns]
+    dy = torch.randn((rows, columns + 7), device=device, dtype=dtype)[:, :columns]
+    dx_accumulate = None
+    if accumulate:
+        dx_accumulate = torch.randn(
+            (rows, columns + 5), device=device, dtype=dtype
+        )[:, :columns]
+
+    x_float = x.float()
+    mean = x_float.mean(dim=-1)
+    rstd = torch.rsqrt(x_float.var(dim=-1, unbiased=False) + eps)
+    block_d = 1 << (columns - 1).bit_length()
+    num_warps = min(max(block_d // 256, 1), 8)
+    actual, dweight, dbias = triton_weighted_layer_norm_bwd(
+        dy=dy,
+        x=x,
+        weight=None,
+        bias=None,
+        mean=mean,
+        rstd=rstd,
+        learnable=False,
+        eps=eps,
+        BLOCK_D=block_d,
+        num_warps=num_warps,
+        dx_accumulate=dx_accumulate,
+    )
+
+    reference_x = x.detach().clone().requires_grad_(True)
+    reference_y = F.layer_norm(reference_x, (columns,), eps=eps)
+    expected = torch.autograd.grad(reference_y, reference_x, dy)[0]
+    if dx_accumulate is not None:
+        expected = expected + dx_accumulate
+
+    absolute_error = (actual.float() - expected.float()).abs()
+    relative_error = absolute_error / expected.float().abs().clamp_min(
+        torch.finfo(torch.float32).eps
+    )
+    print(
+        f"dtype={dtype}, shape={shape}, accumulate={accumulate}, "
+        f"max_abs_error={absolute_error.max().item():.8e}, "
+        f"mean_abs_error={absolute_error.mean().item():.8e}, "
+        f"max_rel_error={relative_error.max().item():.8e}"
+    )
+
+    assert dweight is None
+    assert dbias is None
+    torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)


### PR DESCRIPTION
## Description

Fix residual gradient accumulation in the non-learnable LayerNorm backward path.

- Fuse `dx_accumulate` into the `_layer_norm_bwd_dx` Triton kernel.
- Remove the separate PyTorch `dx.add_()` operation.
- Add focused numerical unit tests for the LayerNorm operator.

Supersedes #447 because the original fork was deleted.
Fixes #446

## Testing

The added unit tests passed successfully in the local GPU environment.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/recsys-examples/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.