### PR TITLE
fix(dynamicemb): address NO_EVICTION value rows by row, not by hash slot

### DIFF
--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
@@ -27,6 +27,7 @@ from dynamicemb.key_value_table import (
     Storage,
     _append_evicted,
     _find_keys,
+    _flat_row_indices_for_value_load,
     eval_lookup,
     get_insert_score_arg,
     load_from_flat,
@@ -182,6 +183,30 @@ class PrefetchState:
     non_admitted_positions: Optional[torch.Tensor] = None
     num_prefetched_keys: int = 0
     outstanding_keys_ref: Optional[torch.Tensor] = None
+    # Value-buffer row per key, when that differs from the hash slot above.
+    # NO_EVICTION is the only strategy where it does: its rows come from a
+    # per-table auto-increment counter, unrelated to where the key hashes, and
+    # its key map is deliberately larger than the value buffer -- so indexing
+    # values by slot reads past the end of the buffer. ``None`` means "same as
+    # slot_indices" (every other strategy), so no extra tensor is allocated.
+    value_row_indices: Optional[torch.Tensor] = None
+    update_value_row_indices: Optional[torch.Tensor] = None
+
+    def rows_or_slots(self) -> Optional[torch.Tensor]:
+        """Indices to address the value buffer with."""
+        return (
+            self.value_row_indices
+            if self.value_row_indices is not None
+            else self.slot_indices
+        )
+
+    def update_rows_or_slots(self) -> Optional[torch.Tensor]:
+        """Backward-pass counterpart of :meth:`rows_or_slots`."""
+        return (
+            self.update_value_row_indices
+            if self.update_value_row_indices is not None
+            else self.update_slot_indices
+        )
 
 
 def _is_hbm_storage(storage: Storage) -> bool:
@@ -568,13 +593,27 @@ def _prefetch_hbm_direct_path(
     accumulated_frequency: Optional[torch.Tensor],
     admit_strategy: Optional[AdmissionStrategy],
     admission_counter: Optional[Counter],
-) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+]:
     """HBM-direct prefetch with counter protection.
 
     Only admitted keys are inserted.  Non-admitted keys get slot_indices = -1
     and their positions are returned for lazy initialization at forward time.
 
-    Returns (slot_indices, update_slot_indices, non_admitted_positions).
+    Returns ``(slot_indices, update_slot_indices, non_admitted_positions,
+    value_row_indices, update_value_row_indices)``. The two index spaces are kept
+    apart because they only coincide by accident: ``slot_indices`` addresses the
+    hash table (and the ref counter beside it), ``value_row_indices`` addresses
+    the flat value buffer. For NO_EVICTION they differ -- rows are handed out by a
+    per-table auto-increment counter while slots come from the key's hash, and the
+    key map is sized ``1 / max_load_factor`` times the value buffer, so a slot can
+    point past the end of it. The row tensors are ``None`` for every other
+    strategy, meaning "same as the slot tensors".
     """
     with torch.cuda.nvtx.range("_prefetch_hbm_direct_path"):
         state = storage._state
