### PR TITLE
feat(dynamicemb): weighted EmbeddingBagCollection training

### DIFF
--- a/corelib/dynamicemb/DynamicEmb_APIs.md
+++ b/corelib/dynamicemb/DynamicEmb_APIs.md
@@ -465,6 +465,17 @@ All pooling modes use fused CUDA kernels for both forward and backward passes. T
         NONE = 2
     ```
 
+**Weighted SUM pooling (training only)** — `SUM` pooling supports optional per-position float32 weights: `out[b] = Σ wᵢ · embᵢ`. Supported only in
+**training mode**, only for `SUM` (no weighted-MEAN variant), and works with mixed-D tables. Two ways to use it:
+
+- **Through TorchRec's `EmbeddingBagCollection`**: build the collection with
+  `is_weighted=True` and attach the weights to the features KJT (`KeyedJaggedTensor(keys=..., values=indices, weights=weights, lengths=...)`);
+  call `model(features)` as usual. The weights ride the KJT through the all2all distribution and reach the DynamicEmb lookup as pooling weights.
+- **Through `BatchedDynamicEmbeddingTablesV2.forward` directly**:
+  `module(indices, offsets, pooling_weights=w)` where `w` is a float32 tensor aligned with `indices` (`w.numel() == indices.numel()`).
+
+Weighted pooling raises `ValueError` when: `pooling_mode != SUM`, the weights are not float32, `weights.numel() != indices.numel()`, or the module is in eval mode.
+
 ## DynamicEmbTableOptions
 
 Per-table configuration for dynamic embedding, passed into `DynamicEmbParameterConstraints` as `dynamicemb_options`. The authoritative definition lives in `dynamicemb.dynamicemb_config.DynamicEmbTableOptions` (this section mirrors its docstring).
@@ -1051,6 +1062,23 @@ Once the model containing `EmbeddingCollection` is built and initialized through
 The switching between training and evaluation modes should be consistent with `nn.Module`, while `training` in [DynamicEmbTableOptions](./dynamicemb/dynamicemb_config.py) is used to guide whether to allocate memory to optimizer states when builds the table.
 
 Due to limited resources, the dynamic embedding table does not pre allocate memory for all keys. If a key appears for the first time during training, it will be initialized immediately during the training process. Please see `initializer_args` and `eval_initializer_args` in `DynamicEmbTableOptions` for more information.
+
+## Weighted EmbeddingBagCollection
+
+Weighted-sum pooling for `EmbeddingBagCollection` tables backed by DynamicEmb is supported in training (see
+[DynamicEmbPoolingMode](#dynamicembpoolingmode)). Gradients are scaled per-position: `grad_embᵢ = wᵢ · grad_pooled`, verified against an exact SGD
+oracle in `test/unit_tests/test_weighted_pooled_embedding_v2.py` and end-to-end through TorchRec's `is_weighted` path in `test/unit_tests/test_weighted_pooled_embedding_fw.py` (1-GPU and multi-GPU).
+
+### Breaking API change: `per_sample_weights` split
+
+`BatchedDynamicEmbeddingTablesV2.forward` previously took `per_sample_weights`, which was consumed as **LFU frequency counters**. That parameter is now split:
+
+- `frequency_counters: Optional[Tensor]` — per-position LFU frequency counters (the old `per_sample_weights` semantics).
+- `pooling_weights: Optional[Tensor]` — per-position float32 weights for weighted-SUM pooling (new; training only, SUM only).
+
+Callers that passed `per_sample_weights=...` for LFU counting must pass `frequency_counters=...` instead.
+
+`InferenceEmbeddingTable`'s `per_sample_weights` (inference/export path) is a separate API and is unchanged.
 
 ## Automatic eviction
 

--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_compute_kernel.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_compute_kernel.py
@@ -369,6 +369,13 @@ class BatchedDynamicEmbeddingBag(
     def purge(self) -> None:
         self._emb_module.reset_cache_states()
 
+    def forward(self, features) -> torch.Tensor:
+        return self._emb_module(
+            indices=features.values().long(),
+            offsets=features.offsets().long(),
+            pooling_weights=features.weights_or_none(),
+        )
+
 
 class BatchedDynamicEmbedding(BaseBatchedEmbedding[torch.Tensor]):
     # FusedOptimizerModule):
@@ -484,5 +491,5 @@ class BatchedDynamicEmbedding(BaseBatchedEmbedding[torch.Tensor]):
         return self._emb_module(
             indices=features.values().long(),
             offsets=features.offsets().long(),
-            per_sample_weights=features.weights_or_none(),
+            frequency_counters=features.weights_or_none(),
         )

--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_function.py
@@ -1109,6 +1109,7 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
         dims: Optional[List[int]] = None,
         max_D: int = 0,
         D_offsets: Optional[torch.Tensor] = None,
+        pooling_weights: Optional[torch.Tensor] = None,
         *args,
     ):
         with torch.cuda.nvtx.range("DynamicEmbeddingFunction.forward"):
@@ -1117,6 +1118,27 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
             emb_dtype = storage.embedding_dtype()
 
             is_pooling = pooling_mode != DynamicEmbPoolingMode.NONE
+            if pooling_weights is not None:
+                if pooling_mode != DynamicEmbPoolingMode.SUM:
+                    raise ValueError(
+                        "pooling_weights requires pooling_mode=SUM (weighted "
+                        f"pooling is only supported for SUM, got {pooling_mode})."
+                    )
+                if pooling_weights.dtype != torch.float32:
+                    raise ValueError(
+                        "pooling_weights must be float32, got "
+                        f"{pooling_weights.dtype}."
+                    )
+                if (
+                    pooling_weights.numel()
+                    != prefetch_state.reverse_indices.numel()
+                ):
+                    raise ValueError(
+                        "pooling_weights.numel() "
+                        f"({pooling_weights.numel()}) must equal "
+                        "reverse_indices.numel() "
+                        f"({prefetch_state.reverse_indices.numel()})."
+                    )
             mixed_D = is_pooling and dims is not None and max_D > min(dims)
             out_dim = max_D if mixed_D else emb_dim
 
@@ -1189,6 +1211,7 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
                         batch_size,
                         D_offsets,
                         max_D,
+                        pooling_weights,
                     )
             else:
                 combiner = -1
@@ -1226,6 +1249,7 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
             ctx.dims = dims
             ctx.max_D = max_D
             ctx.D_offsets = D_offsets
+            ctx.pooling_weights = pooling_weights
             ctx.num_features = (
                 (offsets.shape[0] - 1) // batch_size if batch_size > 0 else 0
             )
@@ -1269,6 +1293,7 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
                         ctx.D_offsets,
                         ctx.combiner,
                         ctx.total_D,
+                        ctx.pooling_weights,
                     )
             else:
                 with torch.cuda.nvtx.range("op:reduce_grads"):
@@ -1353,4 +1378,4 @@ class DynamicEmbeddingFunction(torch.autograd.Function):
                                 preserve_existing=True,
                             )
 
-            return (None,) * 17
+            return (None,) * 18

--- a/corelib/dynamicemb/dynamicemb/batched_dynamicemb_tables.py
+++ b/corelib/dynamicemb/dynamicemb/batched_dynamicemb_tables.py
@@ -1015,7 +1015,8 @@ class BatchedDynamicEmbeddingTablesV2(nn.Module):
         self,
         indices: Tensor,
         offsets: Tensor,
-        per_sample_weights: Optional[Tensor] = None,
+        frequency_counters: Optional[Tensor] = None,
+        pooling_weights: Optional[Tensor] = None,
         feature_requires_grad: Optional[Tensor] = None,
         # 2D tensor of batch size for each rank and feature.
         # Shape (number of features, number of ranks)
@@ -1039,6 +1040,27 @@ class BatchedDynamicEmbeddingTablesV2(nn.Module):
         batch_size = (
             feature_batch_size // self.feature_num if self.feature_num > 0 else 0
         )
+        if pooling_weights is not None:
+            if self.pooling_mode != DynamicEmbPoolingMode.SUM:
+                raise ValueError(
+                    "pooling_weights requires pooling_mode=SUM (weighted pooling "
+                    f"is only supported for SUM, got {self.pooling_mode})."
+                )
+            if not self.training:
+                raise ValueError(
+                    "pooling_weights is only supported in training mode."
+                )
+            if pooling_weights.dtype != torch.float32:
+                raise ValueError(
+                    "pooling_weights must be float32, got "
+                    f"{pooling_weights.dtype}."
+                )
+            if pooling_weights.numel() != indices.numel():
+                raise ValueError(
+                    "pooling_weights.numel() "
+                    f"({pooling_weights.numel()}) must equal indices.numel() "
+                    f"({indices.numel()})."
+                )
 
         if not self.training:
             scores = [self._scores[name] for name in self._table_names]
@@ -1058,7 +1080,7 @@ class BatchedDynamicEmbeddingTablesV2(nn.Module):
                 self.output_dtype,
                 self._eval_initializers,
                 self._evict_strategy,
-                per_sample_weights,
+                frequency_counters,
                 self.pooling_mode,
                 self.total_D,
                 batch_size,
@@ -1073,7 +1095,7 @@ class BatchedDynamicEmbeddingTablesV2(nn.Module):
             )
 
         if not self._prefetch_states:
-            self.prefetch(indices, offsets, frequency_counters=per_sample_weights)
+            self.prefetch(indices, offsets, frequency_counters=frequency_counters)
         prefetch_state = self._prefetch_states.popleft()
 
         res = DynamicEmbeddingFunction.apply(
@@ -1093,6 +1115,7 @@ class BatchedDynamicEmbeddingTablesV2(nn.Module):
             self.dims,
             self.max_D,
             self.D_offsets_t,
+            pooling_weights,
             self._empty_tensor,
         )
         if isinstance(self._cache, DynamicEmbCache):

--- a/corelib/dynamicemb/src/dynamic_emb_op.cu
+++ b/corelib/dynamicemb/src/dynamic_emb_op.cu
@@ -130,7 +130,7 @@ void gather_embedding_pooled(
   const float *d_weights = nullptr;
   at::Tensor w;
   if (weights.has_value()) {
-    auto w = weights.value().contiguous();
+    w = weights.value().contiguous();
     TORCH_CHECK(w.scalar_type() == at::kFloat,
                 "weights must be float32, got ", w.scalar_type());
     TORCH_CHECK(w.is_cuda(), "weights must be a CUDA tensor");

--- a/corelib/dynamicemb/src/dynamic_emb_op.cu
+++ b/corelib/dynamicemb/src/dynamic_emb_op.cu
@@ -110,10 +110,22 @@ void gather_embedding_pooled(
     const std::optional<at::Tensor> &weights = std::nullopt) {
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   int num_slots = offsets.size(0) - 1;
-  ...
+
+  auto src_type =
+      scalartype_to_datatype(convertTypeMetaToScalarType(input.dtype()));
+  auto dst_type =
+      scalartype_to_datatype(convertTypeMetaToScalarType(output.dtype()));
+  auto offset_type =
+      scalartype_to_datatype(convertTypeMetaToScalarType(offsets.dtype()));
+
+  int dim = D_offsets.has_value() ? max_D : static_cast<int>(input.size(1));
+  int src_stride = static_cast<int>(input.stride(0));
   const int *d_D_offsets = nullptr;
   if (D_offsets.has_value()) {
-    ...
+    TORCH_CHECK(D_offsets.value().scalar_type() == at::kInt,
+                "D_offsets must be int32, got ",
+                D_offsets.value().scalar_type());
+    d_D_offsets = reinterpret_cast<const int *>(D_offsets.value().data_ptr());
   }
   const float *d_weights = nullptr;
   if (weights.has_value()) {
@@ -131,7 +143,6 @@ void gather_embedding_pooled(
       combiner, total_D, /*accum_D=*/0, dim, src_stride, num_slots, batch_size,
       src_type, dst_type, offset_type, stream, d_D_offsets, d_weights);
 }
-
 // Generate permutation-aware gather_ids from CSR offsets.
 // grads is [B*F, D] batch-first (row r → b=r/F, f=r%F).
 // Each thread processes one slot (bucket) s; slot s owns indices
@@ -861,7 +872,8 @@ void bind_dyn_emb_op(py::module &m) {
         py::arg("reverse_indices"), py::arg("grads"), py::arg("num_unique"),
         py::arg("batch_size"), py::arg("out_dim"),
         py::arg("offsets") = py::none(), py::arg("D_offsets") = py::none(),
-        py::arg("combiner") = -1, py::arg("total_D") = 0);
+        py::arg("combiner") = -1, py::arg("total_D") = 0,
+	py::arg("weights") = py::none());
 
   m.def("gather_embedding", &gather_embedding,
         "Gather embedding based on index.", py::arg("input"), py::arg("output"),
@@ -872,7 +884,7 @@ void bind_dyn_emb_op(py::module &m) {
         py::arg("input"), py::arg("output"), py::arg("index"),
         py::arg("offsets"), py::arg("combiner"), py::arg("total_D"),
         py::arg("batch_size"), py::arg("D_offsets") = py::none(),
-        py::arg("max_D") = 0);
+        py::arg("max_D") = 0, py::arg("weights") = py::none());
 
   m.def("load_from_flat_table_contiguous", &load_from_flat_table_contiguous,
         "Load from flat table: contiguous copy (NumRegions=0, single-table "

--- a/corelib/dynamicemb/src/dynamic_emb_op.cu
+++ b/corelib/dynamicemb/src/dynamic_emb_op.cu
@@ -276,7 +276,7 @@ reduce_grads(at::Tensor reverse_indices, at::Tensor grads, int64_t num_unique,
 
   // --- Sort weights with the same keys (radix sort is stable, so this
   //     yields the identical permutation as the gather_ids sort) ---
-  at::Tensor sorted_weights;
+  std::optional<at::Tensor> sorted_weights;
   if (weights.has_value()) {
     auto w = weights.value().contiguous();
     TORCH_CHECK(w.scalar_type() == at::kFloat,
@@ -287,7 +287,7 @@ reduce_grads(at::Tensor reverse_indices, at::Tensor grads, int64_t num_unique,
                 ") must equal reverse_indices.numel() (", num_keys, ")");
     TORCH_CHECK(offsets.has_value(),
                 "weights are only supported for pooled (offsets) reduce");
-    sorted_weights = at::empty_like(w);
+    at::Tensor sw = at::empty_like(w);
     DISPATCH_INTEGER_DATATYPE_FUNCTION(id_dtype, id_t, [&] {
       size_t w_temp_bytes = 0;
       cub::DeviceRadixSort::SortPairs(
@@ -295,8 +295,8 @@ reduce_grads(at::Tensor reverse_indices, at::Tensor grads, int64_t num_unique,
           reinterpret_cast<id_t *>(reverse_indices.data_ptr()),
           reinterpret_cast<id_t *>(sorted_reverse_indices.data_ptr()),
           reinterpret_cast<float *>(w.data_ptr()),
-          reinterpret_cast<float *>(sorted_weights.data_ptr()), num_keys, 0,
-          end_bit, stream);
+          reinterpret_cast<float *>(sw.data_ptr()), num_keys, 0, end_bit,
+          stream);
       auto w_temp = at::empty({static_cast<int64_t>(w_temp_bytes)},
                               at::TensorOptions().dtype(at::kByte).device(device_));
       cub::DeviceRadixSort::SortPairs(
@@ -304,11 +304,11 @@ reduce_grads(at::Tensor reverse_indices, at::Tensor grads, int64_t num_unique,
           reinterpret_cast<id_t *>(reverse_indices.data_ptr()),
           reinterpret_cast<id_t *>(sorted_reverse_indices.data_ptr()),
           reinterpret_cast<float *>(w.data_ptr()),
-          reinterpret_cast<float *>(sorted_weights.data_ptr()), num_keys, 0,
-          end_bit, stream);
+          reinterpret_cast<float *>(sw.data_ptr()), num_keys, 0, end_bit,
+          stream);
     });
+    sorted_weights = sw;
   }
-
   // --- LocalReduce ---
   // MEAN scaling is fused inside the reduce kernel for both uniform and
   // multi-dim modes, so no separate scaling pass is needed.

--- a/corelib/dynamicemb/src/dynamic_emb_op.cu
+++ b/corelib/dynamicemb/src/dynamic_emb_op.cu
@@ -128,6 +128,7 @@ void gather_embedding_pooled(
     d_D_offsets = reinterpret_cast<const int *>(D_offsets.value().data_ptr());
   }
   const float *d_weights = nullptr;
+  at::Tensor w;
   if (weights.has_value()) {
     auto w = weights.value().contiguous();
     TORCH_CHECK(w.scalar_type() == at::kFloat,

--- a/corelib/dynamicemb/src/dynamic_emb_op.cu
+++ b/corelib/dynamicemb/src/dynamic_emb_op.cu
@@ -106,30 +106,30 @@ void gather_embedding(at::Tensor input, at::Tensor output, at::Tensor index) {
 void gather_embedding_pooled(
     at::Tensor input, at::Tensor output, at::Tensor index, at::Tensor offsets,
     int combiner, int total_D, int batch_size,
-    const std::optional<at::Tensor> &D_offsets = std::nullopt, int max_D = 0) {
+    const std::optional<at::Tensor> &D_offsets = std::nullopt, int max_D = 0,
+    const std::optional<at::Tensor> &weights = std::nullopt) {
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   int num_slots = offsets.size(0) - 1;
-
-  auto src_type =
-      scalartype_to_datatype(convertTypeMetaToScalarType(input.dtype()));
-  auto dst_type =
-      scalartype_to_datatype(convertTypeMetaToScalarType(output.dtype()));
-  auto offset_type =
-      scalartype_to_datatype(convertTypeMetaToScalarType(offsets.dtype()));
-
-  int dim = D_offsets.has_value() ? max_D : static_cast<int>(input.size(1));
-  int src_stride = static_cast<int>(input.stride(0));
+  ...
   const int *d_D_offsets = nullptr;
   if (D_offsets.has_value()) {
-    TORCH_CHECK(D_offsets.value().scalar_type() == at::kInt,
-                "D_offsets must be int32, got ",
-                D_offsets.value().scalar_type());
-    d_D_offsets = reinterpret_cast<const int *>(D_offsets.value().data_ptr());
+    ...
+  }
+  const float *d_weights = nullptr;
+  if (weights.has_value()) {
+    auto w = weights.value().contiguous();
+    TORCH_CHECK(w.scalar_type() == at::kFloat,
+                "weights must be float32, got ", w.scalar_type());
+    TORCH_CHECK(w.is_cuda(), "weights must be a CUDA tensor");
+    TORCH_CHECK(w.numel() == index.numel(),
+                "weights.numel() (", w.numel(),
+                ") must equal index.numel() (", index.numel(), ")");
+    d_weights = reinterpret_cast<const float *>(w.data_ptr());
   }
   dyn_emb::scatter_combine(
       input.data_ptr(), output.data_ptr(), offsets.data_ptr(), index.data_ptr(),
       combiner, total_D, /*accum_D=*/0, dim, src_stride, num_slots, batch_size,
-      src_type, dst_type, offset_type, stream, d_D_offsets);
+      src_type, dst_type, offset_type, stream, d_D_offsets, d_weights);
 }
 
 // Generate permutation-aware gather_ids from CSR offsets.
@@ -161,7 +161,8 @@ reduce_grads(at::Tensor reverse_indices, at::Tensor grads, int64_t num_unique,
              int batch_size, int64_t out_dim,
              const std::optional<at::Tensor> &offsets = std::nullopt,
              const std::optional<at::Tensor> &D_offsets = std::nullopt,
-             int combiner = -1, int total_D = 0) {
+             int combiner = -1, int total_D = 0,
+	     const std::optional<at::Tensor> &weights = std::nullopt) {
   // When D_offsets is provided (multi-dim pooling):
   //   grads is [B, total_D].  Permutation-aware gather_ids are generated,
   //   sorted with reverse_indices, then a multi-dim variant of LocalReduce
@@ -262,6 +263,41 @@ reduce_grads(at::Tensor reverse_indices, at::Tensor grads, int64_t num_unique,
         end_bit, stream);
   });
 
+  // --- Sort weights with the same keys (radix sort is stable, so this
+  //     yields the identical permutation as the gather_ids sort) ---
+  at::Tensor sorted_weights;
+  if (weights.has_value()) {
+    auto w = weights.value().contiguous();
+    TORCH_CHECK(w.scalar_type() == at::kFloat,
+                "weights must be float32, got ", w.scalar_type());
+    TORCH_CHECK(w.is_cuda(), "weights must be a CUDA tensor");
+    TORCH_CHECK(w.numel() == num_keys,
+                "weights.numel() (", w.numel(),
+                ") must equal reverse_indices.numel() (", num_keys, ")");
+    TORCH_CHECK(offsets.has_value(),
+                "weights are only supported for pooled (offsets) reduce");
+    sorted_weights = at::empty_like(w);
+    DISPATCH_INTEGER_DATATYPE_FUNCTION(id_dtype, id_t, [&] {
+      size_t w_temp_bytes = 0;
+      cub::DeviceRadixSort::SortPairs(
+          nullptr, w_temp_bytes,
+          reinterpret_cast<id_t *>(reverse_indices.data_ptr()),
+          reinterpret_cast<id_t *>(sorted_reverse_indices.data_ptr()),
+          reinterpret_cast<float *>(w.data_ptr()),
+          reinterpret_cast<float *>(sorted_weights.data_ptr()), num_keys, 0,
+          end_bit, stream);
+      auto w_temp = at::empty({static_cast<int64_t>(w_temp_bytes)},
+                              at::TensorOptions().dtype(at::kByte).device(device_));
+      cub::DeviceRadixSort::SortPairs(
+          w_temp.data_ptr(), w_temp_bytes,
+          reinterpret_cast<id_t *>(reverse_indices.data_ptr()),
+          reinterpret_cast<id_t *>(sorted_reverse_indices.data_ptr()),
+          reinterpret_cast<float *>(w.data_ptr()),
+          reinterpret_cast<float *>(sorted_weights.data_ptr()), num_keys, 0,
+          end_bit, stream);
+    });
+  }
+
   // --- LocalReduce ---
   // MEAN scaling is fused inside the reduce kernel for both uniform and
   // multi-dim modes, so no separate scaling pass is needed.
@@ -275,7 +311,9 @@ reduce_grads(at::Tensor reverse_indices, at::Tensor grads, int64_t num_unique,
 
     localReduceOp.local_reduce(grads, unique_grads, sorted_gather_ids,
                                sorted_reverse_indices, stream, D_offsets, offs,
-                               batch_size, num_features, total_D, combiner);
+                               batch_size, num_features, total_D, combiner,
+                               sorted_weights);
+
   } else {
     localReduceOp.local_reduce(grads, unique_grads, sorted_gather_ids,
                                sorted_reverse_indices, stream);
@@ -876,4 +914,18 @@ void bind_dyn_emb_op(py::module &m) {
   m.def("select_insert_failed_values", &select_insert_failed_values,
         "select_insert_failed_values", py::arg("indices"),
         py::arg("input_values"), py::arg("evicted_values"));
+
+  m.def("reduce_grads", &reduce_grads, "reduce grads",
+        py::arg("reverse_indices"), py::arg("grads"), py::arg("num_unique"),
+        py::arg("batch_size"), py::arg("out_dim"),
+        py::arg("offsets") = py::none(), py::arg("D_offsets") = py::none(),
+        py::arg("combiner") = -1, py::arg("total_D") = 0,
+        py::arg("weights") = py::none());
+
+  m.def("gather_embedding_pooled", &gather_embedding_pooled,
+        "Gather embedding with pooling (SUM/MEAN) based on index and offsets.",
+        py::arg("input"), py::arg("output"), py::arg("index"),
+        py::arg("offsets"), py::arg("combiner"), py::arg("total_D"),
+        py::arg("batch_size"), py::arg("D_offsets") = py::none(),
+        py::arg("max_D") = 0, py::arg("weights") = py::none());
 }

--- a/corelib/dynamicemb/src/lookup_backward.cu
+++ b/corelib/dynamicemb/src/lookup_backward.cu
@@ -592,7 +592,7 @@ void LocalReduce::local_reduce(const at::Tensor &in_grads,
                                const std::optional<at::Tensor> &D_offsets,
                                const std::optional<at::Tensor> &offsets, int B,
                                int F, int total_D, int combiner,
-			       const std::optional<at::Tensor> &weights) {
+                               const std::optional<at::Tensor> &weights) {
   if (num_key_ == 0)
     return;
   auto scalar_type = out_grads.dtype().toScalarType();
@@ -636,7 +636,7 @@ void LocalReduce::local_reduce(const at::Tensor &in_grads,
                 unique_key_ids, partial_buffer, partial_unique_ids, stream,
                 d_D_ptr, total_D, F,
                 reinterpret_cast<const offset_t *>(offsets.value().data_ptr()),
-                B, combiner);
+                B, combiner, d_w);
           });
         } else {
           multi_to_one_reduce<grad_t, accum_t, id_t, int64_t, WarpSize>(

--- a/corelib/dynamicemb/src/lookup_backward.cu
+++ b/corelib/dynamicemb/src/lookup_backward.cu
@@ -88,9 +88,6 @@ __global__ void multi_to_one_reduce_kernel1_no_vec(
     if (threadIdx.x < vec_length)
       accum += (accum_t)(tmp_src[threadIdx.x]) * (accum_t)scale;
 
-    if (threadIdx.x < vec_length)
-      accum += (accum_t)(tmp_src[threadIdx.x]) * (accum_t)scale;
-
     // when key changes, write to dst and reset
     if (sp < local_sample_num - 1) {
       id_t new_id = unique_ids[global_index + 1];

--- a/corelib/dynamicemb/src/lookup_backward.cu
+++ b/corelib/dynamicemb/src/lookup_backward.cu
@@ -37,7 +37,7 @@ __global__ void multi_to_one_reduce_kernel1_no_vec(
     const id_t *__restrict__ unique_ids, accum_t *__restrict__ partial_buffer,
     id_t *__restrict__ partial_unique_ids, const int *__restrict__ D_offsets,
     int total_D, int F, const offset_t *__restrict__ offsets, int B,
-    int combiner) {
+    int combiner, const float *__restrict__ weights) {
 
   const int block_id = blockIdx.x;
   int local_sample_num = kWarpSize;
@@ -81,6 +81,12 @@ __global__ void multi_to_one_reduce_kernel1_no_vec(
           scale = 1.0f / (float)pool_size;
       }
     }
+
+    if (weights != nullptr)
+      scale *= weights[global_index];
+
+    if (threadIdx.x < vec_length)
+      accum += (accum_t)(tmp_src[threadIdx.x]) * (accum_t)scale;
 
     if (threadIdx.x < vec_length)
       accum += (accum_t)(tmp_src[threadIdx.x]) * (accum_t)scale;
@@ -183,7 +189,7 @@ __global__ void multi_to_one_reduce_kernel1_vec4(
     const id_t *__restrict__ unique_ids, accum_t *__restrict__ partial_buffer,
     id_t *__restrict__ partial_unique_ids, const int *__restrict__ D_offsets,
     int total_D, int F, const offset_t *__restrict__ offsets, int B,
-    int combiner) {
+    int combiner, const float *__restrict__ weights) {
 
   const int lane_id = threadIdx.x & 31;
   const int warp_id = threadIdx.x >> 5;
@@ -230,6 +236,9 @@ __global__ void multi_to_one_reduce_kernel1_vec4(
           scale = 1.0f / (float)pool_size;
       }
     }
+
+    if (weights != nullptr)
+      scale *= weights[global_index];
 
     for (int i = 0; i < kMaxElemPerThread &&
                     (4 * kWarpSize * i + 4 * lane_id) < vec_length;
@@ -415,7 +424,8 @@ void multi_to_one_reduce(int64_t n, int64_t len_vec, const at::Tensor &in_grads,
                          at::Tensor &partial_unique_ids, cudaStream_t &stream,
                          const int *d_D_offsets = nullptr, int total_D = 0,
                          int F = 0, const offset_t *d_offsets = nullptr,
-                         int B = 0, int combiner = 0) {
+                         int B = 0, int combiner = 0,
+			 const float *d_weights = nullptr) {
   const bool multi_dim = (d_D_offsets != nullptr);
   auto &device_prop = DeviceProp::getDeviceProp(in_grads.device().index());
   const uint64_t first_stage_key_num = n;
@@ -456,13 +466,13 @@ void multi_to_one_reduce(int64_t n, int64_t len_vec, const at::Tensor &in_grads,
                                          true, offset_t>
             <<<grid_size, block_size, 0, stream>>>(
                 n, len_vec, p_in, p_out, p_sorted, p_unique, p_partial,
-                p_partial_ids, d_D_offsets, total_D, F, d_offsets, B, combiner);
+                p_partial_ids, d_D_offsets, total_D, F, d_offsets, B, combiner, d_weights);
       } else {
         multi_to_one_reduce_kernel1_vec4<io_t, accum_t, id_t, 1, kWarpSize,
                                          false, offset_t>
             <<<grid_size, block_size, 0, stream>>>(
                 n, len_vec, p_in, p_out, p_sorted, p_unique, p_partial,
-                p_partial_ids, nullptr, 0, F, d_offsets, B, combiner);
+                p_partial_ids, nullptr, 0, F, d_offsets, B, combiner, d_weights);
       }
       // Stage 2
       int second_grid_size =
@@ -485,13 +495,13 @@ void multi_to_one_reduce(int64_t n, int64_t len_vec, const at::Tensor &in_grads,
                                          true, offset_t>
             <<<grid_size, block_size, 0, stream>>>(
                 n, len_vec, p_in, p_out, p_sorted, p_unique, p_partial,
-                p_partial_ids, d_D_offsets, total_D, F, d_offsets, B, combiner);
+                p_partial_ids, d_D_offsets, total_D, F, d_offsets, B, combiner, d_weights);
       } else {
         multi_to_one_reduce_kernel1_vec4<io_t, accum_t, id_t, 2, kWarpSize,
                                          false, offset_t>
             <<<grid_size, block_size, 0, stream>>>(
                 n, len_vec, p_in, p_out, p_sorted, p_unique, p_partial,
-                p_partial_ids, nullptr, 0, F, d_offsets, B, combiner);
+                p_partial_ids, nullptr, 0, F, d_offsets, B, combiner, d_weights);
       }
       // Stage 2
       int second_grid_size =
@@ -523,13 +533,13 @@ void multi_to_one_reduce(int64_t n, int64_t len_vec, const at::Tensor &in_grads,
                                            offset_t>
             <<<grid_size_unaligned, block_size_unaligned, 0, stream>>>(
                 n, len_vec, p_in, p_out, p_sorted, p_unique, p_partial,
-                p_partial_ids, d_D_offsets, total_D, F, d_offsets, B, combiner);
+                p_partial_ids, d_D_offsets, total_D, F, d_offsets, B, combiner, d_weights);
       } else {
         multi_to_one_reduce_kernel1_no_vec<io_t, accum_t, id_t, kWarpSize,
                                            false, offset_t>
             <<<grid_size_unaligned, block_size_unaligned, 0, stream>>>(
                 n, len_vec, p_in, p_out, p_sorted, p_unique, p_partial,
-                p_partial_ids, nullptr, 0, F, d_offsets, B, combiner);
+                p_partial_ids, nullptr, 0, F, d_offsets, B, combiner, d_weights);
       }
       DEMB_CUDA_KERNEL_LAUNCH_CHECK();
 
@@ -581,7 +591,8 @@ void LocalReduce::local_reduce(const at::Tensor &in_grads,
                                cudaStream_t &stream,
                                const std::optional<at::Tensor> &D_offsets,
                                const std::optional<at::Tensor> &offsets, int B,
-                               int F, int total_D, int combiner) {
+                               int F, int total_D, int combiner,
+			       const std::optional<at::Tensor> &weights) {
   if (num_key_ == 0)
     return;
   auto scalar_type = out_grads.dtype().toScalarType();
@@ -591,6 +602,16 @@ void LocalReduce::local_reduce(const at::Tensor &in_grads,
         "Input grad's dtype mismatches with output grad's.");
   }
   auto grad_type = scalartype_to_datatype(scalar_type);
+
+  const float *d_w = nullptr;
+  if (weights.has_value()) {
+    TORCH_CHECK(weights.value().scalar_type() == at::kFloat,
+                "weights must be float32, got ", weights.value().scalar_type());
+    TORCH_CHECK(weights.value().numel() == num_key_,
+                "weights.numel() (", weights.value().numel(),
+                ") must equal num_key_ (", num_key_, ")");
+    d_w = reinterpret_cast<const float *>(weights.value().data_ptr());
+  }
 
   DISPATCH_FLOAT_DATATYPE_FUNCTION(grad_type, grad_t, [&] {
     DISPATCH_FLOAT_ACCUM_TYPE_FUNC(accum_type_, accum_t, [&] {

--- a/corelib/dynamicemb/src/lookup_backward.h
+++ b/corelib/dynamicemb/src/lookup_backward.h
@@ -50,7 +50,8 @@ public:
                     const at::Tensor &unique_key_ids, cudaStream_t &stream,
                     const std::optional<at::Tensor> &D_offsets = std::nullopt,
                     const std::optional<at::Tensor> &offsets = std::nullopt,
-                    int B = 0, int F = 0, int total_D = 0, int combiner = 0);
+                    int B = 0, int F = 0, int total_D = 0, int combiner = 0,
+                    const std::optional<at::Tensor> &weights = std::nullopt);
 };
 
 } // namespace dyn_emb

--- a/corelib/dynamicemb/src/lookup_forward.cu
+++ b/corelib/dynamicemb/src/lookup_forward.cu
@@ -46,6 +46,10 @@ struct ForwardMultiToOneFMLayoutDesc {
     int pooling_factor = static_cast<int>(offset_ptr[i + 1] - offset_ptr[i]);
     return combiner == 1 ? pooling_factor : 1;
   }
+  HOST_DEVICE_INLINE float get_weight(int i) {
+    // nullptr => unweighted pooling (identical to the old path).
+    return weights_ptr ? weights_ptr[i] : 1.0f;
+  }
   HOST_DEVICE_INLINE const SrcType *get_src_ptr(int i) {
     int idx = reverse_idx_ptr[i];
     return src_ptr + (int64_t)src_stride * idx;
@@ -72,6 +76,7 @@ struct ForwardMultiToOneFMLayoutDesc {
   int batch_size;
   int total_D;
   int accum_D;
+  const float *__restrict__ weights_ptr; // nullptr -> unweighted
 };
 
 void scatter_combine(void *src_ptr, void *dst_ptr, void *offset_ptr,
@@ -79,7 +84,7 @@ void scatter_combine(void *src_ptr, void *dst_ptr, void *offset_ptr,
                      int accum_D, int ev_size, int src_stride, int num_vec,
                      int batch_size, DataType src_type, DataType dst_type,
                      DataType offset_type, cudaStream_t stream,
-                     const int *D_offsets_ptr) {
+                     const int *D_offsets_ptr, const float *weights_ptr) {
 
   DISPATCH_INTEGER_DATATYPE_FUNCTION(offset_type, offset_t, [&] {
     DISPATCH_FLOAT_DATATYPE_FUNCTION(src_type, src_t, [&] {
@@ -96,7 +101,8 @@ void scatter_combine(void *src_ptr, void *dst_ptr, void *offset_ptr,
                                    (dst_t *)dst_ptr,
                                    batch_size,
                                    total_D,
-                                   accum_D};
+                                   accum_D,
+                                   weights_ptr};
         copy_multi_to_one(multi_to_one_desc, ev_size, stream);
       });
     });

--- a/corelib/dynamicemb/src/lookup_forward.h
+++ b/corelib/dynamicemb/src/lookup_forward.h
@@ -30,7 +30,8 @@ void scatter_combine(void *src_ptr, void *dst_ptr, void *offset_ptr,
                      int accum_D, int ev_size, int src_stride, int num_vec,
                      int batch_size, DataType src_type, DataType dst_type,
                      DataType offset_type, cudaStream_t stream,
-                     const int *D_offsets_ptr = nullptr);
+                     const int *D_offsets_ptr = nullptr,
+		     const float *weights_ptr = nullptr);
 
 void scatter_fused(void *src_ptr, void *dst_ptr, void *inverse_idx_ptr,
                    int num_emb, int ev_size, int src_stride, DataType src_type,

--- a/corelib/dynamicemb/src/lookup_kernel.cuh
+++ b/corelib/dynamicemb/src/lookup_kernel.cuh
@@ -874,11 +874,12 @@ __global__ void multi_to_one_cta_per_ev_kernel(CopyDesc copy_desc) {
     float accum[kMaxElemPerThread] = {0.f};
     for (int r = 0; r < (end - start); ++r) {
       const src_type *src_ev = copy_desc.get_src_ptr(r + start);
+      float w = copy_desc.get_weight(r + start);
 #pragma unroll kMaxElemPerThread
       for (int i = 0;
            i < kMaxElemPerThread && blockDim.x * i + threadIdx.x < vec_length;
            ++i) {
-        accum[i] += (float)(src_ev[blockDim.x * i + threadIdx.x]);
+        accum[i] += w * (float)(src_ev[blockDim.x * i + threadIdx.x]);
       }
     }
     if (average_pooling_factor > 0) {
@@ -926,6 +927,7 @@ __global__ void multi_to_one_warp_per_ev_vec4_kernel(CopyDesc copy_desc) {
       for (int j = 0; j < kWarpSize && r + j < L; ++j) {
         int j_ev = __shfl_sync(0xFFFFFFFF, l, j);
         const src_type *src_ev = copy_desc.get_src_ptr(j_ev);
+	float w = copy_desc.get_weight(j_ev);
 
 #pragma unroll kMaxElemPerThread
         for (int i = 0; i < kMaxElemPerThread &&
@@ -935,7 +937,7 @@ __global__ void multi_to_one_warp_per_ev_vec4_kernel(CopyDesc copy_desc) {
           int idx4 = 4 * kWarpSize * i + 4 * lane_id;
           int n = min(vec_length - idx4, copy_width);
           src_elem.load(src_ev + idx4, n);
-          accum[i].accumulate(src_elem);
+          accum[i].accumulate(src_elem, w);
         }
       }
     }

--- a/corelib/dynamicemb/src/lookup_kernel.cuh
+++ b/corelib/dynamicemb/src/lookup_kernel.cuh
@@ -937,7 +937,7 @@ __global__ void multi_to_one_warp_per_ev_vec4_kernel(CopyDesc copy_desc) {
           int idx4 = 4 * kWarpSize * i + 4 * lane_id;
           int n = min(vec_length - idx4, copy_width);
           src_elem.load(src_ev + idx4, n);
-          accum[i].accumulate(src_elem, w);
+          accum[i].accumulate_multiply(src_elem, w);
         }
       }
     }

--- a/corelib/dynamicemb/test/test_batched_dynamic_embedding_tables_v2.py
+++ b/corelib/dynamicemb/test/test_batched_dynamic_embedding_tables_v2.py
@@ -188,7 +188,7 @@ def _bdebt_forward_maybe_lfu(
         return bdebt(
             indices,
             offsets,
-            per_sample_weights=_lfu_per_sample_weights(indices, device),
+            frequency_counters=_lfu_per_sample_weights(indices, device),
         )
     return bdebt(indices, offsets)
 

--- a/corelib/dynamicemb/test/unit_tests/test_weighted_pooled_embedding_fw.py
+++ b/corelib/dynamicemb/test/unit_tests/test_weighted_pooled_embedding_fw.py
@@ -126,7 +126,7 @@ def main(argv: List[str]) -> None:
         )
         for f in range(args.num_embedding_table)
     ]
-    ebc = torchrec.EmbeddingBagCollection(tables=eb_configs, device=torch.device("meta"))
+    ebc = torchrec.EmbeddingBagCollection(tables=eb_configs, device=torch.device("meta"), is_weighted=True,)
 
     dict_const = {}
     for i in range(args.num_embedding_table):

--- a/corelib/dynamicemb/test/unit_tests/test_weighted_pooled_embedding_fw.py
+++ b/corelib/dynamicemb/test/unit_tests/test_weighted_pooled_embedding_fw.py
@@ -51,7 +51,7 @@ def feature_idx_to_name(i):
 
 def generate_sparse_feature_with_weights(
     feature_num, num_embeddings_list, multi_hot_sizes, local_batch_size
-) -> Tuple[torchrec.KeyedJaggedTensor, torchrec.KeyedJaggedTensor]:
+) -> torchrec.KeyedJaggedTensor:
     feature_batch = feature_num * local_batch_size
     indices, lengths, weights = [], [], []
     for i in range(feature_batch):
@@ -65,25 +65,19 @@ def generate_sparse_feature_with_weights(
             weights.append(random.uniform(0.5, 2.0))
         lengths.append(cur_bag_size)
     keys = [feature_idx_to_name(f) for f in range(feature_num)]
-    features = torchrec.KeyedJaggedTensor(
+    return torchrec.KeyedJaggedTensor(
         keys=keys,
         values=torch.tensor(indices, dtype=torch.int64).cuda(),
+        weights=torch.tensor(weights, dtype=torch.float32).cuda(),
         lengths=torch.tensor(lengths, dtype=torch.int64).cuda(),
     )
-    weights_kjt = torchrec.KeyedJaggedTensor(
-        keys=keys,
-        values=torch.tensor(weights, dtype=torch.float32).cuda(),
-        lengths=torch.tensor(lengths, dtype=torch.int64).cuda(),
-    )
-    return features, weights_kjt
 
-
-def reference_weighted_sum(features, weights_kjt, local_batch_size):
+def reference_weighted_sum(features, local_batch_size):
     """Reference per local slot: slot s = f*B + b -> sum w * (idx % MOD)."""
     F = len(features.keys())
     out = torch.zeros(local_batch_size, F, device=features.values().device)
     offsets = features.offsets().view(-1)
-    w_values = weights_kjt.values()
+    w_values = features.weights()
     for s in range(F * local_batch_size):
         f, b = s // local_batch_size, s % local_batch_size
         acc = 0.0
@@ -93,7 +87,6 @@ def reference_weighted_sum(features, weights_kjt, local_batch_size):
             )
         out[b, f] = acc
     return out
-
 
 @record
 def main(argv: List[str]) -> None:
@@ -130,7 +123,6 @@ def main(argv: List[str]) -> None:
             num_embeddings=num_embeddings_per_feature[f],
             feature_names=[feature_idx_to_name(f)],
             pooling=PoolingType.SUM,
-            weighted=True,
         )
         for f in range(args.num_embedding_table)
     ]
@@ -192,15 +184,15 @@ def main(argv: List[str]) -> None:
     ]
 
     for _ in range(args.num_iterations):
-        features, weights_kjt = generate_sparse_feature_with_weights(
+        features = generate_sparse_feature_with_weights(
             args.num_embedding_table,
             num_embeddings_per_feature,
             multi_hot_sizes,
             local_batch_size,
         )
-        ret = model(features, weights_kjt)
+        ret = model(features)
         kt = ret.values()  # [B_local, F * embedding_dim]
-        ref = reference_weighted_sum(features, weights_kjt, local_batch_size)
+        ref = reference_weighted_sum(features, local_batch_size)
 
         for f in range(args.num_embedding_table):
             col = prefix_dims[f]

--- a/corelib/dynamicemb/test/unit_tests/test_weighted_pooled_embedding_fw.py
+++ b/corelib/dynamicemb/test/unit_tests/test_weighted_pooled_embedding_fw.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Weighted EmbeddingBagCollection end-to-end with DynamicEmb tables (torchrun).
+
+The DEBUG initializer fills row i with i % 100_000, so the weighted-sum output
+has an exact reference computed from the local pre-all2all features."""
+
+import argparse
+import os
+import random
+from typing import List, Tuple
+
+import torch
+import torch.distributed as dist
+import torchrec
+from dynamicemb import (
+    DynamicEmbCheckMode,
+    DynamicEmbInitializerArgs,
+    DynamicEmbInitializerMode,
+    DynamicEmbTableOptions,
+)
+from dynamicemb.dynamicemb_config import DEBUG_EMB_INITIALIZER_MOD
+from dynamicemb.planner import (
+    DynamicEmbeddingEnumerator,
+    DynamicEmbeddingShardingPlanner,
+    DynamicEmbParameterConstraints,
+)
+from dynamicemb.shard import DynamicEmbeddingBagCollectionSharder
+from torch.distributed.elastic.multiprocessing.errors import record
+from torchrec.distributed.comm import get_local_size
+from torchrec.distributed.model_parallel import (
+    DefaultDataParallelWrapper,
+    DistributedModelParallel,
+)
+from torchrec.distributed.planner import Topology
+from torchrec.distributed.planner.storage_reservations import (
+    HeuristicalStorageReservation,
+)
+from torchrec.distributed.types import BoundsCheckMode, ShardingType
+from torchrec.modules.embedding_configs import PoolingType
+
+
+def table_idx_to_name(i):
+    return f"t_{i}"
+
+
+def feature_idx_to_name(i):
+    return f"cate_{i}"
+
+
+def generate_sparse_feature_with_weights(
+    feature_num, num_embeddings_list, multi_hot_sizes, local_batch_size
+) -> Tuple[torchrec.KeyedJaggedTensor, torchrec.KeyedJaggedTensor]:
+    feature_batch = feature_num * local_batch_size
+    indices, lengths, weights = [], [], []
+    for i in range(feature_batch):
+        f = i // local_batch_size
+        cur_bag_size = random.randint(1, multi_hot_sizes[f])
+        cur_bag = set({})
+        while len(cur_bag) < cur_bag_size:
+            cur_bag.add(random.randint(0, num_embeddings_list[f] - 1))
+        for idx in cur_bag:
+            indices.append(idx)
+            weights.append(random.uniform(0.5, 2.0))
+        lengths.append(cur_bag_size)
+    keys = [feature_idx_to_name(f) for f in range(feature_num)]
+    features = torchrec.KeyedJaggedTensor(
+        keys=keys,
+        values=torch.tensor(indices, dtype=torch.int64).cuda(),
+        lengths=torch.tensor(lengths, dtype=torch.int64).cuda(),
+    )
+    weights_kjt = torchrec.KeyedJaggedTensor(
+        keys=keys,
+        values=torch.tensor(weights, dtype=torch.float32).cuda(),
+        lengths=torch.tensor(lengths, dtype=torch.int64).cuda(),
+    )
+    return features, weights_kjt
+
+
+def reference_weighted_sum(features, weights_kjt, local_batch_size):
+    """Reference per local slot: slot s = f*B + b -> sum w * (idx % MOD)."""
+    F = len(features.keys())
+    out = torch.zeros(local_batch_size, F, device=features.values().device)
+    offsets = features.offsets().view(-1)
+    w_values = weights_kjt.values()
+    for s in range(F * local_batch_size):
+        f, b = s // local_batch_size, s % local_batch_size
+        acc = 0.0
+        for p in range(int(offsets[s]), int(offsets[s + 1])):
+            acc += float(w_values[p]) * float(
+                int(features.values()[p]) % DEBUG_EMB_INITIALIZER_MOD
+            )
+        out[b, f] = acc
+    return out
+
+
+@record
+def main(argv: List[str]) -> None:
+    parser = argparse.ArgumentParser(
+        description="Weighted EmbeddingBagCollection example with DynamicEmb"
+    )
+    parser.add_argument("--batch_size", type=int, default=32)
+    parser.add_argument("--embedding_dim", type=int, default=8)
+    parser.add_argument("--num_embedding_table", type=int, default=2)
+    parser.add_argument("--multi_hot_sizes", type=str, default="4,4")
+    parser.add_argument("--num_embeddings_per_feature", type=str, default="1024,2048")
+    parser.add_argument("--num_iterations", type=int, default=2)
+    args = parser.parse_args(argv)
+
+    dist.init_process_group(backend="nccl")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    multi_hot_sizes = [int(x) for x in args.multi_hot_sizes.split(",")]
+    num_embeddings_per_feature = [
+        int(x) for x in args.num_embeddings_per_feature.split(",")
+    ]
+    assert args.num_embedding_table == len(multi_hot_sizes) == len(num_embeddings_per_feature)
+
+    # NOTE: `weighted=True` is the torchrec EmbeddingBagConfig field; weighted
+    # tables require pooling=SUM. Adjust the flag name if the installed
+    # torchrec release differs.
+    eb_configs = [
+        torchrec.EmbeddingBagConfig(
+            name=table_idx_to_name(f),
+            embedding_dim=args.embedding_dim,
+            num_embeddings=num_embeddings_per_feature[f],
+            feature_names=[feature_idx_to_name(f)],
+            pooling=PoolingType.SUM,
+            weighted=True,
+        )
+        for f in range(args.num_embedding_table)
+    ]
+    ebc = torchrec.EmbeddingBagCollection(tables=eb_configs, device=torch.device("meta"))
+
+    dict_const = {}
+    for i in range(args.num_embedding_table):
+        dict_const[table_idx_to_name(i)] = DynamicEmbParameterConstraints(
+            sharding_types=[ShardingType.ROW_WISE.value],
+            pooling_factors=[multi_hot_sizes[i]],
+            num_poolings=[1],
+            enforce_hbm=True,
+            bounds_check_mode=BoundsCheckMode.NONE,
+            use_dynamicemb=True,
+            dynamicemb_options=DynamicEmbTableOptions(
+                global_hbm_for_values=1024**3,
+                initializer_args=DynamicEmbInitializerArgs(
+                    mode=DynamicEmbInitializerMode.DEBUG
+                ),
+                safe_check_mode=DynamicEmbCheckMode.IGNORE,
+            ),
+        )
+
+    topology = Topology(
+        local_world_size=get_local_size(),
+        world_size=world_size,
+        compute_device=device.type,
+        hbm_cap=80 * 1024**3,
+        ddr_cap=1024**4,
+        intra_host_bw=300e9,
+        inter_host_bw=25e9,
+    )
+    enumerator = DynamicEmbeddingEnumerator(
+        topology=topology, batch_size=args.batch_size, constraints=dict_const
+    )
+    planner = DynamicEmbeddingShardingPlanner(
+        eb_configs=eb_configs,
+        topology=topology,
+        constraints=dict_const,
+        batch_size=args.batch_size,
+        enumerator=enumerator,
+        storage_reservation=HeuristicalStorageReservation(percentage=0.05),
+        debug=True,
+    )
+
+    sharder = DynamicEmbeddingBagCollectionSharder(fused_params={})
+    plan = planner.collective_plan(ebc, [sharder], dist.GroupMember.WORLD)
+    model = DistributedModelParallel(
+        module=ebc,
+        device=device,
+        sharders=[sharder],
+        plan=plan,
+        data_parallel_wrapper=DefaultDataParallelWrapper(),
+    )
+
+    local_batch_size = args.batch_size // world_size
+    prefix_dims = [0] + [
+        args.embedding_dim * i for i in range(1, args.num_embedding_table + 1)
+    ]
+
+    for _ in range(args.num_iterations):
+        features, weights_kjt = generate_sparse_feature_with_weights(
+            args.num_embedding_table,
+            num_embeddings_per_feature,
+            multi_hot_sizes,
+            local_batch_size,
+        )
+        ret = model(features, weights_kjt)
+        kt = ret.values()  # [B_local, F * embedding_dim]
+        ref = reference_weighted_sum(features, weights_kjt, local_batch_size)
+
+        for f in range(args.num_embedding_table):
+            col = prefix_dims[f]
+            for b in range(local_batch_size):
+                assert torch.allclose(
+                    kt[b, col].float(), ref[b, f], rtol=1e-4, atol=1e-2
+                ), (
+                    f"rank {local_rank} f={f} b={b}: "
+                    f"{kt[b, col].item()} vs {ref[b, f].item()}"
+                )
+
+        loss = kt.sum()
+        loss.backward()
+        torch.cuda.synchronize()
+
+        if local_rank == 0:
+            print(f"Weighted DynamicEmb iteration {_ + 1} Passed")
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    import sys
+    main(sys.argv[1:])

--- a/corelib/dynamicemb/test/unit_tests/test_weighted_pooled_embedding_v2.py
+++ b/corelib/dynamicemb/test/unit_tests/test_weighted_pooled_embedding_v2.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Weighted pooled (SUM) training tests at the BatchedDynamicEmbeddingTablesV2
+level. The DEBUG initializer fills every dim of row i with i % 100_000, so the
+weighted-sum output and the SGD update have exact Python oracles."""
+
+import pytest
+import torch
+from dynamicemb import (
+    DynamicEmbCheckMode,
+    DynamicEmbInitializerArgs,
+    DynamicEmbInitializerMode,
+    DynamicEmbPoolingMode,
+    DynamicEmbScoreStrategy,
+    DynamicEmbTableOptions,
+)
+from dynamicemb.batched_dynamicemb_tables import BatchedDynamicEmbeddingTablesV2
+from dynamicemb.dynamicemb_config import DEBUG_EMB_INITIALIZER_MOD
+from fbgemm_gpu.split_embedding_configs import EmbOptimType
+from torchrec.distributed.types import BoundsCheckMode
+
+
+@pytest.fixture
+def current_device():
+    assert torch.cuda.is_available()
+    return torch.cuda.current_device()
+
+
+def _debug_value(idx: torch.Tensor) -> torch.Tensor:
+    return (idx % DEBUG_EMB_INITIALIZER_MOD).float()
+
+
+def _make_v2(
+    dims,
+    pooling_mode=DynamicEmbPoolingMode.SUM,
+    lr=0.5,
+    num_tables=None,
+    device=None,
+):
+    device = device or torch.cuda.current_device()
+    opts = [
+        DynamicEmbTableOptions(
+            dim=d,
+            max_capacity=4096,
+            init_capacity=4096,
+            index_type=torch.int64,
+            embedding_dtype=torch.float32,
+            device_id=device,
+            bucket_capacity=128,
+            safe_check_mode=DynamicEmbCheckMode.IGNORE,
+            local_hbm_for_values=1024**3,
+            score_strategy=DynamicEmbScoreStrategy.STEP,
+            initializer_args=DynamicEmbInitializerArgs(
+                mode=DynamicEmbInitializerMode.DEBUG
+            ),
+        )
+        for d in dims
+    ]
+    return BatchedDynamicEmbeddingTablesV2(
+        table_options=opts,
+        table_names=[f"t{i}" for i in range(len(opts))],
+        feature_table_map=list(range(len(opts))),
+        pooling_mode=pooling_mode,
+        optimizer=EmbOptimType.SGD,
+        learning_rate=lr,
+        stochastic_rounding=False,
+        bounds_check_mode=BoundsCheckMode.NONE,
+    )
+
+
+def _weighted_oracle(indices, offsets, weights, batch_size, feature_num):
+    """Reference weighted-sum pooling: slot s = f * B + b. Returns [B, F]."""
+    out = torch.zeros(batch_size, feature_num, device=indices.device)
+    for s in range(feature_num * batch_size):
+        f, b = s // batch_size, s % batch_size
+        acc = 0.0
+        for p in range(int(offsets[s]), int(offsets[s + 1])):
+            acc += float(weights[p]) * float(indices[p] % DEBUG_EMB_INITIALIZER_MOD)
+        out[b, f] = acc
+    return out
+
+
+def test_weighted_sum_forward(current_device):
+    device = torch.cuda.current_device()
+    B, F = 2, 1
+    module = _make_v2([8], device=device)
+
+    indices = torch.tensor([5, 12, 300, 7, 9], dtype=torch.int64, device=device)
+    offsets = torch.tensor([0, 3, 5], dtype=torch.int64, device=device)
+    weights = torch.tensor([0.5, 1.5, 2.0, 1.0, 3.0], dtype=torch.float32, device=device)
+
+    out = module(indices, offsets, pooling_weights=weights)  # [B, 8]
+    ref = _weighted_oracle(indices, offsets, weights, B, F)  # [B, F]
+
+    assert out.shape == (B, 8)
+    for b in range(B):
+        for c in (0, 3, 7):  # every dim of the row carries the same DEBUG value
+            assert torch.allclose(
+                out[b, c], ref[b, 0], rtol=1e-5, atol=1e-3
+            ), f"b={b} c={c}: {out[b, c].item()} vs {ref[b, 0].item()}"
+
+
+def test_weighted_sum_backward_sgd_oracle(current_device):
+    device = torch.cuda.current_device()
+    B, F, lr = 2, 1, 0.5
+    module = _make_v2([8], lr=lr, device=device)
+
+    indices = torch.tensor([5, 12, 300, 7, 9], dtype=torch.int64, device=device)
+    offsets = torch.tensor([0, 3, 5], dtype=torch.int64, device=device)
+    weights = torch.tensor([0.5, 1.5, 2.0, 1.0, 3.0], dtype=torch.float32, device=device)
+
+    out = module(indices, offsets, pooling_weights=weights)
+    target = torch.full((B, 8), 2.0, dtype=torch.float32, device=device)
+    (out * target).sum().backward()
+    torch.cuda.synchronize()
+
+    # grad_k = 2.0 * sum of weights over the key's positions; SGD: v -= lr * grad.
+    keys_cpu = indices.tolist()
+    wsum = {}
+    for k, w in zip(keys_cpu, weights.tolist()):
+        wsum[k] = wsum.get(k, 0.0) + w
+
+    exp_keys, exp_vals = module.export_keys_values("t0", torch.device(device))
+    got = {int(k): v for k, v in zip(exp_keys.tolist(), exp_vals)}
+    for k, s in wsum.items():
+        expected = float(k % DEBUG_EMB_INITIALIZER_MOD) - lr * 2.0 * s
+        row = got[k]
+        assert torch.allclose(row, torch.full_like(row, expected), atol=1e-3), (
+            f"key {k}: got {row[0].item()}, expected {expected}"
+        )
+
+
+def test_weighted_sum_mixed_D_forward(current_device):
+    device = torch.cuda.current_device()
+    B, F = 2, 2
+    module = _make_v2([8, 4], device=device)  # mixed-D: 8 + 4 = 12 columns
+
+    # Feature-major slots: s0=f0b0, s1=f0b1, s2=f1b0, s3=f1b1
+    indices = torch.tensor([5, 12, 7, 9, 100, 3, 1, 1], dtype=torch.int64, device=device)
+    offsets = torch.tensor([0, 2, 4, 6, 8], dtype=torch.int64, device=device)
+    weights = torch.tensor(
+        [0.5, 1.5, 1.0, 3.0, 2.0, 2.0, 0.25, 0.75], dtype=torch.float32, device=device
+    )
+
+    out = module(indices, offsets, pooling_weights=weights)  # [B, 12]
+    ref = _weighted_oracle(indices, offsets, weights, B, F)  # [B, F]
+
+    assert out.shape == (B, 12)
+    for b in range(B):
+        for f in range(F):
+            col = 0 if f == 0 else 8
+            assert torch.allclose(out[b, col], ref[b, f], rtol=1e-5, atol=1e-3), (
+                f"b={b} f={f}: {out[b, col].item()} vs {ref[b, f].item()}"
+            )
+
+
+def test_weighted_errors(current_device):
+    device = torch.cuda.current_device()
+    indices = torch.tensor([5, 12], dtype=torch.int64, device=device)
+    offsets = torch.tensor([0, 1, 2], dtype=torch.int64, device=device)
+    weights = torch.tensor([0.5, 1.5], dtype=torch.float32, device=device)
+
+    # weights + MEAN -> ValueError
+    mean_mod = _make_v2([8], pooling_mode=DynamicEmbPoolingMode.MEAN, device=device)
+    with pytest.raises(ValueError):
+        mean_mod(indices, offsets, pooling_weights=weights)
+
+    # non-fp32 weights -> ValueError
+    mod = _make_v2([8], device=device)
+    with pytest.raises(ValueError):
+        mod(indices, offsets, pooling_weights=weights.half())
+
+    # numel mismatch -> ValueError
+    with pytest.raises(ValueError):
+        mod(indices, offsets, pooling_weights=weights[:1])
+
+    # eval mode -> ValueError
+    mod_eval = _make_v2([8], device=device)
+    mod_eval.eval()
+    with pytest.raises(ValueError):
+        mod_eval(indices, offsets, pooling_weights=weights)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/recsys-examples/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

Adds weighted-sum pooling (training only) for DynamicEmb-backed EmbeddingBagCollection tables.

- Weighted forward `out[b] = Σ wᵢ·embᵢ` and backward `grad_embᵢ = wᵢ·grad_pooled` via new optional weights in `gather_embedding_pooled` / `reduce_grads` (fp32, mixed-D supported).
- TorchRec integration: `EmbeddingBagCollection(..., is_weighted=True)` with weights attached to the features KJT.
- Breaking API change: `BatchedDynamicEmbeddingTablesV2.forward`'s `per_sample_weights` is split into `frequency_counters` (LFU) and `pooling_weights` (weighted SUM).

Tests: V2-level fwd/bwd SGD oracle (incl. mixed-D) and error cases; end-to-end weighted EBC on 1 and 4 GPUs. All DynamicEmb unit suites pass.