@@ -583,7 +622,7 @@ def _prefetch_hbm_direct_path(
 
         if h_num_total == 0:
             empty = torch.empty(0, dtype=torch.int64, device=device)
-            return empty, empty.clone(), None
+            return empty, empty.clone(), None, None, None
 
         with torch.cuda.nvtx.range("op:storage_find"):
             (
@@ -593,7 +632,7 @@ def _prefetch_hbm_direct_path(
                 missing_table_ids,
                 missing_scores,
                 _,
-                _,
+                score_out,
                 indices,
             ) = _find_keys(
                 state,
@@ -607,8 +646,24 @@ def _prefetch_hbm_direct_path(
         if found_slots.numel() > 0:
             storage.increment_counter(found_slots, unique_table_ids[found_mask])
 
+        # NO_EVICTION stores each key's value row IN its score word, so a lookup
+        # hit yields the row in ``score_out`` -- ``indices`` stays a hash slot and
+        # must not be used to address the value buffer.
+        is_no_eviction = state.no_eviction_next_index is not None
+        rows = (
+            _flat_row_indices_for_value_load(state, found_mask, score_out, indices)
+            if is_no_eviction
+            else None
+        )
+
         if h_num_missing == 0:
-            return indices, indices.clone(), None
+            return (
+                indices,
+                indices.clone(),
+                None,
+                rows,
+                rows.clone() if rows is not None else None,
+            )
 
         # Determine admission for missing keys
         non_admitted_positions: Optional[torch.Tensor] = None
@@ -686,13 +741,14 @@ def _prefetch_hbm_direct_path(
                         admitted_tids,
                         score_arg,
                     )
-            new_indices = (
-                score_arg.value.to(torch.int64)
-                if state.no_eviction_next_index is not None
-                else new_indices
+            # The insert returns the hash slot; NO_EVICTION's value row is the
+            # score it just assigned. Keep both: the counter is indexed by slot,
+            # the value buffer by row.
+            new_rows = (
+                score_arg.value.to(torch.int64) if is_no_eviction else new_indices
             )
             with torch.cuda.nvtx.range("op:store_to_flat"):
-                store_to_flat(state, new_indices, admitted_tids, init_values)
+                store_to_flat(state, new_rows, admitted_tids, init_values)
 
             inserted_mask = new_indices >= 0
             if inserted_mask.any():
@@ -702,17 +758,30 @@ def _prefetch_hbm_direct_path(
                 )
 
             indices[admitted_unique_positions] = new_indices
+            if rows is not None:
+                rows[admitted_unique_positions] = new_rows
 
         # Non-admitted keys: ensure slot_indices = -1
         if non_admitted_positions is not None:
             indices[non_admitted_positions] = -1
+            if rows is not None:
+                rows[non_admitted_positions] = -1
 
         update_slot_indices = indices.clone()
         still_missing = indices < 0
         if still_missing.any():
             update_slot_indices[still_missing] = -1
 
-        return indices, update_slot_indices, non_admitted_positions
+        update_rows = None
+        if rows is not None:
+            update_rows = rows.clone()
+            # Mask on the SLOT tensor: a key that failed to be placed has slot
+            # -1, and its row must be masked out with it (the row itself may be a
+            # valid-looking auto-increment value).
+            if still_missing.any():
+                update_rows[still_missing] = -1
+
+        return indices, update_slot_indices, non_admitted_positions, rows, update_rows
 
 
 def dynamicemb_prefetch(
@@ -778,6 +847,12 @@ def dynamicemb_prefetch(
         slot_indices = None
         update_slot_indices = None
         non_admitted_positions = None
+        # Only the HBM-direct path can see a value row that differs from the hash
+        # slot; the cache path addresses the cache's own buffer, where they always
+        # coincide (a cache is never NO_EVICTION -- it enables overflow, which
+        # NO_EVICTION rejects at construction).
+        value_row_indices = None
+        update_value_row_indices = None
         if caching:
             storage_mode = StorageMode.CACHE
         elif _is_hbm_storage(storage):
@@ -821,6 +896,8 @@ def dynamicemb_prefetch(
                 slot_indices,
                 update_slot_indices,
                 non_admitted_positions,
+                value_row_indices,
+                update_value_row_indices,
             ) = _prefetch_hbm_direct_path(
                 storage,
                 unique_keys,
@@ -849,6 +926,8 @@ def dynamicemb_prefetch(
             non_admitted_positions=non_admitted_positions,
             num_prefetched_keys=num_prefetched_keys,
             outstanding_keys_ref=outstanding_keys_ref,
+            value_row_indices=value_row_indices,
+            update_value_row_indices=update_value_row_indices,
         )
 
 
@@ -1099,7 +1178,9 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
                 with torch.cuda.nvtx.range("op:load_from_flat"):
                     unique_embs = load_from_flat(
                         state,
-                        prefetch_state.slot_indices,
+                        # Value buffer: address by row, which is the slot for
+                        # every strategy except NO_EVICTION.
+                        prefetch_state.rows_or_slots(),
                         prefetch_state.unique_table_ids,
                         copy_mode=CopyMode.EMBEDDING,
                     )
@@ -1177,6 +1258,9 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
             ctx.storage = storage
             ctx.slot_indices = prefetch_state.slot_indices
             ctx.update_slot_indices = prefetch_state.update_slot_indices
+            # Same split as the forward: the fused optimizer writes into the
+            # value buffer (rows), the ref counter is indexed by hash slot.
+            ctx.update_value_rows = prefetch_state.update_rows_or_slots()
             ctx.storage_mode = prefetch_state.storage_mode
             ctx.optimizer = optimizer
             ctx.pooling_mode = pooling_mode
@@ -1259,7 +1343,8 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
                     with torch.cuda.nvtx.range("op:optimizer_update_fused"):
                         optimizer.fused_update_for_flat_table(
                             unique_grads.to(ctx.emb_dtype),
-                            ctx.update_slot_indices,
+                            # Writes into the value buffer -> rows.
+                            ctx.update_value_rows,
                             state.table_ptrs_dev,
                             unique_table_ids,
                             state.table_value_dims,
@@ -1273,6 +1358,7 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
                         cache if ctx.storage_mode == StorageMode.CACHE else storage
                     )
 
+                    # Ref counter sits beside the hash table -> slots.
                     counter_owner.decrement_counter(
                         ctx.update_slot_indices, ctx.unique_table_ids
                     )

--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
@@ -179,7 +179,6 @@ class PrefetchState:
     emb_dtype: torch.dtype
     storage_mode: StorageMode
     slot_indices: Optional[torch.Tensor]
-    update_slot_indices: Optional[torch.Tensor] = None
     non_admitted_positions: Optional[torch.Tensor] = None
     num_prefetched_keys: int = 0
     outstanding_keys_ref: Optional[torch.Tensor] = None
@@ -190,22 +189,18 @@ class PrefetchState:
     # values by slot reads past the end of the buffer. ``None`` means "same as
     # slot_indices" (every other strategy), so no extra tensor is allocated.
     value_row_indices: Optional[torch.Tensor] = None
-    update_value_row_indices: Optional[torch.Tensor] = None
 
     def rows_or_slots(self) -> Optional[torch.Tensor]:
-        """Indices to address the value buffer with."""
+        """Indices to address the value buffer with, forward and backward alike.
+
+        Both passes want the same thing -- the row each key's value lives in --
+        so one accessor serves both. Anything indexed by hash slot (the ref
+        counter) must not go through here.
+        """
         return (
             self.value_row_indices
             if self.value_row_indices is not None
             else self.slot_indices
-        )
-
-    def update_rows_or_slots(self) -> Optional[torch.Tensor]:
-        """Backward-pass counterpart of :meth:`rows_or_slots`."""
-        return (
-            self.update_value_row_indices
-            if self.update_value_row_indices is not None
-            else self.update_slot_indices
         )
 
 
@@ -334,14 +329,14 @@ def _prefetch_cache_path(
     accumulated_frequency: Optional[torch.Tensor],
     admit_strategy: Optional[AdmissionStrategy],
     admission_counter: Optional[Counter],
-) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     """Cache prefetch with counter protection and overflow buffer.
 
     Only admitted keys are inserted into the cache.  Non-admitted keys get
     slot_indices = -1 and their positions (in the unique_keys array) are
     returned so the forward pass can lazily initialize their embeddings.
 
-    Returns (slot_indices, update_slot_indices, non_admitted_positions).
+    Returns (slot_indices, non_admitted_positions).
     """
     with torch.cuda.nvtx.range("_prefetch_cache_path"):
         device = unique_keys.device
@@ -350,7 +345,7 @@ def _prefetch_cache_path(
 
         if h_num_total == 0:
             empty = torch.empty(0, dtype=torch.int64, device=device)
-            return empty, empty.clone(), None
+            return empty, None
 
         # 1. Lookup with overflow fallback
         with torch.cuda.nvtx.range("op:cache_lookup"):
@@ -374,7 +369,7 @@ def _prefetch_cache_path(
             )
 
         if h_num_miss == 0:
-            return slot_indices, slot_indices.clone(), None
+            return slot_indices, None
 
         miss_lfu_freq = (
             accumulated_frequency[miss_compact_idx]
@@ -438,8 +433,7 @@ def _prefetch_cache_path(
         # 5. Insert only storage-found + admitted-new keys into cache
         if not _bool_item(keys_to_insert_mask.any()):
             slot_indices[miss_compact_idx] = -1
-            update_slot_indices = slot_indices.clone()
-            return slot_indices, update_slot_indices, non_admitted_positions
+            return slot_indices, non_admitted_positions
 
         with torch.cuda.nvtx.range("op:flagged_compact"):
             _, insert_to_miss, (insert_keys, insert_tids) = flagged_compact(
@@ -575,11 +569,7 @@ def _prefetch_cache_path(
         if non_admitted_positions is not None:
             slot_indices[non_admitted_positions] = -1
 
-        update_slot_indices = slot_indices.clone()
-        if non_admitted_positions is not None:
-            update_slot_indices[non_admitted_positions] = -1
-
-        return slot_indices, update_slot_indices, non_admitted_positions
+        return slot_indices, non_admitted_positions
 
 
 def _prefetch_hbm_direct_path(
@@ -593,27 +583,20 @@ def _prefetch_hbm_direct_path(
     accumulated_frequency: Optional[torch.Tensor],
     admit_strategy: Optional[AdmissionStrategy],
     admission_counter: Optional[Counter],
-) -> Tuple[
-    torch.Tensor,
-    torch.Tensor,
-    Optional[torch.Tensor],
-    Optional[torch.Tensor],
-    Optional[torch.Tensor],
-]:
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
     """HBM-direct prefetch with counter protection.
 
     Only admitted keys are inserted.  Non-admitted keys get slot_indices = -1
     and their positions are returned for lazy initialization at forward time.
 
-    Returns ``(slot_indices, update_slot_indices, non_admitted_positions,
-    value_row_indices, update_value_row_indices)``. The two index spaces are kept
-    apart because they only coincide by accident: ``slot_indices`` addresses the
-    hash table (and the ref counter beside it), ``value_row_indices`` addresses
-    the flat value buffer. For NO_EVICTION they differ -- rows are handed out by a
-    per-table auto-increment counter while slots come from the key's hash, and the
-    key map is sized ``1 / max_load_factor`` times the value buffer, so a slot can
-    point past the end of it. The row tensors are ``None`` for every other
-    strategy, meaning "same as the slot tensors".
+    Returns ``(slot_indices, non_admitted_positions, value_row_indices)``. The two index spaces are kept apart because they only
+    coincide by accident: ``slot_indices`` addresses the hash table (and the ref
+    counter beside it), ``value_row_indices`` addresses the flat value buffer. For
+    NO_EVICTION they differ -- rows are handed out by a per-table auto-increment
+    counter while slots come from the key's hash, and the key map is sized
+    ``1 / max_load_factor`` times the value buffer, so a slot can point past the
+    end of it. ``value_row_indices`` is ``None`` for every other strategy, meaning
+    "same as the slot tensors".
     """
     with torch.cuda.nvtx.range("_prefetch_hbm_direct_path"):
         state = storage._state
@@ -622,7 +605,7 @@ def _prefetch_hbm_direct_path(
 
         if h_num_total == 0:
             empty = torch.empty(0, dtype=torch.int64, device=device)
-            return empty, empty.clone(), None, None, None
+            return empty, None, None
 
         with torch.cuda.nvtx.range("op:storage_find"):
             (
@@ -657,13 +640,7 @@ def _prefetch_hbm_direct_path(
         )
 
         if h_num_missing == 0:
-            return (
-                indices,
-                indices.clone(),
-                None,
-                rows,
-                rows.clone() if rows is not None else None,
-            )
+            return indices, None, rows
 
         # Determine admission for missing keys
         non_admitted_positions: Optional[torch.Tensor] = None
@@ -767,21 +744,7 @@ def _prefetch_hbm_direct_path(
             if rows is not None:
                 rows[non_admitted_positions] = -1
 
-        update_slot_indices = indices.clone()
-        still_missing = indices < 0
-        if still_missing.any():
-            update_slot_indices[still_missing] = -1
-
-        update_rows = None
-        if rows is not None:
-            update_rows = rows.clone()
-            # Mask on the SLOT tensor: a key that failed to be placed has slot
-            # -1, and its row must be masked out with it (the row itself may be a
-            # valid-looking auto-increment value).
-            if still_missing.any():
-                update_rows[still_missing] = -1
-
-        return indices, update_slot_indices, non_admitted_positions, rows, update_rows
+        return indices, non_admitted_positions, rows
 
 
 def dynamicemb_prefetch(
@@ -845,14 +808,12 @@ def dynamicemb_prefetch(
         )
 
         slot_indices = None
-        update_slot_indices = None
         non_admitted_positions = None
         # Only the HBM-direct path can see a value row that differs from the hash
         # slot; the cache path addresses the cache's own buffer, where they always
         # coincide (a cache is never NO_EVICTION -- it enables overflow, which
         # NO_EVICTION rejects at construction).
         value_row_indices = None
-        update_value_row_indices = None
         if caching:
             storage_mode = StorageMode.CACHE
         elif _is_hbm_storage(storage):
@@ -875,7 +836,6 @@ def dynamicemb_prefetch(
                     )
             (
                 slot_indices,
-                update_slot_indices,
                 non_admitted_positions,
             ) = _prefetch_cache_path(
                 cache,
@@ -894,10 +854,8 @@ def dynamicemb_prefetch(
         elif storage_mode == StorageMode.HBM_DIRECT:
             (
                 slot_indices,
-                update_slot_indices,
                 non_admitted_positions,
                 value_row_indices,
-                update_value_row_indices,
             ) = _prefetch_hbm_direct_path(
                 storage,
                 unique_keys,
@@ -922,12 +880,10 @@ def dynamicemb_prefetch(
             emb_dtype=emb_dtype,
             slot_indices=slot_indices,
             storage_mode=storage_mode,
-            update_slot_indices=update_slot_indices,
             non_admitted_positions=non_admitted_positions,
             num_prefetched_keys=num_prefetched_keys,
             outstanding_keys_ref=outstanding_keys_ref,
             value_row_indices=value_row_indices,
-            update_value_row_indices=update_value_row_indices,
         )
 
 
@@ -1168,7 +1124,7 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
             mixed_D = is_pooling and dims is not None and max_D > min(dims)
             out_dim = max_D if mixed_D else emb_dim
 
-            use_counter = prefetch_state.update_slot_indices is not None
+            use_counter = prefetch_state.slot_indices is not None
             if use_counter:
                 state = (
                     cache._state
@@ -1257,10 +1213,9 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
             ctx.cache = cache
             ctx.storage = storage
             ctx.slot_indices = prefetch_state.slot_indices
-            ctx.update_slot_indices = prefetch_state.update_slot_indices
             # Same split as the forward: the fused optimizer writes into the
             # value buffer (rows), the ref counter is indexed by hash slot.
-            ctx.update_value_rows = prefetch_state.update_rows_or_slots()
+            ctx.update_value_rows = prefetch_state.rows_or_slots()
             ctx.storage_mode = prefetch_state.storage_mode
             ctx.optimizer = optimizer
             ctx.pooling_mode = pooling_mode
@@ -1360,7 +1315,7 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
 
                     # Ref counter sits beside the hash table -> slots.
                     counter_owner.decrement_counter(
-                        ctx.update_slot_indices, ctx.unique_table_ids
+                        ctx.slot_indices, ctx.unique_table_ids
                     )
 
                 if not ctx.use_counter and ctx.unique_values is not None:

--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
@@ -179,29 +179,18 @@ class PrefetchState:
     emb_dtype: torch.dtype
     storage_mode: StorageMode
     slot_indices: Optional[torch.Tensor]
+    # Value-buffer row per key -- what forward and backward both address values
+    # with. It differs from ``slot_indices`` only under NO_EVICTION, whose rows
+    # come from a per-table auto-increment counter unrelated to where the key
+    # hashes, and whose key map is deliberately larger than the value buffer, so
+    # indexing values by slot reads past the end of it. Every other strategy
+    # points this at the slot tensor itself rather than leaving it unset, so a
+    # consumer never has to ask which of the two it is holding. Anything indexed
+    # by hash slot (the ref counter) uses ``slot_indices``.
+    value_row_indices: Optional[torch.Tensor] = None
     non_admitted_positions: Optional[torch.Tensor] = None
     num_prefetched_keys: int = 0
     outstanding_keys_ref: Optional[torch.Tensor] = None
-    # Value-buffer row per key, when that differs from the hash slot above.
-    # NO_EVICTION is the only strategy where it does: its rows come from a
-    # per-table auto-increment counter, unrelated to where the key hashes, and
-    # its key map is deliberately larger than the value buffer -- so indexing
-    # values by slot reads past the end of the buffer. ``None`` means "same as
-    # slot_indices" (every other strategy), so no extra tensor is allocated.
-    value_row_indices: Optional[torch.Tensor] = None
-
-    def rows_or_slots(self) -> Optional[torch.Tensor]:
-        """Indices to address the value buffer with, forward and backward alike.
-
-        Both passes want the same thing -- the row each key's value lives in --
-        so one accessor serves both. Anything indexed by hash slot (the ref
-        counter) must not go through here.
-        """
-        return (
-            self.value_row_indices
-            if self.value_row_indices is not None
-            else self.slot_indices
-        )
 
 
 def _is_hbm_storage(storage: Storage) -> bool:
@@ -589,14 +578,15 @@ def _prefetch_hbm_direct_path(
     Only admitted keys are inserted.  Non-admitted keys get slot_indices = -1
     and their positions are returned for lazy initialization at forward time.
 
-    Returns ``(slot_indices, non_admitted_positions, value_row_indices)``. The two index spaces are kept apart because they only
-    coincide by accident: ``slot_indices`` addresses the hash table (and the ref
-    counter beside it), ``value_row_indices`` addresses the flat value buffer. For
-    NO_EVICTION they differ -- rows are handed out by a per-table auto-increment
-    counter while slots come from the key's hash, and the key map is sized
+    Returns ``(slot_indices, non_admitted_positions, value_row_indices)``. The
+    two index spaces are kept apart because they only coincide by accident:
+    ``slot_indices`` addresses the hash table (and the ref counter beside it),
+    ``value_row_indices`` addresses the flat value buffer. For NO_EVICTION they
+    differ -- rows are handed out by a per-table auto-increment counter while
+    slots come from the key's hash, and the key map is sized
     ``1 / max_load_factor`` times the value buffer, so a slot can point past the
-    end of it. ``value_row_indices`` is ``None`` for every other strategy, meaning
-    "same as the slot tensors".
+    end of it. Every other strategy returns the slot tensor itself as the rows,
+    so the caller always gets something it can address values with.
     """
     with torch.cuda.nvtx.range("_prefetch_hbm_direct_path"):
         state = storage._state
@@ -605,7 +595,7 @@ def _prefetch_hbm_direct_path(
 
         if h_num_total == 0:
             empty = torch.empty(0, dtype=torch.int64, device=device)
-            return empty, None, None
+            return empty, None, empty
 
         with torch.cuda.nvtx.range("op:storage_find"):
             (
@@ -631,12 +621,14 @@ def _prefetch_hbm_direct_path(
 
         # NO_EVICTION stores each key's value row IN its score word, so a lookup
         # hit yields the row in ``score_out`` -- ``indices`` stays a hash slot and
-        # must not be used to address the value buffer.
+        # must not be used to address the value buffer. Every other strategy
+        # addresses values by slot, so ``rows`` is ``indices`` itself and the
+        # writes below reach it for free.
         is_no_eviction = state.no_eviction_next_index is not None
         rows = (
             _flat_row_indices_for_value_load(state, found_mask, score_out, indices)
             if is_no_eviction
-            else None
+            else indices
         )
 
         if h_num_missing == 0:
@@ -735,13 +727,17 @@ def _prefetch_hbm_direct_path(
                 )
 
             indices[admitted_unique_positions] = new_indices
-            if rows is not None:
+            # Skipped while ``rows`` aliases ``indices``: the write above already
+            # covered it. Testing identity rather than ``is_no_eviction`` keeps
+            # this correct even if ``rows`` ever stops being an alias -- it would
+            # simply be filled explicitly with the same values.
+            if rows is not indices:
                 rows[admitted_unique_positions] = new_rows
 
         # Non-admitted keys: ensure slot_indices = -1
         if non_admitted_positions is not None:
             indices[non_admitted_positions] = -1
-            if rows is not None:
+            if rows is not indices:
                 rows[non_admitted_positions] = -1
 
         return indices, non_admitted_positions, rows
@@ -809,10 +805,6 @@ def dynamicemb_prefetch(
 
         slot_indices = None
         non_admitted_positions = None
-        # Only the HBM-direct path can see a value row that differs from the hash
-        # slot; the cache path addresses the cache's own buffer, where they always
-        # coincide (a cache is never NO_EVICTION -- it enables overflow, which
-        # NO_EVICTION rejects at construction).
         value_row_indices = None
         if caching:
             storage_mode = StorageMode.CACHE
@@ -851,6 +843,10 @@ def dynamicemb_prefetch(
                 admit_strategy,
                 admission_counter,
             )
+            # The cache addresses its own value buffer by cache slot: a cache is
+            # never NO_EVICTION (it enables overflow, which NO_EVICTION rejects
+            # at construction), so the two index spaces coincide here.
+            value_row_indices = slot_indices
         elif storage_mode == StorageMode.HBM_DIRECT:
             (
                 slot_indices,
@@ -1136,7 +1132,7 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
                         state,
                         # Value buffer: address by row, which is the slot for
                         # every strategy except NO_EVICTION.
-                        prefetch_state.rows_or_slots(),
+                        prefetch_state.value_row_indices,
                         prefetch_state.unique_table_ids,
                         copy_mode=CopyMode.EMBEDDING,
                     )
@@ -1215,7 +1211,7 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
             ctx.slot_indices = prefetch_state.slot_indices
             # Same split as the forward: the fused optimizer writes into the
             # value buffer (rows), the ref counter is indexed by hash slot.
-            ctx.update_value_rows = prefetch_state.rows_or_slots()
+            ctx.update_value_rows = prefetch_state.value_row_indices
             ctx.storage_mode = prefetch_state.storage_mode
             ctx.optimizer = optimizer
             ctx.pooling_mode = pooling_mode

--- a/corelib/dynamicemb/test/unit_test.sh
+++ b/corelib/dynamicemb/test/unit_test.sh
@@ -14,6 +14,7 @@ FWD_BWD_TEST_FILES=(
     "test/unit_tests/test_hybrid_storage_export.sh"
     "test/unit_tests/test_vmm_tensor.py"
     "test/unit_tests/test_padded_buffer_optimizer.py"
+    "test/unit_tests/test_no_eviction_row_indexing.py"
 )
 
 LOAD_DUMP_TEST_FILES=(

--- a/corelib/dynamicemb/test/unit_tests/test_no_eviction_row_indexing.py
+++ b/corelib/dynamicemb/test/unit_tests/test_no_eviction_row_indexing.py
@@ -1,0 +1,418 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NO_EVICTION is the only score strategy whose value row differs from its hash
+slot: rows come from a per-table auto-increment counter, and the key map is sized
+``1 / max_load_factor`` times the value buffer. Addressing the value buffer with a
+slot therefore reads the wrong row -- or past the end of the buffer entirely.
+
+These tests drive the forward path over keys that are *already resident*, which is
+what makes a lookup (rather than an insert) supply the index.
+"""
+
+import pytest
+import torch
+from dynamicemb import (
+    DynamicEmbCheckMode,
+    DynamicEmbInitializerArgs,
+    DynamicEmbInitializerMode,
+    DynamicEmbPoolingMode,
+    DynamicEmbScoreStrategy,
+    DynamicEmbTableOptions,
+    EmbOptimType,
+)
+from dynamicemb.batched_dynamicemb_tables import BatchedDynamicEmbeddingTablesV2
+
+# The DEBUG initializer writes `key % DEBUG_EMB_INITIALIZER_MOD` into every
+# element, so a row can be checked against the key that should own it.
+DEBUG_MOD = 100_000
+DIM = 8
+TABLE = "t_0"
+
+
+@pytest.fixture
+def current_device():
+    assert torch.cuda.is_available()
+    return torch.cuda.current_device()
+
+
+def build_model(current_device: int, max_capacity: int, init_capacity=None):
+    options = DynamicEmbTableOptions(
+        index_type=torch.int64,
+        embedding_dtype=torch.float32,
+        device_id=current_device,
+        dim=DIM,
+        max_capacity=max_capacity,
+        init_capacity=init_capacity,
+        bucket_capacity=128,
+        safe_check_mode=DynamicEmbCheckMode.IGNORE,
+        local_hbm_for_values=1024**3,
+        score_strategy=DynamicEmbScoreStrategy.NO_EVICTION,
+        caching=False,
+        initializer_args=DynamicEmbInitializerArgs(
+            mode=DynamicEmbInitializerMode.DEBUG
+        ),
+    )
+    return BatchedDynamicEmbeddingTablesV2(
+        table_options=[options],
+        output_dtype=torch.float32,
+        table_names=[TABLE],
+        feature_table_map=[0],
+        pooling_mode=DynamicEmbPoolingMode.SUM,
+        use_index_dedup=False,
+    )
+
+
+def build_caching_model(
+    current_device: int,
+    max_capacity: int,
+    cache_fraction: float,
+    optimizer: EmbOptimType = EmbOptimType.SGD,
+    **opt_params,
+):
+    """A CACHING-layout model: small GPU cache in front of a host-resident
+    NO_EVICTION backing store.
+
+    The cache size follows ``local_hbm_for_values / total_value_bytes``
+    (``batched_dynamicemb_tables.py`` picks ``cap_scale`` from that ratio), so a
+    small *cache_fraction* forces real spill traffic between the two tiers.
+    """
+    value_bytes = max_capacity * torch.finfo(torch.float32).bits // 8 * DIM
+    options = DynamicEmbTableOptions(
+        index_type=torch.int64,
+        embedding_dtype=torch.float32,
+        device_id=current_device,
+        dim=DIM,
+        max_capacity=max_capacity,
+        bucket_capacity=128,
+        safe_check_mode=DynamicEmbCheckMode.IGNORE,
+        local_hbm_for_values=int(value_bytes * cache_fraction),
+        score_strategy=DynamicEmbScoreStrategy.NO_EVICTION,
+        caching=True,
+        initializer_args=DynamicEmbInitializerArgs(
+            mode=DynamicEmbInitializerMode.DEBUG
+        ),
+    )
+    return BatchedDynamicEmbeddingTablesV2(
+        table_options=[options],
+        output_dtype=torch.float32,
+        table_names=[TABLE],
+        feature_table_map=[0],
+        pooling_mode=DynamicEmbPoolingMode.SUM,
+        use_index_dedup=False,
+        optimizer=optimizer,
+        **opt_params,
+    )
+
+
+def next_row_counter(model, table_id: int = 0) -> int:
+    """The backing store's NO_EVICTION auto-increment row counter."""
+    return int(model._storage._state.no_eviction_next_index_dev[table_id].item())
+
+
+def lookup(model, keys, device):
+    """One SUM-pooled feature, one key per bag -> out[i] is keys[i]'s embedding."""
+    indices = torch.tensor(keys, dtype=torch.int64, device=device)
+    offsets = torch.arange(0, len(keys) + 1, dtype=torch.int64, device=device)
+    out = model(indices, offsets)
+    torch.cuda.synchronize()
+    return out
+
+
+def assert_debug_values(out: torch.Tensor, keys):
+    """Every row must carry its own key's DEBUG pattern, not another row's."""
+    expected = torch.tensor(
+        [k % DEBUG_MOD for k in keys], dtype=out.dtype, device=out.device
+    )
+    torch.testing.assert_close(out, expected.unsqueeze(1).expand(-1, out.size(1)))
+
+
+def test_resident_keys_reread_correctly(current_device):
+    """A second forward over the same keys must return the same embeddings.
+
+    Regression: the HBM-direct prefetch returned the *hash slot* for keys that hit
+    in the table (``h_num_missing == 0`` early return), and the forward fed that
+    straight into ``load_from_flat``. For NO_EVICTION the key map is twice the
+    value buffer, so roughly half those slots addressed rows past the end of the
+    buffer -- an illegal memory access.
+    """
+    device = torch.device(f"cuda:{current_device}")
+    model = build_model(current_device, max_capacity=65536 * 2)
+    keys = list(range(1001, 1301))
+
+    first = lookup(model, keys, device)  # all miss -> rows come from the insert
+    assert_debug_values(first, keys)
+
+    second = lookup(model, keys, device)  # all hit -> rows must come from the score
+    assert_debug_values(second, keys)
+    torch.testing.assert_close(first, second)
+
+
+def test_mixed_hit_and_miss_batch(current_device):
+    """A batch that both hits and misses: found keys take the lookup index, new
+    keys the freshly assigned row, and the two must not be crossed."""
+    device = torch.device(f"cuda:{current_device}")
+    model = build_model(current_device, max_capacity=65536 * 2)
+
+    resident = list(range(2001, 2201))
+    lookup(model, resident, device)
+
+    fresh = list(range(9001, 9201))
+    mixed = resident + fresh
+    out = lookup(model, mixed, device)
+    assert_debug_values(out, mixed)
+
+    # Everything is resident now; one more pass must be stable.
+    assert_debug_values(lookup(model, mixed, device), mixed)
+
+
+def test_survives_repeated_passes(current_device):
+    """Rows stay stable across many passes (the ref counter is indexed by slot,
+    the values by row -- mixing them up corrupts one or the other over time)."""
+    device = torch.device(f"cuda:{current_device}")
+    model = build_model(current_device, max_capacity=65536 * 2)
+    keys = list(range(3001, 3201))
+    for _ in range(5):
+        assert_debug_values(lookup(model, keys, device), keys)
+
+
+@pytest.mark.parametrize(
+    "init_capacity, n_keys, expect_growth",
+    [
+        # init == max_capacity: the value buffer is allocated to exactly the
+        # logical row count, so an out-of-range slot runs off the end of the
+        # allocation -- the loud, crashing form of the bug.
+        (None, 800, False),
+        # A small init_capacity leaves the buffer's *reserved* region far larger
+        # than its logical one, so an out-of-range slot lands in reserved-but-
+        # unused memory: no fault, just the wrong row. This is the silent form,
+        # and the reason the bug survived -- the repo's own NO_EVICTION test uses
+        # a small init_capacity and so only ever hit this variant.
+        (4096, 800, False),
+        # Same small buffer, but enough keys to cross max_load_factor (0.5 of a
+        # 2*4096 key map) and actually rehash. Expansion grows the key map and the
+        # value buffer by different amounts, so the two spaces stay mismatched
+        # across the resize.
+        (4096, 6000, True),
+    ],
+)
+def test_explicit_init_capacity(current_device, init_capacity, n_keys, expect_growth):
+    """Resident-key re-reads across the buffer-sizing regimes that decide whether
+    a slot/row mix-up faults or corrupts silently."""
+    device = torch.device(f"cuda:{current_device}")
+    model = build_model(
+        current_device, max_capacity=65536 * 2, init_capacity=init_capacity
+    )
+    cap_before = model._storage._state.key_index_map.capacity(0)
+
+    keys = list(range(4001, 4001 + n_keys))
+    assert_debug_values(lookup(model, keys, device), keys)  # insert
+    assert_debug_values(lookup(model, keys, device), keys)  # all resident
+
+    cap_after = model._storage._state.key_index_map.capacity(0)
+    if expect_growth:
+        assert cap_after > cap_before, (
+            f"expected a rehash with {n_keys} keys in a {cap_before}-slot map, "
+            "but the table never grew -- this case no longer covers expansion"
+        )
+        # One more pass after the rehash: slots moved, rows did not.
+        assert_debug_values(lookup(model, keys, device), keys)
+    else:
+        assert cap_after == cap_before
+
+
+# ---------------------------------------------------------------------------
+# CACHING layout: GPU cache (forcibly TIMESTAMP/LRU) + host NO_EVICTION backing
+# ---------------------------------------------------------------------------
+
+
+def test_caching_downgrades_cache_but_not_backing(current_device):
+    """The cache tier cannot be NO_EVICTION (it enables an overflow buffer, which
+    ``create_table_state`` rejects for NO_EVICTION), so it is forced to
+    TIMESTAMP/LRU while the backing store keeps NO_EVICTION.
+
+    Pinning this down matters for users: with ``caching=True`` the *cache* still
+    evicts -- only the backing store never drops a key.
+    """
+    model = build_caching_model(
+        current_device, max_capacity=16384, cache_fraction=0.125
+    )
+    assert model._cache is not None, "expected a CACHING layout"
+    assert (
+        model._cache._state.options_list[0].score_strategy
+        == DynamicEmbScoreStrategy.TIMESTAMP
+    )
+    assert (
+        model._storage._state.options_list[0].score_strategy
+        == DynamicEmbScoreStrategy.NO_EVICTION
+    )
+    assert model._storage._state.no_eviction_next_index is not None
+
+
+def test_caching_spill_does_not_leak_rows(current_device):
+    """Spilling a key from cache to backing must reuse its existing logical row.
+
+    NO_EVICTION rows come from a per-table auto-increment counter. If the spill
+    path re-inserted an already-resident key without ``preserve_existing``, that
+    key would be handed a *fresh* row on every eviction: the old row is orphaned
+    and the counter climbs with spill traffic rather than with distinct keys --
+    eventually past the value buffer, which is sized from the key count.
+
+    Backward is required, not decorative: a prefetched key is pinned by the
+    cache's ref counter until ``decrement_counter`` runs in the backward pass, so
+    a forward-only loop cannot evict anything and nothing would ever spill.
+    ``learning_rate=0`` keeps the DEBUG pattern intact for the value checks.
+    """
+    device = torch.device(f"cuda:{current_device}")
+    model = build_caching_model(
+        current_device,
+        max_capacity=16384,
+        cache_fraction=0.125,
+        learning_rate=0.0,
+    )
+    keys = list(range(1001, 5001))  # 4000 distinct keys, ~2x the cache
+
+    for _ in range(4):  # repeated sweeps -> repeated evict/refill of the same keys
+        for start in range(0, len(keys), 500):
+            chunk = keys[start : start + 500]
+            out = lookup(model, chunk, device)
+            out.sum().backward()  # releases the cache pins so eviction can happen
+            torch.cuda.synchronize()
+            assert_debug_values(out, chunk)
+
+    rows = next_row_counter(model)
+    assert rows > 0, "nothing ever spilled to the backing store -- test is vacuous"
+    # One row per distinct key, no matter how much spill traffic happened. A leak
+    # would push this ABOVE the distinct-key count.
+    assert rows == len(keys), (
+        f"expected {len(keys)} rows for {len(keys)} distinct keys, got {rows} -- "
+        "rows are leaking on spill"
+    )
+
+
+def test_caching_backing_retains_every_key(current_device):
+    """NO_EVICTION's core promise: the backing store never drops a key, however
+    hard the cache in front of it evicts.
+
+    This has to be a *structural* check. The DEBUG initializer returns
+    ``key % DEBUG_MOD``, so a key that was dropped and re-initialised reads back
+    exactly like one that was retained -- value assertions cannot detect a drop.
+    Counting live entries in the two tiers can.
+    """
+    device = torch.device(f"cuda:{current_device}")
+    model = build_caching_model(
+        current_device,
+        max_capacity=16384,
+        cache_fraction=0.125,
+        learning_rate=0.0,
+    )
+    keys = list(range(2001, 6001))
+
+    for start in range(0, len(keys), 500):
+        chunk = keys[start : start + 500]
+        out = lookup(model, chunk, device)
+        out.sum().backward()  # unpins cache entries so eviction can proceed
+        torch.cuda.synchronize()
+
+    cached = int(model._cache._state.key_index_map.size(0))
+    spilled = int(model._storage._state.key_index_map.size(0))
+    # The cache is a fraction of the key set, so it must have evicted...
+    assert cached < len(keys), (
+        f"cache holds all {len(keys)} keys -- it never evicted, so this test "
+        "says nothing about the backing store"
+    )
+    # ...and everything it evicted landed in the backing store rather than being
+    # dropped. The rest is still cache-resident and has not spilled yet.
+    assert spilled + cached == len(keys), (
+        f"{spilled} spilled + {cached} cached != {len(keys)} keys -- some key was "
+        "dropped between the tiers"
+    )
+
+    # Push the cache down so the backing store must hold the complete key set.
+    model.flush()
+    backing = int(model._storage._state.key_index_map.size(0))
+    assert backing == len(keys), (
+        f"backing store holds {backing} of {len(keys)} keys after flush -- "
+        "NO_EVICTION must never drop one"
+    )
+
+
+def test_hbm_direct_backward_writes_the_right_row(current_device):
+    """The backward half of the slot/row split, on the layout where they differ.
+
+    ``fused_update_for_flat_table`` writes gradients into the **value buffer**
+    (rows) while ``decrement_counter`` touches the **ref counter** (slots). Every
+    other test here is forward-only, so this is the only coverage of the backward
+    index space -- and NO_EVICTION on HBM-direct is the one configuration where
+    feeding it a slot instead of a row would corrupt a different key's row.
+
+    ``loss = out.sum()`` gives every element a gradient of exactly 1, so plain SGD
+    moves each embedding from ``key % DEBUG_MOD`` to ``key % DEBUG_MOD - lr``. A
+    write that landed on the wrong row shows up as one key un-updated and another
+    double-updated.
+    """
+    device = torch.device(f"cuda:{current_device}")
+    lr = 0.5
+    options = DynamicEmbTableOptions(
+        index_type=torch.int64,
+        embedding_dtype=torch.float32,
+        device_id=current_device,
+        dim=DIM,
+        max_capacity=65536 * 2,
+        bucket_capacity=128,
+        safe_check_mode=DynamicEmbCheckMode.IGNORE,
+        local_hbm_for_values=1024**3,
+        score_strategy=DynamicEmbScoreStrategy.NO_EVICTION,
+        caching=False,
+        initializer_args=DynamicEmbInitializerArgs(
+            mode=DynamicEmbInitializerMode.DEBUG
+        ),
+    )
+    model = BatchedDynamicEmbeddingTablesV2(
+        table_options=[options],
+        output_dtype=torch.float32,
+        table_names=[TABLE],
+        feature_table_map=[0],
+        pooling_mode=DynamicEmbPoolingMode.SUM,
+        use_index_dedup=False,
+        optimizer=EmbOptimType.SGD,
+        learning_rate=lr,
+        stochastic_rounding=False,
+    )
+    assert model._cache is None, "expected the HBM-direct layout"
+    keys = list(range(5001, 5301))
+
+    out = lookup(model, keys, device)  # insert; rows come from the counter
+    assert_debug_values(out, keys)
+    out.sum().backward()
+    torch.cuda.synchronize()
+
+    # Re-read: this lookup takes the resident path, where the row must come from
+    # the stored score rather than the hash slot.
+    after = lookup(model, keys, device)
+    expected = torch.tensor(
+        [k % DEBUG_MOD - lr for k in keys], dtype=after.dtype, device=after.device
+    )
+    torch.testing.assert_close(after, expected.unsqueeze(1).expand(-1, after.size(1)))
+
+    # A second step must move every row again by exactly lr -- no row left behind,
+    # none hit twice.
+    after.sum().backward()
+    torch.cuda.synchronize()
+    final = lookup(model, keys, device)
+    expected2 = torch.tensor(
+        [k % DEBUG_MOD - 2 * lr for k in keys], dtype=final.dtype, device=final.device
+    )
+    torch.testing.assert_close(final, expected2.unsqueeze(1).expand(-1, final.size(1)))


### PR DESCRIPTION
NO_EVICTION is the only score strategy whose value row differs from its hash slot: rows come from a per-table auto-increment counter (its score word is repurposed as the row index) while slots come from the key's hash. Its key map is also sized 1/max_load_factor times the value buffer, so a slot can address well past the end of it.

_prefetch_hbm_direct_path translated slot to row on the insert branch only (score_arg.value), and returned the raw hash slot from the lookup branch's `h_num_missing == 0` early return. The forward fed that straight into load_from_flat, so a batch whose keys were all resident read the wrong row -- or, when the value buffer is allocated to exactly its logical row count, past the allocation entirely ("an illegal memory access", dynamic_emb_op.cu:561). The helper for exactly this translation, _flat_row_indices_for_value_load, was already used by the four DynamicEmbStorage / HybridStorage.find call sites but never on this path.

Carry the two index spaces separately instead of relying on them coinciding. PrefetchState gains value_row_indices / update_value_row_indices (None meaning "same as the slot tensors", so no extra allocation for any other strategy), and each consumer picks by what it addresses:

  load_from_flat, fused_update_for_flat_table  -> value buffer -> row
  increment_counter, decrement_counter         -> ref counter  -> slot

This also fixes a quieter defect on the same code: new_indices was overwritten with the row *before* increment_counter, so newly inserted NO_EVICTION keys pinned the wrong counter entry while looked-up keys pinned the right one.

The fault only surfaces on the HBM-direct layout: HybridStorage rejects NO_EVICTION at construction, and with caching the GPU cache is forced to TIMESTAMP/LRU, so every slot on that path is a cache slot.

Regression coverage in test_no_eviction_row_indexing.py checks values rather than liveness -- the DEBUG initializer writes key % 100000, so a wrong-row read fails on the number instead of waiting for a page fault. It spans both failure modes (crashing and silent), a rehash, the backward index space, and the caching layout's spill/fill boundary.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/recsys-examples/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
